### PR TITLE
Add compile options info

### DIFF
--- a/Config/AltBuildSystems/TasmanianConfig.hpp
+++ b/Config/AltBuildSystems/TasmanianConfig.hpp
@@ -37,6 +37,7 @@
 #define TASMANIAN_LICENSE "BSD 3-Clause with UT-Battelle disclaimer"
 
 #define TASMANIAN_GIT_COMMIT_HASH "Tasmanian git hash is not available here"
+#define TASMANIAN_CXX_FLAGS "Not availabe in simple GNU Make mode"
 
 ////////////////////////////////////////////////////////////////////////
 // In order to enable advanced options for Tasmanian,

--- a/Config/TasmanianConfig.in.hpp
+++ b/Config/TasmanianConfig.in.hpp
@@ -37,7 +37,7 @@
 #define TASMANIAN_LICENSE "@Tasmanian_license@"
 
 #define TASMANIAN_GIT_COMMIT_HASH "@Tasmanian_git_hash@"
-#define TASMANIAN_CXX_FLAGS "@CMAKE_CXX_FLAGS@"
+#define TASMANIAN_CXX_FLAGS "@CMAKE_BUILD_TYPE@, @CMAKE_CXX_FLAGS@"
 
 // cmake options propagated to the source code
 #cmakedefine Tasmanian_ENABLE_BLAS

--- a/Config/TasmanianConfig.in.hpp
+++ b/Config/TasmanianConfig.in.hpp
@@ -37,6 +37,7 @@
 #define TASMANIAN_LICENSE "@Tasmanian_license@"
 
 #define TASMANIAN_GIT_COMMIT_HASH "@Tasmanian_git_hash@"
+#define TASMANIAN_CXX_FLAGS "@CMAKE_CXX_FLAGS@"
 
 // cmake options propagated to the source code
 #cmakedefine Tasmanian_ENABLE_BLAS

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -46,6 +46,7 @@ namespace TasGrid{
 const char* TasmanianSparseGrid::getVersion(){ return TASMANIAN_VERSION_STRING; }
 const char* TasmanianSparseGrid::getLicense(){ return TASMANIAN_LICENSE; }
 const char* TasmanianSparseGrid::getGitCommitHash(){ return TASMANIAN_GIT_COMMIT_HASH; }
+const char* TasmanianSparseGrid::getCmakeCxxFlags(){ return TASMANIAN_CXX_FLAGS; }
 int TasmanianSparseGrid::getVersionMajor(){ return TASMANIAN_VERSION_MAJOR; }
 int TasmanianSparseGrid::getVersionMinor(){ return TASMANIAN_VERSION_MINOR; }
 bool TasmanianSparseGrid::isOpenMPEnabled(){
@@ -587,7 +588,7 @@ double TasmanianSparseGrid::getQuadratureScale(int num_dimensions, TypeOneDRule 
         double power = -0.5 * (1.0 + global->getAlpha());
         for(int j=0; j<num_dimensions; j++) scale *= pow(domain_transform_b[j], power);
     }else if (rule == rule_fourier){
-        for(int j=0; j<num_dimensions; j++) scale *= (domain_transform_b[j] - domain_transform_a[j]); 
+        for(int j=0; j<num_dimensions; j++) scale *= (domain_transform_b[j] - domain_transform_a[j]);
     }else{
         for(int j=0; j<num_dimensions; j++) scale *= (domain_transform_b[j] - domain_transform_a[j]) / 2.0;
     }

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -588,7 +588,7 @@ double TasmanianSparseGrid::getQuadratureScale(int num_dimensions, TypeOneDRule 
         double power = -0.5 * (1.0 + global->getAlpha());
         for(int j=0; j<num_dimensions; j++) scale *= pow(domain_transform_b[j], power);
     }else if (rule == rule_fourier){
-        for(int j=0; j<num_dimensions; j++) scale *= (domain_transform_b[j] - domain_transform_a[j]);
+        for(int j=0; j<num_dimensions; j++) scale *= (domain_transform_b[j] - domain_transform_a[j]); 
     }else{
         for(int j=0; j<num_dimensions; j++) scale *= (domain_transform_b[j] - domain_transform_a[j]) / 2.0;
     }

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -56,6 +56,7 @@ public:
     static int getVersionMinor();
     static const char* getLicense(); // human readable
     static const char* getGitCommitHash();
+    static const char* getCmakeCxxFlags();
     static bool isOpenMPEnabled();
 
     void setErrorLog(std::ostream *os);

--- a/SparseGrids/tasgrid_main.cpp
+++ b/SparseGrids/tasgrid_main.cpp
@@ -73,6 +73,7 @@ int main(int argc, const char ** argv){
         cout << "Tasmanian Sparse Grids  version: " << TasmanianSparseGrid::getVersion() << endl;
         if (strcmp(TasmanianSparseGrid::getGitCommitHash(), "Tasmanian git hash is not available here") != 0){
             cout << "                git commit hash: " << TasmanianSparseGrid::getGitCommitHash() << endl;
+            cout << "                cmake cxx flags: " << TasmanianSparseGrid::getCmakeCxxFlags() << endl;
         }
         cout << "                        license: " << TasmanianSparseGrid::getLicense() << endl;
         if (TasmanianSparseGrid::isOpenMPEnabled()){


### PR DESCRIPTION
* All Tasmanian `cmake` options can be retrieved from the compiled library
* The compiled options specified per target are created automatically
* The user specifies the build type and additional flags
* Therefore, with the correct cmake lists file (from the git commit ID), the Tasmanian options, and the build type with the cxx flags, a specific build of Tasmanian can be reproduced exactly
* This fulfils the xSDK policy M8