### PR TITLE
Custom random generator for DREAM

### DIFF
--- a/DREAM/TasmanianDREAM.cpp
+++ b/DREAM/TasmanianDREAM.cpp
@@ -446,10 +446,14 @@ void TasmanianDREAM::advanceMCMCDREAM(bool useLogForm){
     int num_need_evaluation = num_chains;
 
     bool allValid = true; //, savedGaussian = false;
+    double unilength = 1.0 / ((double) num_chains);
 
     for(int i=0; i<num_chains; i++){
-        int index1 = rand() % num_chains;
-        int index2 = rand() % num_chains;
+        int index1 = (int) (core->getSample01() / unilength);
+        int index2 = (int) (core->getSample01() / unilength);
+        if (index1 >= num_chains) index1 = num_chains; // this is needed in case core->getSample01() returns 1.0
+        if (index2 >= num_chains) index2 = num_chains;
+
 
         valid[i] = true;
 

--- a/DREAM/tasdreamExternalTests.cpp
+++ b/DREAM/tasdreamExternalTests.cpp
@@ -38,6 +38,16 @@ using std::cerr;
 using std::endl;
 using std::setw;
 
+TestRNG::TestRNG(int seed): s(seed % 2097165){}
+TestRNG::~TestRNG(){}
+
+double TestRNG::getSample01() const{
+    s *= 511;
+    s += 127;
+    s %= 2097165;
+    return (double)(((double) s) / 2097165.0);
+}
+
 ExternalTester::ExternalTester(int num_monte_carlo) : num_mc(num_monte_carlo){
     #ifdef _TASMANIAN_WINDOWS_
     srand(15);

--- a/DREAM/tasdreamExternalTests.hpp
+++ b/DREAM/tasdreamExternalTests.hpp
@@ -46,6 +46,16 @@ enum TestList{
     test_all, test_analytic, test_model
 };
 
+class TestRNG : public TasDREAM::BaseUniform{
+public:
+    TestRNG(int seed);
+    ~TestRNG();
+
+    double getSample01() const;
+private:
+    mutable int s;
+};
+
 class ExternalTester{
 public:
     ExternalTester(int num_monte_carlo = 1);

--- a/DREAM/tasdreamExternalTests.hpp
+++ b/DREAM/tasdreamExternalTests.hpp
@@ -84,6 +84,7 @@ private:
     int num_mc;
     int wfirst, wsecond, wthird;
     bool verbose;
+    int rngseed;
 
     TasDREAM::CppUniformSampler u;
 


### PR DESCRIPTION
* added custom random number generator for all DREAM tests; this will remove the dependence on the compiler provided rand() calls and remove compiler dependence for the tests
* DREAM uses the overwritten random number generator to select the chains for computing increments; there is no place in the code left, where compiler provided rand() would be used when a custom rng is provided