### PR TITLE
Acceleration fallback logic

### DIFF
--- a/Config/AltBuildSystems/TasmanianConfig.hpp
+++ b/Config/AltBuildSystems/TasmanianConfig.hpp
@@ -48,6 +48,7 @@
 /* #undef Tasmanian_ENABLE_BLAS */
 /* #undef Tasmanian_ENABLE_CUBLAS */
 /* #undef Tasmanian_ENABLE_CUDA */
+/* #undef Tasmanian_ENABLE_MAGMA */
 /* #undef Tasmanian_ENABLE_MPI */
 
 // used mostly to suppress default cerr messages

--- a/Config/AltBuildSystems/testTSG.py
+++ b/Config/AltBuildSystems/testTSG.py
@@ -151,7 +151,7 @@ class TestTasmanian(unittest.TestCase):
         else:
             print("            none")
 
-        #grid.printStats() # covers the printStats(), but silence for a release as it prints an empty grid
+        grid.printStats() # covers the printStats(), but silence for a release as it prints an empty grid
 
         # test I/O for Global Grids
         # iDimension, iOutputs, iDepth, sType, sRule, fAlpha, fBeta, useTransform, loadFunciton, limitLevels
@@ -192,7 +192,7 @@ class TestTasmanian(unittest.TestCase):
             self.compareGrids(gridA, gridB)
 
         # test an error message from wrong read
-        #print("Attempting a bogus read to see if error would be properly registered")
+        print("Attempting a bogus read to see if error would be properly registered")
         gridB.disableLog()
         self.assertFalse(gridB.read("testSaveBlah"), "Failed to flag a fake read")
         gridB.setErrorLogCerr()
@@ -367,15 +367,8 @@ class TestTasmanian(unittest.TestCase):
         print("\nTesting accelerated evaluate consistency")
 
         iGPUID = -1
-
-        # acceleration meta-data
+        
         grid = TasmanianSG.TasmanianSparseGrid()
-        grid.makeLocalPolynomialGrid(2, 1, 2, 1, 'semi-localp')
-        for accel in TasmanianSG.lsTsgAccelTypes:
-            grid.enableAcceleration(accel)
-            sA = grid.getAccelerationType()
-            bTest = ((accel not in sA) or (sA not in accel))
-            self.assertFalse(bTest, "set/get Acceleration")
 
         if (False):
             bHasBlas = ("ON" == "ON")
@@ -385,6 +378,19 @@ class TestTasmanian(unittest.TestCase):
             self.assertTrue((grid.isAccelerationAvailable("gpu-cublas") == bHasCuBlas), "failed to match cublas")
             self.assertTrue((grid.isAccelerationAvailable("gpu-cuda") == bHasCuda), "failed to match cuda")
             self.assertTrue((grid.isAccelerationAvailable("gpu-default") == (bHasCuBlas or bHasCuda)), "failed to match cuda")
+
+            # acceleration meta-data
+            lsAvailableAcc = []
+            if (bHasBlas): lsAvailableAcc.append("cpu-blas")
+            if (bHasCuBlas): lsAvailableAcc.append("gpu-cublas")
+            if (bHasCuda): lsAvailableAcc.append("gpu-cuda")
+            grid.makeLocalPolynomialGrid(2, 1, 2, 1, 'semi-localp')
+            for accel in lsAvailableAcc:
+                grid.enableAcceleration(accel)
+                sA = grid.getAccelerationType()
+                bTest = ((accel not in sA) or (sA not in accel))
+                self.assertFalse(bTest, "set/get Acceleration")
+
 
         self.assertTrue((grid.getGPUID() == 0), "did not default to gpu 0")
 

--- a/InterfacePython/testTSG.in.py
+++ b/InterfacePython/testTSG.in.py
@@ -367,15 +367,8 @@ class TestTasmanian(unittest.TestCase):
         print("\nTesting accelerated evaluate consistency")
 
         iGPUID = @Tasmanian_TESTS_GPU_ID@
-
-        # acceleration meta-data
+        
         grid = TasmanianSG.TasmanianSparseGrid()
-        grid.makeLocalPolynomialGrid(2, 1, 2, 1, 'semi-localp')
-        for accel in TasmanianSG.lsTsgAccelTypes:
-            grid.enableAcceleration(accel)
-            sA = grid.getAccelerationType()
-            bTest = ((accel not in sA) or (sA not in accel))
-            self.assertFalse(bTest, "set/get Acceleration")
 
         if (@Tasmanian_cmake_synctest_enable@):
             bHasBlas = ("@Tasmanian_ENABLE_BLAS@" == "ON")
