### PR TITLE
Specify number of threads to use in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -850,6 +850,13 @@ endif()
 if (Tasmanian_ENABLE_FORTRAN)
     add_test(Fortran fortester)
 endif()
+include(ProcessorCount)
+ProcessorCount(NUM_PROCS)
+set(Tasmanian_TESTS_OMP_NUM_THREADS ${NUM_PROCS} CACHE STRING "Number of OpenMP threads to use in the tests (default is all available cores)")
+set_tests_properties( Tasgrid Tasdream PROPERTIES
+    PROCESSORS ${Tasmanian_TESTS_OMP_NUM_THREADS}
+    ENVIRONMENT OMP_NUM_THREADS=${Tasmanian_TESTS_OMP_NUM_THREADS}
+)
 
 
 ########################################################################


### PR DESCRIPTION
This should address your comment about using `-j<num_procs>` when running the tests in #10 

Basically we can specify how many process slots a test requires. I chose 4 as the default. I can change it if you like. Note that I only listed `Tasgrid` and `Tasdream`. Let me know if I should include others.