### PR TITLE
MATLAB interface for Fourier

### DIFF
--- a/InterfaceMATLAB/tsgCoreTests.m
+++ b/InterfaceMATLAB/tsgCoreTests.m
@@ -464,21 +464,21 @@ if ((abs(norm(sum(w)) - 58.0) > 1.E-11) || (abs(max(p(:, 1)) - 13.0/3.0) > 1.E-1
 end
 
 % correctness of 1-D
-[lGrid, pf] = tsgMakeFourier('_tsgcoretests_lgrid', 1, 1, 'level', 2);
-bmark = [0.0; 1.0/3.0; 2.0/3.0; 1.0/9.0; 2.0/9.0; 4.0/9.0; 5.0/9.0; 7.0/9.0; 8.0/9.0];
-if (norm(pf - bmark) > 1.E-11)
+[lGrid, p] = tsgMakeFourier('_tsgcoretests_lgrid', 1, 1, 'level', 2);
+tp = [0.0; 1.0/3.0; 2.0/3.0; 1.0/9.0; 2.0/9.0; 4.0/9.0; 5.0/9.0; 7.0/9.0; 8.0/9.0];
+if (norm(p - tp) > 1.E-11)
     error('Mismatch in tsgMakeFourier: points');
 end
 
 % level limits
-[lGrid, p] = tsgMakeFourier('_tsgcoretests_lgrid', 3, 1, 'level', 2, [], [], [], [], [0, 1, 2]);
-if (min(abs(p(:,1))) > 1.E-8)
+[lGrid, p] = tsgMakeFourier('_tsgcoretests_lgrid', 3, 1, 'level', 3, [], [], [], [], [0, 1, 2]);
+if (max(abs(p(:,1))) > 1.E-8)
     error('Mismatch in tsgMakeFourier: level limit, dim 1');
 end
-if (min(abs(p(:,2) - 2.0/3.0)) > 1.E-8)
+if (min(abs(p(:,2) - 1.0/9.0)) < 1.E-8)
     error('Mismatch in tsgMakeFourier: level limit, dim 2');
 end
-if (min(abs(p(:,3) - 8.0/9.0)) > 1.E-8)
+if (min(abs(p(:,3) - 1.0/27.0)) < 1.E-8)
     error('Mismatch in tsgMakeFourier: level limit, dim 3');
 end
 tsgDeleteGrid(lGrid);

--- a/InterfaceMATLAB/tsgCoreTests.m
+++ b/InterfaceMATLAB/tsgCoreTests.m
@@ -445,6 +445,44 @@ if (min(abs(p(:,3) - 0.125)) < 1.E-8)
 end
 tsgDeleteGrid(lGrid);
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%                     tsgMakeFourier()                             %%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% test transform
+[lGrid, p] = tsgMakeFourier('_tsgcoretests_lgrid', 3, 1, 'level', 1, [3.0 5.0; -7.0 -6.0; -12.0 17.0]);
+if ((abs(max(p(:, 1)) - 13.0/3.0) > 1.E-11) || (abs(min(p(:, 1)) - 3.0) > 1.E-11) ...
+    || (abs(max(p(:, 2)) + 19.0/3.0) > 1.E-11) || (abs(min(p(:, 2)) + 7.0) > 1.E-11) ...
+    || (abs(max(p(:, 3)) - 22.0/3.0) > 1.E-11) || (abs(min(p(:, 3)) + 12.0) > 1.E-11))
+    error('Mismatch in tsgMakeFourier: transform');
+end
+[w, p] = tsgGetQuadrature(lGrid);
+if ((abs(norm(sum(w)) - 58.0) > 1.E-11) || (abs(max(p(:, 1)) - 13.0/3.0) > 1.E-11) ...
+    || (abs(min(p(:, 1)) - 3.0) > 1.E-11) || (abs(max(p(:, 2)) + 19.0/3.0) > 1.E-11) ...
+    || (abs(min(p(:, 2)) + 7.0) > 1.E-11) || (abs(max(p(:, 3)) - 22.0/3.0) > 1.E-11) ...
+    || (abs(min(p(:, 3)) + 12.0) > 1.E-11))
+    error('Mismatch in tsgMakeFourier: getQuadrature');
+end
+
+% correctness of 1-D
+[lGrid, pf] = tsgMakeFourier('_tsgcoretests_lgrid', 1, 1, 'level', 2);
+bmark = [0.0; 1.0/3.0; 2.0/3.0; 1.0/9.0; 2.0/9.0; 4.0/9.0; 5.0/9.0; 7.0/9.0; 8.0/9.0];
+if (norm(pf - bmark) > 1.E-11)
+    error('Mismatch in tsgMakeFourier: points');
+end
+
+% level limits
+[lGrid, p] = tsgMakeFourier('_tsgcoretests_lgrid', 3, 1, 'level', 2, [], [], [], [], [0, 1, 2]);
+if (min(abs(p(:,1))) > 1.E-8)
+    error('Mismatch in tsgMakeFourier: level limit, dim 1');
+end
+if (min(abs(p(:,2) - 2.0/3.0)) > 1.E-8)
+    error('Mismatch in tsgMakeFourier: level limit, dim 2');
+end
+if (min(abs(p(:,3) - 8.0/9.0)) > 1.E-8)
+    error('Mismatch in tsgMakeFourier: level limit, dim 3');
+end
+tsgDeleteGrid(lGrid);
+
 disp(['tsgMake* functions:       PASS']);
 
 
@@ -633,6 +671,19 @@ pnts = [-1.0 + 2.0 * rand(13, 2)];
 res = mVan * coef;
 if (norm(tres - res) > 1.E-11)
     error(['Mismatch in tsgEvaluateHierarchy: localp grid test']);
+end
+
+% this tests reading a complex matrix
+[lGrid, p] = tsgMakeFourier('_tsgcoretests_ml', 2, 1, 'level', 4);
+v = [exp(-p(:,1).^2 - 2.0 * p(:,2).^2)];
+tsgLoadValues(lGrid, v);
+pnts = [-1.0 + 2.0 * rand(13, 2)];
+[tres] = tsgEvaluate(lGrid, pnts);
+[mVan] = tsgEvaluateHierarchy(lGrid, pnts);
+[coef] = tsgGetHCoefficients(lGrid);
+res = real(mVan * coef);
+if (norm(tres - res) > 1.E-11)
+    error(['Mismatch in tsgEvaluateHierarchy: Fourier grid test']);
 end
 
 tsgDeleteGrid(lGrid);

--- a/InterfaceMATLAB/tsgCoreTests.m
+++ b/InterfaceMATLAB/tsgCoreTests.m
@@ -105,7 +105,7 @@ end
 for iL = 7:8
     [w, p] = tsgMakeQuadrature(2, 'gauss-patterson', 'qptotal', iL, -1);
     [wc, pc] = tsgMakeQuadrature(2, 'gauss-patterson', 'qptotal', iL, -1, [], [], [], [], 'asin', [4, 4]);
-    
+
     I  = sum(w  .* (1.0 ./ ((1.0 + 5.0 .* p(:,1).^2)  .* (1.0 + 5.0 .* p(:,2).^2))));
     Ic = sum(wc .* (1.0 ./ ((1.0 + 5.0 .* pc(:,1).^2) .* (1.0 + 5.0 .* pc(:,2).^2))));
     %[abs(I - 1.028825601981092^2), abs(Ic - 1.028825601981092^2)]
@@ -421,14 +421,14 @@ for iL = 3:4
     [w, p] = tsgGetQuadrature(lGrid);
     [lGrid, p] = tsgMakeWavelet('_tsgcoretests_lgrid', 2, 1, iL, 1);
     [wc, pc] = tsgGetQuadrature(lGrid);
-    
+
     I  = sum(w  .* (1.0 ./ ((1.0 + 5.0 .* p(:,1).^2)  .* (1.0 + 5.0 .* p(:,2).^2))));
     Ic = sum(wc .* (1.0 ./ ((1.0 + 5.0 .* pc(:,1).^2) .* (1.0 + 5.0 .* pc(:,2).^2))));
 
     if (abs(I - 1.028825601981092^2) < abs(Ic - 1.028825601981092^2))
         error('Mismatch in points and weights of simple quadrature: conformal map');
     end
-    
+
 end
 tsgDeleteGrid(lGrid);
 

--- a/InterfaceMATLAB/tsgEvaluateHierarchy.m
+++ b/InterfaceMATLAB/tsgEvaluateHierarchy.m
@@ -59,7 +59,7 @@ else
         [vals] = tsgReadMatrix(sFileO);
     elseif (strcmp(lGrid.sType, 'fourier'))
         [tmp] = tsgReadMatrix(sFileO);
-        vals = tmp(:,1:2:end) + sqrt(-1)*tmp(:,2:2:end);
+        vals = tmp(:,1:2:end) + i * tmp(:,2:2:end);     % i is unit imaginary
     else
         fid = fopen(sFileO);
         TSG = fread(fid, [1, 3], '*char');
@@ -72,8 +72,8 @@ else
             indx = fread(fid, [NNZ], '*int')';
             vals = fread(fid, [NNZ], '*double')';
             rindx = ones(NNZ, 1);
-            for i = 1:Rows
-                rindx((pntr(i)+1):(pntr(i+1))) = i;
+            for r = 1:Rows
+                rindx((pntr(r)+1):(pntr(r+1))) = r;
             end
             %[Rows, Cols, NNZ]
             vals = sparse(rindx, double(indx + 1.0), vals, double(Rows), double(Cols), double(NNZ));

--- a/InterfaceMATLAB/tsgEvaluateHierarchy.m
+++ b/InterfaceMATLAB/tsgEvaluateHierarchy.m
@@ -28,7 +28,7 @@ function [vals] = tsgEvaluateHierarchy(lGrid, mX)
 [sFiles, sTasGrid] = tsgGetPaths();
 [sFileG, sFileX, sFileV, sFileO, sFileW, sFileC] = tsgMakeFilenames(lGrid.sName);
 
-if (strcmp(lGrid.sType, 'global') || strcmp(lGrid.sType, 'sequence'))
+if (strcmp(lGrid.sType, 'global') || strcmp(lGrid.sType, 'sequence') || strcmp(lGrid.sType, 'fourier'))
     sCommand = [sTasGrid,' -evalhierarchyd'];
 else
     sCommand = [sTasGrid,' -evalhierarchys'];
@@ -57,6 +57,9 @@ else
     end
     if (strcmp(lGrid.sType, 'global') || strcmp(lGrid.sType, 'sequence'))
         [vals] = tsgReadMatrix(sFileO);
+    elseif (strcmp(lGrid.sType, 'fourier'))
+        [tmp] = tsgReadMatrix(sFileO);
+        vals = tmp(:,1:2:end) + sqrt(-1)*tmp(:,2:2:end);
     else
         fid = fopen(sFileO);
         TSG = fread(fid, [1, 3], '*char');

--- a/InterfaceMATLAB/tsgGetHCoefficients.m
+++ b/InterfaceMATLAB/tsgGetHCoefficients.m
@@ -34,7 +34,6 @@ else
         fprintf(1,['Warning: Command had non-empty output:\n']);
         disp(cmdout);
     end
-    
     [coefficients] = tsgReadMatrix(sFileO, strcmp(lGrid.sType, 'fourier'));  % read file as a complex file if appropriate
 end
 

--- a/InterfaceMATLAB/tsgGetHCoefficients.m
+++ b/InterfaceMATLAB/tsgGetHCoefficients.m
@@ -39,8 +39,7 @@ end
 
 if (strcmp(lGrid.sType, 'fourier'))
     % convert to complex matrix if needed
-    coefficients(:, 1:end/2) = coefficients(:, 1:2:end) + sqrt(-1)*coefficients(:, 2:2:end);
-    coefficients = coefficients(:, 1:end/2);
+    coefficients = coefficients(:, 1:2:end) + i * coefficients(:, 2:2:end);     % i is unit imaginary
 end
 
 tsgCleanTempFiles(lGrid, lClean);

--- a/InterfaceMATLAB/tsgGetHCoefficients.m
+++ b/InterfaceMATLAB/tsgGetHCoefficients.m
@@ -10,7 +10,7 @@ function [coefficients] = tsgGetHCoefficients(lGrid)
 %
 % OUTPUT:
 %
-% coefficients: the hierarchical coefficients of the grid in an array of dimension [num_poits, iOut]
+% coefficients: the hierarchical coefficients of the grid in an array of dimension [num_points, iOut]
 %
 
 [sFiles, sTasGrid] = tsgGetPaths();
@@ -34,7 +34,8 @@ else
         fprintf(1,['Warning: Command had non-empty output:\n']);
         disp(cmdout);
     end
-    [coefficients] = tsgReadMatrix(sFileO);
+    
+    [coefficients] = tsgReadMatrix(sFileO, strcmp(lGrid.sType, 'fourier'));  % read file as a complex file if appropriate
 end
 
 tsgCleanTempFiles(lGrid, lClean);

--- a/InterfaceMATLAB/tsgGetHCoefficients.m
+++ b/InterfaceMATLAB/tsgGetHCoefficients.m
@@ -34,7 +34,13 @@ else
         fprintf(1,['Warning: Command had non-empty output:\n']);
         disp(cmdout);
     end
-    [coefficients] = tsgReadMatrix(sFileO, strcmp(lGrid.sType, 'fourier'));  % read file as a complex file if appropriate
+    [coefficients] = tsgReadMatrix(sFileO);
+end
+
+if (strcmp(lGrid.sType, 'fourier'))
+    % convert to complex matrix if needed
+    coefficients(:, 1:end/2) = coefficients(:, 1:2:end) + sqrt(-1)*coefficients(:, 2:2:end);
+    coefficients = coefficients(:, 1:end/2);
 end
 
 tsgCleanTempFiles(lGrid, lClean);

--- a/InterfaceMATLAB/tsgLoadHCoefficients.m
+++ b/InterfaceMATLAB/tsgLoadHCoefficients.m
@@ -26,6 +26,13 @@ sCommand = [sTasGrid,' -setcoefficients'];
 
 sCommand = [sCommand, ' -gridfile ', sFileG];
 
+if (strcmp(lGrid.sType, 'fourier'))
+    mRealMat = zeros(size(mValues, 1), 2 * size(mValues, 2));
+    mRealMat(:, 1:2:end) = real(mValues);
+    mRealMat(:, 2:2:end) = imag(mValues);
+    mValues = mRealMat;
+end
+
 tsgWriteMatrix(sFileV, mValues);
 lClean.sFileV = 1;
 

--- a/InterfaceMATLAB/tsgLoadHCoefficients.m
+++ b/InterfaceMATLAB/tsgLoadHCoefficients.m
@@ -10,8 +10,8 @@ function tsgLoadHCoefficients(lGrid, mValues)
 %
 % mValues: a matrix with dimension [num_needed_points, iOut]
 %          each row corresponds to the values of the hierarchical
-%          coefficients at the corresponding needed point. 
-%          The order and leading dimension must match the points 
+%          coefficients at the corresponding needed point.
+%          The order and leading dimension must match the points
 %          obtained form tsgGetNeededPoints(...) command
 %
 % OUTPUT:

--- a/InterfaceMATLAB/tsgMakeFourier.m
+++ b/InterfaceMATLAB/tsgMakeFourier.m
@@ -1,7 +1,7 @@
 function [lGrid, points] = tsgMakeFourier(sGridName, iDim, iOut, sType, iDepth, mTransformAB, vAnisotropy, sConformalMap, vConfromalWeights, vLimitLevels)
 %
-% [lGrid, points] = 
-%               tsgMakeFourier(sGridName, iDim, iOut, sType, iDepth, 
+% [lGrid, points] =
+%               tsgMakeFourier(sGridName, iDim, iOut, sType, iDepth,
 %                    mTransformAB, vAlphaBeta, vAnisotropy,
 %                    sConformalMap, vConfromalWeights)
 %
@@ -9,7 +9,7 @@ function [lGrid, points] = tsgMakeFourier(sGridName, iDim, iOut, sType, iDepth, 
 %
 % INPUT:
 %
-% sGridName: the name of the grid, give it a string name, 
+% sGridName: the name of the grid, give it a string name,
 %            i.e. 'myGrid' or '1' or 'pi314'
 %            DO NOT LEAVE THIS EMPTY
 %
@@ -40,7 +40,7 @@ function [lGrid, points] = tsgMakeFourier(sGridName, iDim, iOut, sType, iDepth, 
 %               transform specifies the lower and upper bound of the domain
 %               in each direction. For gauss-laguerre and gauss-hermite
 %               grids, the transform gives the a and b parameters that
-%               change the weight to 
+%               change the weight to
 %               exp(-b (x - a))  and  exp(-b (x - a)^2)
 %
 % lCustomRule: (global grids of custom-tabulated rule)
@@ -60,14 +60,14 @@ function [lGrid, points] = tsgMakeFourier(sGridName, iDim, iOut, sType, iDepth, 
 %                   lCustomRule.vNodes
 %                   lCustomRule.vWeights
 %
-%                  see help tsgWriteCustomRuleFile.m for definition of 
+%                  see help tsgWriteCustomRuleFile.m for definition of
 %                  each field of the structure
 %
 % sConformalMap: (optional string giving the type of transform)
 %                conformal maps provide a non-linear domain transform,
 %                approximation (quadrature or interpolation) is done
 %                on the composition of f and the transform. A suitable
-%                transform could reduce the error by as much as an 
+%                transform could reduce the error by as much as an
 %                order of magnitude.
 %
 %                'asin': truncated MacLaurin series of arch-sin
@@ -79,9 +79,9 @@ function [lGrid, points] = tsgMakeFourier(sGridName, iDim, iOut, sType, iDepth, 
 % vLimitLevels: (optional vector of integers of size iDim)
 %               limit the level in each direction, no points beyond the
 %               specified limit will be used, e.g., in 2D using
-%               clenshaw-curtis rule, [1, 99] forces the grid to have 
-%               at most 3 possible values in the first variable and 
-%               ~2^99 (practically infinite) number in the second 
+%               clenshaw-curtis rule, [1, 99] forces the grid to have
+%               at most 3 possible values in the first variable and
+%               ~2^99 (practically infinite) number in the second
 %               direction. vLimitLevels works in conjunction with
 %               iDepth and sType, the points added to the grid will
 %               obey both bounds
@@ -91,11 +91,11 @@ function [lGrid, points] = tsgMakeFourier(sGridName, iDim, iOut, sType, iDepth, 
 % lGrid: list containing information about the sparse grid, can be used
 %        to call other functions
 %
-% points: (optional) the points of the grid in an array 
+% points: (optional) the points of the grid in an array
 %         of dimension [num_points, dim]
 %
-% [lGrid, points] = 
-%               tsgMakeFourier(sGridName, iDim, iOut, sType, iDepth, 
+% [lGrid, points] =
+%               tsgMakeFourier(sGridName, iDim, iOut, sType, iDepth,
 %                    mTransformAB, vAnisotropy,
 %                    sConformalMap, vConfromalWeights)
 %

--- a/InterfaceMATLAB/tsgMakeFourier.m
+++ b/InterfaceMATLAB/tsgMakeFourier.m
@@ -1,0 +1,221 @@
+function [lGrid, points] = tsgMakeFourier(sGridName, iDim, iOut, sType, iDepth, mTransformAB, vAnisotropy, sConformalMap, vConfromalWeights, vLimitLevels)
+%
+% [lGrid, points] = 
+%               tsgMakeFourier(sGridName, iDim, iOut, sType, iDepth, 
+%                    mTransformAB, vAlphaBeta, vAnisotropy,
+%                    sConformalMap, vConfromalWeights)
+%
+% creates a new sparse grid using a Fourier rule
+%
+% INPUT:
+%
+% sGridName: the name of the grid, give it a string name, 
+%            i.e. 'myGrid' or '1' or 'pi314'
+%            DO NOT LEAVE THIS EMPTY
+%
+% iDim: (integer, positive)
+%       the number of inputs
+%
+% iOut: (integer, non-negative)
+%       the number of outputs
+%
+% sType: (string giving the tensor selection strategy)
+%       'level'     'curved'     'hyperbolic'     'tensor'
+%       'iptotal'   'ipcurved'   'iphyperbolic'   'iptensor'
+%       'qptotal'   'qpcurved'   'qphyperbolic'   'qptensor'
+%
+% iDepth: (integer non-negative)
+%       controls the density of the grid, i.e., the offset for the tensor
+%       selection, the meaning of iDepth depends on sType
+%       Example 1: sType == 'iptotal' will give a grid that interpolates
+%              exactly all polynomials of degree up to and including iDepth
+%       Example 2: sType == 'qptotal' will give a grid that integrates
+%              exactly all polynomials of degree up to and including iDepth
+%
+% vAnisotropy: (optional vector of positive integers, length iDim or 2*iDim)
+%       the anisotropic weights associated with sType
+%
+% mTransformAB: (optional matrix of size iDim x 2)
+%               for all but gauss-laguerre and gauss-hermite grids, the
+%               transform specifies the lower and upper bound of the domain
+%               in each direction. For gauss-laguerre and gauss-hermite
+%               grids, the transform gives the a and b parameters that
+%               change the weight to 
+%               exp(-b (x - a))  and  exp(-b (x - a)^2)
+%
+% lCustomRule: (global grids of custom-tabulated rule)
+%              custom_rule can be either of 3 things:
+%
+%                string containing filename with a defined custom name
+%
+%                structure containing the filed lCustomRule.sFilename,
+%                which is the name of a file containing the user defined
+%                rule
+%
+%                structure defining the fields
+%                   lCustomRule.sDescription
+%                   lCustomRule.iMaxLevel
+%                   lCustomRule.vLevels
+%                   lCustomRule.vPrecision
+%                   lCustomRule.vNodes
+%                   lCustomRule.vWeights
+%
+%                  see help tsgWriteCustomRuleFile.m for definition of 
+%                  each field of the structure
+%
+% sConformalMap: (optional string giving the type of transform)
+%                conformal maps provide a non-linear domain transform,
+%                approximation (quadrature or interpolation) is done
+%                on the composition of f and the transform. A suitable
+%                transform could reduce the error by as much as an 
+%                order of magnitude.
+%
+%                'asin': truncated MacLaurin series of arch-sin
+%
+% vConfromalWeights: (optional parameters for the conformal trnasform)
+%               'asin': indicate the number of terms to keep after
+%                       truncation
+%
+% vLimitLevels: (optional vector of integers of size iDim)
+%               limit the level in each direction, no points beyond the
+%               specified limit will be used, e.g., in 2D using
+%               clenshaw-curtis rule, [1, 99] forces the grid to have 
+%               at most 3 possible values in the first variable and 
+%               ~2^99 (practically infinite) number in the second 
+%               direction. vLimitLevels works in conjunction with
+%               iDepth and sType, the points added to the grid will
+%               obey both bounds
+%
+% OUTPUT:
+%
+% lGrid: list containing information about the sparse grid, can be used
+%        to call other functions
+%
+% points: (optional) the points of the grid in an array 
+%         of dimension [num_points, dim]
+%
+% [lGrid, points] = 
+%               tsgMakeFourier(sGridName, iDim, iOut, sType, iDepth, 
+%                    mTransformAB, vAnisotropy,
+%                    sConformalMap, vConfromalWeights)
+%
+
+if (~isnumeric(iDim) || ~isreal(iDim) || ~(rem(iDim,1) == 0) || ~(sum(size(iDim) == [1,1])) || ~(iDim > 0))
+    error('iDim must be a positive integer')
+end
+if (~isnumeric(iOut) || ~isreal(iOut) || ~(rem(iOut,1) == 0) || ~(sum(size(iOut) == [1,1])) || ~(iOut > 0))
+    error('iOut must be a positive integer')
+end
+
+% create lGrid object
+lGrid.sName = sGridName;
+lGrid.iDim  = iDim;
+lGrid.iOut  =  iOut;
+lGrid.sType = 'fourier';
+
+% check for conflict with tsgMakeQuadrature
+if (strcmp(sGridName, ''))
+    error('sGridName cannot be empty');
+end
+
+% generate filenames
+[sFiles, sTasGrid] = tsgGetPaths();
+[sFileG, sFileX, sFileV, sFileO, sFileW, sFileC, sFileL] = tsgMakeFilenames(lGrid.sName);
+
+sCommand = [sTasGrid,' -makefourier'];
+
+sCommand = [sCommand, ' -gridfile ',   sFileG];
+sCommand = [sCommand, ' -dimensions ', num2str(lGrid.iDim)];
+sCommand = [sCommand, ' -outputs ',    num2str(lGrid.iOut)];
+sCommand = [sCommand, ' -depth ',      num2str(iDepth)];
+sCommand = [sCommand, ' -type ',       sType];
+
+% set the domain transformation
+if (exist('mTransformAB') && (max(size(mTransformAB)) ~= 0))
+    if (size(mTransformAB, 2) ~= 2)
+        error(' mTransformAB must be a matrix with 2 columns');
+    end
+    if (size(mTransformAB, 1) ~= lGrid.iDim)
+        error(' mTransformAB must be a matrix with iDim number of rows');
+    end
+    tsgWriteMatrix(sFileV, mTransformAB);
+    lClean.sFileV = 1;
+    sCommand = [sCommand, ' -tf ',sFileV];
+end
+
+% set anisotropy
+if (exist('vAnisotropy') && (max(size(vAnisotropy)) ~= 0))
+    if (min(size(vAnisotropy)) ~= 1)
+        error(' vAnisotropy must be a vector, i.e., one row or one column');
+    end
+    if (max(size(vAnisotropy)) ~= lGrid.iDim)
+        error(' vAnisotropy must be a vector of size iDim');
+    end
+    if (size(vAnisotropy, 1) > size(vAnisotropy, 2))
+        tsgWriteMatrix(sFileW, vAnisotropy');
+    else
+        tsgWriteMatrix(sFileW, vAnisotropy);
+    end
+    lClean.sFileW = 1;
+    sCommand = [sCommand, ' -anisotropyfile ', sFileW];
+end
+
+% set conformal mapping
+if (exist('sConformalMap')  && (max(size(sConformalMap)) ~= 0))
+    if (~exist('vConfromalWeights'))
+        error(' sConformalMap requires vConfromalWeights')
+    end
+    sCommand = [sCommand, ' -conformaltype ', sConformalMap];
+    if (size(vConfromalWeights, 1) > size(vConfromalWeights, 2))
+        tsgWriteMatrix(sFileC, vConfromalWeights');
+    else
+        tsgWriteMatrix(sFileC, vConfromalWeights);
+    end
+    lClean.sFileC = 1;
+    sCommand = [sCommand, ' -conformalfile ', sFileC];
+end
+
+% set level limits
+if (exist('vLimitLevels') && (max(size(vLimitLevels)) ~= 0))
+    if (min(size(vLimitLevels)) ~= 1)
+        error(' vLimitLevels must be a vector, i.e., one row or one column');
+    end
+    if (max(size(vLimitLevels)) ~= lGrid.iDim)
+        error(' vLimitLevels must be a vector of size iDim');
+    end
+    if (size(vLimitLevels, 1) > size(vLimitLevels, 2))
+        tsgWriteMatrix(sFileL, vLimitLevels');
+    else
+        tsgWriteMatrix(sFileL, vLimitLevels);
+    end
+    lClean.sFileL = 1;
+    sCommand = [sCommand, ' -levellimitsfile ', sFileL];
+end
+
+% read the points for the grid
+if (nargout > 1)
+    sCommand = [sCommand, ' -of ', sFileO];
+    lClean.sFileO = 1;
+end
+
+[status, cmdout] = system(sCommand);
+
+if (max(size(findstr('ERROR', cmdout))) ~= 0)
+    disp(cmdout);
+    error('The tasgrid execurable returned an error, see above');
+    return;
+else
+    if (~isempty(cmdout))
+        fprintf(1,['WARNING: Command had non-empty output:\n']);
+        disp(cmdout);
+    end
+    if (nargout > 1)
+        points = tsgReadMatrix(sFileO);
+    end
+end
+
+if (exist('lClean'))
+    tsgCleanTempFiles(lGrid, lClean);
+end
+
+end

--- a/InterfaceMATLAB/tsgMakeQuadrature.m
+++ b/InterfaceMATLAB/tsgMakeQuadrature.m
@@ -28,6 +28,11 @@ function [weights, points] = tsgMakeQuadrature(iDim, s1D, sType, iDepth, iOrder,
 %                 Note: the quadrature induced by those rules is 
 %                       constructed by integrating the interpolant
 %
+%       'fourier'
+%                 approximation using Fourier basis; nested nodes
+%                 Note: the quadrature induced by this rule is
+%                       constructed by integrating the interpolant
+%
 %    Quadrature rules, the weights target exactness with respect to the
 %                        highest polynomial degree possible
 %

--- a/InterfaceMATLAB/tsgMakeQuadrature.m
+++ b/InterfaceMATLAB/tsgMakeQuadrature.m
@@ -1,7 +1,7 @@
 function [weights, points] = tsgMakeQuadrature(iDim, s1D, sType, iDepth, iOrder, mTransformAB, vAlphaBeta, vAnisotropy, lCustomRule, sConformalMap, vConfromalWeights, vLimitLevels)
 %
-% [weights, points] = tsgMakeQuadrature(iDim, s1D, sType, iDepth, iOrder, 
-%                    mTransformAB, vAlphaBeta, vAnisotropy, lCustomRule, 
+% [weights, points] = tsgMakeQuadrature(iDim, s1D, sType, iDepth, iOrder,
+%                    mTransformAB, vAlphaBeta, vAnisotropy, lCustomRule,
 %                        sConformalMap, vConfromalWeights, vLimitLevels)
 %
 % creates a set of points and weights for integration
@@ -13,7 +13,7 @@ function [weights, points] = tsgMakeQuadrature(iDim, s1D, sType, iDepth, iOrder,
 %
 % s1D: (string for the underlying 1-D rule that induces the grid)
 %
-%    Interpolation rules (Note: the quadrature induced by those rules is 
+%    Interpolation rules (Note: the quadrature induced by those rules is
 %                               constructed by integrating the interpolant)
 %
 %   'clenshaw-curtis'         'clenshaw-curtis-zero'           'fejer2'
@@ -25,7 +25,7 @@ function [weights, points] = tsgMakeQuadrature(iDim, s1D, sType, iDepth, iOrder,
 %       'chebyshev'  'chebyshev-odd'
 %                 approximation using roots of Chebyshev polynomials
 %                 non-nested case (in contrast to Clenshaw-Curtis nodes)
-%                 Note: the quadrature induced by those rules is 
+%                 Note: the quadrature induced by those rules is
 %                       constructed by integrating the interpolant
 %
 %       'fourier'
@@ -66,7 +66,7 @@ function [weights, points] = tsgMakeQuadrature(iDim, s1D, sType, iDepth, iOrder,
 %                 approximation using roots of polynomials orthogonal in
 %                 measure |x|^alpha * epx(-x^2)
 %
-%    Local rules (Note: the quadrature induced by those rules is 
+%    Local rules (Note: the quadrature induced by those rules is
 %                       constructed by integrating the interpolant)
 %            Note: local rules ignore the values of inputs sType,
 %                  vAnisotropy and vAlphaBeta
@@ -100,7 +100,7 @@ function [weights, points] = tsgMakeQuadrature(iDim, s1D, sType, iDepth, iOrder,
 %               transform specifies the lower and upper bound of the domain
 %               in each direction. For gauss-laguerre and gauss-hermite
 %               grids, the transform gives the a and b parameters that
-%               change the weight to 
+%               change the weight to
 %               exp(-b (x - a))  and  exp(-b (x - a)^2)
 %
 % vAnisotropy: (optional vector of positive integers, length iDim or 2*iDim)
@@ -135,7 +135,7 @@ function [weights, points] = tsgMakeQuadrature(iDim, s1D, sType, iDepth, iOrder,
 %                conformal maps provide a non-linear domain transform,
 %                approximation (quadrature or interpolation) is done
 %                on the composition of f and the transform. A suitable
-%                transform could reduce the error by as much as an 
+%                transform could reduce the error by as much as an
 %                order of magnitude.
 %
 %                'asin': truncated MacLaurin series of arch-sin
@@ -147,9 +147,9 @@ function [weights, points] = tsgMakeQuadrature(iDim, s1D, sType, iDepth, iOrder,
 % vLimitLevels: (optional vector of integers of size iDim)
 %               limit the level in each direction, no points beyond the
 %               specified limit will be used, e.g., in 2D using
-%               clenshaw-curtis rule, [1, 99] forces the grid to have 
-%               at most 3 possible values in the first variable and 
-%               ~2^99 (practicallyt infinite) number in the second 
+%               clenshaw-curtis rule, [1, 99] forces the grid to have
+%               at most 3 possible values in the first variable and
+%               ~2^99 (practicallyt infinite) number in the second
 %               direction. vLimitLevels works in conjunction with
 %               iDepth and sType, the points added to the grid will
 %               obey both bounds
@@ -163,8 +163,8 @@ function [weights, points] = tsgMakeQuadrature(iDim, s1D, sType, iDepth, iOrder,
 %
 % points: the quadrature nodes, i.e., quad(f) = weights' * f(points)
 %
-% [weights, points] = tsgMakeQuadrature(iDim, s1D, sType, iDepth, iOrder, 
-%                    mTransformAB, vAlphaBeta, vAnisotropy, lCustomRule, 
+% [weights, points] = tsgMakeQuadrature(iDim, s1D, sType, iDepth, iOrder,
+%                    mTransformAB, vAlphaBeta, vAnisotropy, lCustomRule,
 %                        sConformalMap, vConfromalWeights, vLimitLevels)
 %
 
@@ -183,7 +183,7 @@ if (bLocal)
     sCommand = [sCommand, ' -order ', num2str(iOrder)];
 else
     sCommand = [sCommand, ' -type ',  sType];
-    
+
     % set anisotropy
     if (exist('vAnisotropy') && (max(size(vAnisotropy)) ~= 0))
         if (min(size(vAnisotropy)) ~= 1)

--- a/InterfaceMATLAB/tsgReadMatrix.m
+++ b/InterfaceMATLAB/tsgReadMatrix.m
@@ -1,11 +1,6 @@
-function [mat] = tsgReadMatrix(filename, bIsComplex)
+function [mat] = tsgReadMatrix(filename)
 %
-% [mat] = tsgReadMatrix(filename, bIsComplex)
-%
-% bIsComplex     :  (optional, default 0)
-%                   set to 1 if values are complex
-%                   
-% [mat] = tsgReadMatrix(filename, 0)
+% [mat] = tsgReadMatrix(filename)
 %
 % reads a matrix from a file format
 % 
@@ -14,21 +9,8 @@ function [mat] = tsgReadMatrix(filename, bIsComplex)
 % 5 6 7 8
 % 9 10 11 12
 %
-% results in the matrix [1 2 3 4; 5 6 7 8; 9 10 11 12], whereas...
+% results in the matrix [1 2 3 4; 5 6 7 8; 9 10 11 12;]
 %
-% [mat] = tsgReadMatrix(filename, 1) reads the file
-%
-% 3 4
-% 1 2 3 4
-% 5 6 7 8
-% 9 10 11 12
-%
-% results in the matrix [1+2i 3+4i; 5+6i 7+8i; 9+10i 11+12i]
-%
-
-if (~(exist('bIsComplex')) || (~(bIsComplex == 0 || bIsComplex == 1)))
-    bIsComplex = 0;
-end
 
 fid = fopen(filename);
 
@@ -40,11 +22,6 @@ if (TSG == 'TSG')
     Cols = D(2);
     mat = fread(fid, [Cols, Rows], '*double')';
     fclose(fid);
-    if(bIsComplex)
-        % modify matrix in place to save on storage
-        mat(:,1:(Cols/2)) = mat(:,1:2:Cols) + sqrt(-1)*mat(:,2:2:Cols);
-        mat = mat(:,1:(Cols/2));
-    end
     return;
 else
     fclose(fid);
@@ -66,16 +43,11 @@ else
 end
 
 for i = 1:Ni
-
+    
     [s] = fscanf(fid, ' %f ', [1, Nj]);
     
     mat(i,:) = s;
     
-end
-
-if (bIsComplex)
-    mat(:,1:(Nj/2)) = mat(:,1:2:Nj) + sqrt(-1)*mat(:,2:2:Nj);
-    mat = mat(:,1:(Nj/2));
 end
 
 fclose(fid);

--- a/InterfaceMATLAB/tsgReadMatrix.m
+++ b/InterfaceMATLAB/tsgReadMatrix.m
@@ -2,10 +2,8 @@ function [mat] = tsgReadMatrix(filename, bIsComplex)
 %
 % [mat] = tsgReadMatrix(filename, bIsComplex)
 %
-% bIsComplex     :   (optional, default 0)
+% bIsComplex     :  (optional, default 0)
 %                   set to 1 if values are complex
-%                   file must have twice as many columns as the second
-%                       number in header line if bIsComplex = 1
 %                   
 % [mat] = tsgReadMatrix(filename, 0)
 %
@@ -16,11 +14,11 @@ function [mat] = tsgReadMatrix(filename, bIsComplex)
 % 5 6 7 8
 % 9 10 11 12
 %
-% results in the matrix [1 2 3 4; 5 6 7 8; 9 10 11 12;]
+% results in the matrix [1 2 3 4; 5 6 7 8; 9 10 11 12], whereas...
 %
 % [mat] = tsgReadMatrix(filename, 1) reads the file
 %
-% 3 2
+% 3 4
 % 1 2 3 4
 % 5 6 7 8
 % 9 10 11 12
@@ -43,9 +41,8 @@ if (TSG == 'TSG')
     mat = fread(fid, [Cols, Rows], '*double')';
     fclose(fid);
     if(bIsComplex)
-        for j = 1:(Cols/2)
-            mat(:,j) = mat(:,2*j-1) + sqrt(-1)*mat(:,2*j);
-        end
+        % modify matrix in place to save on storage
+        mat(:,1:(Cols/2)) = mat(:,1:2:Cols) + sqrt(-1)*mat(:,2:2:Cols);
         mat = mat(:,1:(Cols/2));
     end
     return;
@@ -77,12 +74,9 @@ for i = 1:Ni
 end
 
 if (bIsComplex)
-    for j = 1:(Nj/2)
-        mat(:,j) = mat(:,2*j-1) + sqrt(-1)*mat(:,2*j);
-    end
+    mat(:,1:(Nj/2)) = mat(:,1:2:Nj) + sqrt(-1)*mat(:,2:2:Nj);
     mat = mat(:,1:(Nj/2));
 end
-
 
 fclose(fid);
 

--- a/InterfaceMATLAB/tsgReadMatrix.m
+++ b/InterfaceMATLAB/tsgReadMatrix.m
@@ -1,6 +1,13 @@
-function [mat] = tsgReadMatrix(filename)
+function [mat] = tsgReadMatrix(filename, bIsComplex)
 %
-% [mat] = tsgReadMatrix(filename)
+% [mat] = tsgReadMatrix(filename, bIsComplex)
+%
+% bIsComplex     :   (optional, default 0)
+%                   set to 1 if values are complex
+%                   file must have twice as many columns as the second
+%                       number in header line if bIsComplex = 1
+%                   
+% [mat] = tsgReadMatrix(filename, 0)
 %
 % reads a matrix from a file format
 % 
@@ -11,6 +18,19 @@ function [mat] = tsgReadMatrix(filename)
 %
 % results in the matrix [1 2 3 4; 5 6 7 8; 9 10 11 12;]
 %
+% [mat] = tsgReadMatrix(filename, 1) reads the file
+%
+% 3 2
+% 1 2 3 4
+% 5 6 7 8
+% 9 10 11 12
+%
+% results in the matrix [1+2i 3+4i; 5+6i 7+8i; 9+10i 11+12i]
+%
+
+if (~(exist('bIsComplex')) || (~(bIsComplex == 0 || bIsComplex == 1)))
+    bIsComplex = 0;
+end
 
 fid = fopen(filename);
 
@@ -22,6 +42,12 @@ if (TSG == 'TSG')
     Cols = D(2);
     mat = fread(fid, [Cols, Rows], '*double')';
     fclose(fid);
+    if(bIsComplex)
+        for j = 1:(Cols/2)
+            mat(:,j) = mat(:,2*j-1) + sqrt(-1)*mat(:,2*j);
+        end
+        mat = mat(:,1:(Cols/2));
+    end
     return;
 else
     fclose(fid);
@@ -43,12 +69,20 @@ else
 end
 
 for i = 1:Ni
-    
+
     [s] = fscanf(fid, ' %f ', [1, Nj]);
     
     mat(i,:) = s;
     
 end
+
+if (bIsComplex)
+    for j = 1:(Nj/2)
+        mat(:,j) = mat(:,2*j-1) + sqrt(-1)*mat(:,2*j);
+    end
+    mat = mat(:,1:(Nj/2));
+end
+
 
 fclose(fid);
 

--- a/InterfaceMATLAB/tsgReadMatrix.m
+++ b/InterfaceMATLAB/tsgReadMatrix.m
@@ -3,7 +3,7 @@ function [mat] = tsgReadMatrix(filename)
 % [mat] = tsgReadMatrix(filename)
 %
 % reads a matrix from a file format
-% 
+%
 % 3 4
 % 1 2 3 4
 % 5 6 7 8
@@ -43,11 +43,11 @@ else
 end
 
 for i = 1:Ni
-    
+
     [s] = fscanf(fid, ' %f ', [1, Nj]);
-    
+
     mat(i,:) = s;
-    
+
 end
 
 fclose(fid);

--- a/InterfaceMATLAB/tsgReloadGrid.m
+++ b/InterfaceMATLAB/tsgReloadGrid.m
@@ -48,6 +48,8 @@ elseif (strcmp(l1{4}, 'Local'))
     lGrid.sType = 'localpolynomial';
 elseif (strcmp(l1{4}, 'Wavelets'))
     lGrid.sType = 'wavelet';
+elseif (strcmp(l1{4}, 'Fourier'))
+    lGrid.sType = 'fourier';
 end
 
 lGrid.iDim = str2num(l2{3});

--- a/InterfaceMATLAB/tsgWriteMatrix.m
+++ b/InterfaceMATLAB/tsgWriteMatrix.m
@@ -4,19 +4,12 @@ function tsgWriteMatrix(filename, mat)
 %
 % write a matrix to a text file
 % 
-% the matrix [1 2 3 4; 5 6 7 8; 9 10 11 12;]
+% Both the real matrix [1 2 3 4; 5 6 7 8; 9 10 11 12] and the complex
+% matrix [1+2i 3+4i; 5+6i 7+8i; 9+10i 11+12i]
 %
-% is written as
+% are written as
 %
 % 3 4
-% 1 2 3 4
-% 5 6 7 8
-% 9 10 11 12
-%
-%
-% the complex matrix [1+2i 3+4i; 5+6i 7+8i; 9+10i 11+12i] is written as
-%
-% 3 2
 % 1 2 3 4
 % 5 6 7 8
 % 9 10 11 12

--- a/InterfaceMATLAB/tsgWriteMatrix.m
+++ b/InterfaceMATLAB/tsgWriteMatrix.m
@@ -3,7 +3,7 @@ function tsgWriteMatrix(filename, mat)
 % tsgWriteMatrix(filename, mat)
 %
 % write a matrix to a text file
-% 
+%
 % the matrix [1 2 3 4; 5 6 7 8; 9 10 11 12;]
 %
 % is written as
@@ -42,19 +42,19 @@ if (prod(size(mat)) < 1000) % small matrix, use ascii format
 else
 
     fid = fopen(filename, 'wb');
-    
+
     Ni = size(mat, 1);
     Nj = size(mat, 2);
-    
+
     fwrite(fid, ['TSG']);
     fwrite(fid, [Ni, Nj], 'integer*4');
     fwrite(fid, mat', 'double');
-    
+
     %if (size(mat, 1) > 10)
     %    size(mat)
     %    mat(1:10, :)
     %end
-    
+
     fclose(fid);
 
 end

--- a/InterfaceMATLAB/tsgWriteMatrix.m
+++ b/InterfaceMATLAB/tsgWriteMatrix.m
@@ -13,28 +13,56 @@ function tsgWriteMatrix(filename, mat)
 % 5 6 7 8
 % 9 10 11 12
 %
+%
+% the complex matrix [1+2i 3+4i; 5+6i 7+8i; 9+10i 11+12i] is written as
+%
+% 3 2
+% 1 2 3 4
+% 5 6 7 8
+% 9 10 11 12
+%
+
+bIsComplex = ~isreal(mat);
 
 if (prod(size(mat)) < 1000) % small matrix, use ascii format
 
     fid = fopen(filename, 'w');
 
-    fprintf(fid, '%d  %d\n', size(mat, 1), size(mat, 2)); % load the number of points
+    Ni = size(mat, 1);
+
+    if(bIsComplex)
+        Nj = 2 * size(mat, 2);
+    else
+        Nj = size(mat, 2);
+    end
+
+    fprintf(fid, '%d  %d\n', Ni, Nj); % load the number of points
 
     %format long;
-
-    Ni = size(mat, 1);
-    Nj = size(mat, 2);
 
     fmt = [''];
 
     for i = 1:Nj
-        fmt = [fmt, '%2.20e '];
+        if (~bIsComplex)
+            fmt = [fmt, '%2.20e '];
+        else
+            fmt = [fmt, '%2.20e %2.20e '];
+        end
     end
 
     fmt = [fmt(1:end-1), '\n'];
 
-    for i = 1:Ni
-        fprintf(fid, fmt, mat(i,:));
+    if (~bIsComplex)
+        for i = 1:Ni
+            fprintf(fid, fmt, mat(i,:));
+        end
+    else
+        pmat = zeros(Ni, Nj);
+        pmat(:,1:2:Nj) = real(mat);
+        pmat(:,2:2:Nj) = imag(mat);
+        for i = 1:Ni
+            fprintf(fid, fmt, pmat(i,:));
+        end
     end
 
     fclose(fid);
@@ -44,11 +72,23 @@ else
     fid = fopen(filename, 'wb');
     
     Ni = size(mat, 1);
-    Nj = size(mat, 2);
+
+    if (bIsComplex)
+        Nj = 2 * size(mat, 2);
+    else
+        Nj = size(mat, 2);
+    end
     
     fwrite(fid, ['TSG']);
     fwrite(fid, [Ni, Nj], 'integer*4');
-    fwrite(fid, mat', 'double');
+    if (~bIsComplex)
+        fwrite(fid, mat', 'double');
+    else
+        pmat = zeros(Ni,Nj);
+        pmat(:,1:2:Nj) = real(mat);
+        pmat(:,2:2:Nj) = imag(mat);
+        fwrite(fid, pmat', 'double');
+    end
     
     %if (size(mat, 1) > 10)
     %    size(mat)

--- a/InterfaceMATLAB/tsgWriteMatrix.m
+++ b/InterfaceMATLAB/tsgWriteMatrix.m
@@ -4,10 +4,9 @@ function tsgWriteMatrix(filename, mat)
 %
 % write a matrix to a text file
 % 
-% Both the real matrix [1 2 3 4; 5 6 7 8; 9 10 11 12] and the complex
-% matrix [1+2i 3+4i; 5+6i 7+8i; 9+10i 11+12i]
+% the matrix [1 2 3 4; 5 6 7 8; 9 10 11 12;]
 %
-% are written as
+% is written as
 %
 % 3 4
 % 1 2 3 4
@@ -15,47 +14,27 @@ function tsgWriteMatrix(filename, mat)
 % 9 10 11 12
 %
 
-bIsComplex = ~isreal(mat);
-
 if (prod(size(mat)) < 1000) % small matrix, use ascii format
 
     fid = fopen(filename, 'w');
 
-    Ni = size(mat, 1);
-
-    if(bIsComplex)
-        Nj = 2 * size(mat, 2);
-    else
-        Nj = size(mat, 2);
-    end
-
-    fprintf(fid, '%d  %d\n', Ni, Nj); % load the number of points
+    fprintf(fid, '%d  %d\n', size(mat, 1), size(mat, 2)); % load the number of points
 
     %format long;
+
+    Ni = size(mat, 1);
+    Nj = size(mat, 2);
 
     fmt = [''];
 
     for i = 1:Nj
-        if (~bIsComplex)
-            fmt = [fmt, '%2.20e '];
-        else
-            fmt = [fmt, '%2.20e %2.20e '];
-        end
+        fmt = [fmt, '%2.20e '];
     end
 
     fmt = [fmt(1:end-1), '\n'];
 
-    if (~bIsComplex)
-        for i = 1:Ni
-            fprintf(fid, fmt, mat(i,:));
-        end
-    else
-        pmat = zeros(Ni, Nj);
-        pmat(:,1:2:Nj) = real(mat);
-        pmat(:,2:2:Nj) = imag(mat);
-        for i = 1:Ni
-            fprintf(fid, fmt, pmat(i,:));
-        end
+    for i = 1:Ni
+        fprintf(fid, fmt, mat(i,:));
     end
 
     fclose(fid);
@@ -65,23 +44,11 @@ else
     fid = fopen(filename, 'wb');
     
     Ni = size(mat, 1);
-
-    if (bIsComplex)
-        Nj = 2 * size(mat, 2);
-    else
-        Nj = size(mat, 2);
-    end
+    Nj = size(mat, 2);
     
     fwrite(fid, ['TSG']);
     fwrite(fid, [Ni, Nj], 'integer*4');
-    if (~bIsComplex)
-        fwrite(fid, mat', 'double');
-    else
-        pmat = zeros(Ni,Nj);
-        pmat(:,1:2:Nj) = real(mat);
-        pmat(:,2:2:Nj) = imag(mat);
-        fwrite(fid, pmat', 'double');
-    end
+    fwrite(fid, mat', 'double');
     
     %if (size(mat, 1) > 10)
     %    size(mat)

--- a/SparseGrids/tsgGridFourier.cpp
+++ b/SparseGrids/tsgGridFourier.cpp
@@ -625,7 +625,7 @@ void GridFourier::getInterpolationWeights(const double x[], double weights[]) co
     delete[] basisFuncs;
 }
 
-double* GridFourier::getQuadratureWeights() const{
+double* GridFourier::getQuadratureWeights() const {
     int num_points = getNumPoints();
     double *w = new double[num_points];
     getQuadratureWeights(w);


### PR DESCRIPTION
This branch adds a MATLAB wrapper for the Fourier basis. Changes:
* `tsgReadMatrix.m` now has a boolean flag `bIsComplex`; `tsgWriteMatrix.m` automatically detects whether the matrix is complex
* added `tsgMakeFourier.m`
* fixed a bug that was causing all-zero quadrature weights for the Fourier rule when using `./tasgrid -makequadrature` (source was in `tsgCoreOneDimensional.cpp`)
* added extra case to `printGridStats` in `TasmanianSparseGrid.cpp` so that the MATLAB interface can detect a Fourier rule
* small formatting changes