@@ -385,6 +378,19 @@ class TestTasmanian(unittest.TestCase):
             self.assertTrue((grid.isAccelerationAvailable("gpu-cublas") == bHasCuBlas), "failed to match cublas")
             self.assertTrue((grid.isAccelerationAvailable("gpu-cuda") == bHasCuda), "failed to match cuda")
             self.assertTrue((grid.isAccelerationAvailable("gpu-default") == (bHasCuBlas or bHasCuda)), "failed to match cuda")
+
+            # acceleration meta-data
+            lsAvailableAcc = []
+            if (bHasBlas): lsAvailableAcc.append("cpu-blas")
+            if (bHasCuBlas): lsAvailableAcc.append("gpu-cublas")
+            if (bHasCuda): lsAvailableAcc.append("gpu-cuda")
+            grid.makeLocalPolynomialGrid(2, 1, 2, 1, 'semi-localp')
+            for accel in lsAvailableAcc:
+                grid.enableAcceleration(accel)
+                sA = grid.getAccelerationType()
+                bTest = ((accel not in sA) or (sA not in accel))
+                self.assertFalse(bTest, "set/get Acceleration")
+
 
         self.assertTrue((grid.getGPUID() == 0), "did not default to gpu 0")
 

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -38,7 +38,7 @@
 #if defined(Tasmanian_ENABLE_CUBLAS) || defined(Tasmanian_ENABLE_CUDA)
 #define _TASMANIAN_SETGPU cudaSetDevice(gpuID);
 #else
-#define _TASMANIAN_SETGPU 
+#define _TASMANIAN_SETGPU
 #endif // defined
 
 namespace TasGrid{
@@ -374,6 +374,10 @@ void TasmanianSparseGrid::evaluateFast(const double x[], double y[]) const{
             _TASMANIAN_SETGPU
             base->evaluateFastGPUcuda(x_canonical, y, logstream);
             break;
+        case accel_gpu_magma:
+            _TASMANIAN_SETGPU
+            base->evaluateFastGPUmagma(x_canonical, y, logstream);
+            break;
         case accel_cpu_blas:
             base->evaluateFastCPUblas(x_canonical, y);
             break;
@@ -396,6 +400,10 @@ void TasmanianSparseGrid::evaluateBatch(const double x[], int num_x, double y[])
         case accel_gpu_cuda:
             _TASMANIAN_SETGPU
             base->evaluateBatchGPUcuda(x_canonical, num_x, y, logstream);
+            break;
+        case accel_gpu_magma:
+            _TASMANIAN_SETGPU
+            base->evaluateBatchGPUmagma(x_canonical, num_x, y, logstream);
             break;
         case accel_cpu_blas:
             base->evaluateBatchCPUblas(x_canonical, num_x, y);
@@ -535,11 +543,11 @@ double TasmanianSparseGrid::getQuadratureScale(int num_dimensions, TypeOneDRule 
     if ((rule == rule_gausschebyshev1)    || (rule == rule_gausschebyshev2)    || (rule == rule_gaussgegenbauer)    || (rule == rule_gaussjacobi) ||
         (rule == rule_gausschebyshev1odd) || (rule == rule_gausschebyshev2odd) || (rule == rule_gaussgegenbauerodd) || (rule == rule_gaussjacobiodd)){
         double alpha = ((rule == rule_gausschebyshev1) || (rule == rule_gausschebyshev1odd)) ? -0.5 :
-                       ((rule == rule_gausschebyshev2) || (rule == rule_gausschebyshev2odd)) ?  0.5 : 
+                       ((rule == rule_gausschebyshev2) || (rule == rule_gausschebyshev2odd)) ?  0.5 :
                        global->getAlpha();
-        double beta = ((rule == rule_gausschebyshev1) || (rule == rule_gausschebyshev1odd)) ? -0.5 : 
-                      ((rule == rule_gausschebyshev2) || (rule == rule_gausschebyshev2odd)) ?  0.5 : 
-                      ((rule == rule_gaussgegenbauer) || (rule == rule_gaussgegenbauerodd)) ? global->getAlpha() : 
+        double beta = ((rule == rule_gausschebyshev1) || (rule == rule_gausschebyshev1odd)) ? -0.5 :
+                      ((rule == rule_gausschebyshev2) || (rule == rule_gausschebyshev2odd)) ?  0.5 :
+                      ((rule == rule_gaussgegenbauer) || (rule == rule_gaussgegenbauerodd)) ? global->getAlpha() :
                       global->getBeta();
         for(int j=0; j<num_dimensions; j++) scale *= pow(0.5*(domain_transform_b[j] - domain_transform_a[j]), alpha + beta + 1.0);
     }else if ((rule == rule_gausslaguerre) || (rule == rule_gausslaguerreodd)){

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -335,8 +335,6 @@ TypeAcceleration AccelerationMeta::getIOAccelerationString(const char * name){
         return accel_gpu_cuda;
     }else if (strcmp(name, "gpu-magma") == 0){
         return accel_gpu_magma;
-    }else if (strcmp(name, "gpu-fullmem") == 0){
-        return accel_gpu_fullmemory;
     }else{
         return accel_none;
     }
@@ -348,14 +346,12 @@ const char* AccelerationMeta::getIOAccelerationString(TypeAcceleration accel){
         case accel_gpu_cublas:     return "gpu-cublas";
         case accel_gpu_cuda:       return "gpu-cuda";
         case accel_gpu_magma:      return "gpu-magma";
-        case accel_gpu_fullmemory: return "gpu-fullmem";
         default: return "none";
     }
 }
 int AccelerationMeta::getIOAccelerationInt(TypeAcceleration accel){
     switch (accel){
         case accel_cpu_blas:       return 1;
-        case accel_gpu_fullmemory: return 2;
         case accel_gpu_default:    return 3;
         case accel_gpu_cublas:     return 4;
         case accel_gpu_cuda:       return 5;
@@ -368,8 +364,7 @@ bool AccelerationMeta::isAccTypeFullMemoryGPU(TypeAcceleration accel){
         case accel_gpu_default:
         case accel_gpu_cublas:
         case accel_gpu_cuda:
-        case accel_gpu_magma:
-        case accel_gpu_fullmemory: return true;
+        case accel_gpu_magma: return true;
         default:
             return false;
     }
@@ -379,8 +374,7 @@ bool AccelerationMeta::isAccTypeGPU(TypeAcceleration accel){
         case accel_gpu_default:
         case accel_gpu_cublas:
         case accel_gpu_cuda:
-        case accel_gpu_magma:
-        case accel_gpu_fullmemory: return true;
+        case accel_gpu_magma: return true;
         default:
             return false;
     }

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -147,6 +147,8 @@ namespace AccelerationMeta{
     bool isAccTypeFullMemoryGPU(TypeAcceleration accel);
     bool isAccTypeGPU(TypeAcceleration accel);
 
+    TypeAcceleration getAvailableFallback(TypeAcceleration accel);
+    
     void cudaCheckError(void *cudaStatus, const char *info, std::ostream *os);
     void cublasCheckError(void *cublasStatus, const char *info, std::ostream *os);
     void cusparseCheckError(void *cusparseStatus, const char *info, std::ostream *os);

--- a/SparseGrids/tsgEnumerates.hpp
+++ b/SparseGrids/tsgEnumerates.hpp
@@ -112,11 +112,11 @@ enum TypeRefinement{
 enum TypeAcceleration{
     accel_none,
     accel_cpu_blas, // default if compiled with CPU-BLAS flag
-    accel_gpu_fullmemory, // load all values entirely into the GPU
-    accel_gpu_default,
-    accel_gpu_cublas,
-    accel_gpu_cuda,
-    accel_gpu_magma
+    accel_gpu_fullmemory, // (deprecated, remove from code)
+    accel_gpu_default, // currently magma (in v5.1 it was cuda)
+    accel_gpu_cublas, // CPU + CUBLAS (effective for large num_outputs only)
+    accel_gpu_cuda, // CUDA kernels, automatically couples with cublas
+    accel_gpu_magma // implies combination with CUDA kernels, if CUDA is ON
 };
 
 enum TypeLocalPolynomialBackendFlavor{

--- a/SparseGrids/tsgEnumerates.hpp
+++ b/SparseGrids/tsgEnumerates.hpp
@@ -112,7 +112,6 @@ enum TypeRefinement{
 enum TypeAcceleration{
     accel_none,
     accel_cpu_blas, // default if compiled with CPU-BLAS flag
-    accel_gpu_fullmemory, // (deprecated, remove from code)
     accel_gpu_default, // currently magma (in v5.1 it was cuda)
     accel_gpu_cublas, // CPU + CUBLAS (effective for large num_outputs only)
     accel_gpu_cuda, // CUDA kernels, automatically couples with cublas


### PR DESCRIPTION
* Acceleration fall-back logic was split between two functions `evaluateFast()` and `evaluateBatch()`, not it is all in one place
* Added MAGMA to the logic
* Updated the tests to account for the changes
* Propagated to legacy build system

**Note:** there are two layers of fall-back logic:
* **layer 1** the user specifies a given mode, which was not used on build time, then fall-back to the *next-best* from the options available on compile time.
* **layer 2** is specific to each type of grid and covers cases that have not been implemented yet, as well as use of non-existing functions (e.g., ensure we don't make calls to CUDA when CUDA is missing). The second layer **does not** guarantee the use of *next-best*.