### PR TITLE
Fourier fixes

### DIFF
--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -1100,7 +1100,8 @@ void TasmanianSparseGrid::printGridStats(std::ostream *os) const{
     if (isSequence()) (*os) << "Sequence";
     if (isLocalPolynomial()) (*os) << "Local Polynomial";
     if (isWavelet()) (*os) << "Wavelets";
-    if (!(isGlobal() || isSequence() || isLocalPolynomial() || isWavelet())) (*os) << "none";
+    if (isFourier()) (*os) << "Fourier";
+    if (!(isGlobal() || isSequence() || isLocalPolynomial() || isWavelet() || isFourier())) (*os) << "none";
     (*os) << endl;
 
     (*os) << setw(L1) << "Dimensions:" << "   " << getNumDimensions() << endl;

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -951,20 +951,9 @@ void TasmanianSparseGrid::evaluateSparseHierarchicalFunctions(const double x[], 
         }
         pntr[num_x] = num_nz;
         delete[] dense_vals;
-    }else if (fourier != 0){
-        int num_points = base->getNumPoints();
-        vals = new double[2*num_x * num_points];
-        base->evaluateHierarchicalFunctions(x_canonical, num_x, vals);
-        pntr = new int[num_x + 1];
-        pntr[0] = 0;
-        for(int i=0; i<num_x; i++) pntr[i+1] = pntr[i] + num_points;
-        indx  = new int[num_x * num_points];
-        for(int i=0; i<num_x; i++){
-            for(int j=0; j<num_points; j++) indx[i*num_points + j] = j;
-        }
     }else{
         int num_points = base->getNumPoints();
-        vals = new double[num_x * num_points];
+        vals = new double[(fourier != 0 ? 2 * num_x * num_points : num_x * num_points)];
         base->evaluateHierarchicalFunctions(x_canonical, num_x, vals);
         pntr = new int[num_x + 1];
         pntr[0] = 0;

--- a/SparseGrids/tasgridWrapper.cpp
+++ b/SparseGrids/tasgridWrapper.cpp
@@ -828,7 +828,7 @@ bool TasgridWrapper::getEvalHierarchySparse(){
             ofs << endl << indx[0];
             for(int i=1; i<num_nz; i++) ofs << " " << indx[i];
             if (grid->isFourier()){
-                ofs << endl << vals[0] << vals[1];
+                ofs << endl << vals[0] << " " << vals[1];
                 for(int i=1; i<num_nz; i++) ofs << " " << vals[2*i] << " " << vals[2*i+1];
             }else{
                 ofs << endl << vals[0];
@@ -860,7 +860,7 @@ bool TasgridWrapper::getEvalHierarchySparse(){
         cout << endl << indx[0];
         for(int i=1; i<num_nz; i++) cout << " " << indx[i];
         if (grid->isFourier()){
-            cout << endl << vals[0] << vals[1];
+            cout << endl << vals[0] << " " << vals[1];
             for(int i=1; i<num_nz; i++) cout << " " << vals[2*i] << " " << vals[2*i+1];
         }else{
             cout << endl << vals[0];

--- a/SparseGrids/tsgCoreOneDimensional.cpp
+++ b/SparseGrids/tsgCoreOneDimensional.cpp
@@ -375,7 +375,7 @@ bool OneDimensionalMeta::isSequence(TypeOneDRule rule){
     return ((rule == rule_leja) || (rule == rule_rleja) || (rule == rule_rlejashifted) || (rule == rule_maxlebesgue) || (rule == rule_minlebesgue) || (rule == rule_mindelta));
 }
 bool OneDimensionalMeta::isGlobal(TypeOneDRule rule){
-    return !((rule == rule_semilocalp) || (rule == rule_localp0) || (rule == rule_localp) || (rule == rule_wavelet) || (rule == rule_none));
+    return !((rule == rule_semilocalp) || (rule == rule_localp0) || (rule == rule_localp) || (rule == rule_wavelet) || (rule == rule_fourier) || (rule == rule_none));
 }
 bool OneDimensionalMeta::isSingleNodeGrowth(TypeOneDRule rule){
     return ((rule == rule_leja) || (rule == rule_rleja) || (rule == rule_rlejashifted) || (rule == rule_maxlebesgue) || (rule == rule_minlebesgue) || (rule == rule_mindelta) ||

--- a/SparseGrids/tsgGridFourier.cpp
+++ b/SparseGrids/tsgGridFourier.cpp
@@ -735,17 +735,28 @@ void GridFourier::evaluateBatchGPUmagma(int, const double x[], int num_x, double
 }
 
 void GridFourier::integrate(double q[], double *conformal_correction) const{
-    double *w = getQuadratureWeights();
-    if (conformal_correction != 0){ for(int i=0; i<points->getNumIndexes(); i++) w[i] *= conformal_correction[i]; }
     std::fill(q, q+num_outputs, 0.0);
-    #pragma omp parallel for schedule(static)
-    for(int k=0; k<num_outputs; k++){
-        for(int i=0; i<points->getNumIndexes(); i++){
-            const double *v = values->getValues(i);
-            q[k] += w[i] * v[k];
+    if (conformal_correction == 0){
+        // everything vanishes except the Fourier coeff of e^0
+        int *zeros_num_dim = new int[num_dimensions];
+        std::fill(zeros_num_dim, zeros_num_dim + num_dimensions, 0);
+        int idx = exponents->getSlot(zeros_num_dim);
+        for(int k=0; k<num_outputs; k++){
+            q[k] = fourier_coefs[num_outputs * idx + k].real();
         }
+        delete[] zeros_num_dim;
+    }else{
+        // Do the expensive computation if we have a conformal map
+        double *w = getQuadratureWeights();
+        for(int i=0; i<points->getNumIndexes(); i++){
+            w[i] *= conformal_correction[i];
+            const double *v = values->getValues(i);
+            for(int k=0; k<num_outputs; k++){
+                q[k] += w[i] * v[k];
+            }
+        }
+        delete[] w;
     }
-    delete[] w;
 }
 
 void GridFourier::evaluateHierarchicalFunctions(const double x[], int num_x, double y[]) const{
@@ -762,6 +773,12 @@ void GridFourier::setHierarchicalCoefficients(const double c[], TypeAcceleration
     // second two entries are real/imag parts of the Fourier coef for the second basis function and first output dim
     // and so on
     if (accel != 0) accel->resetGPULoadedData();
+    if (points == 0){
+        points = needed;
+        needed = 0;
+    }
+    if (fourier_coefs != 0) delete[] fourier_coefs;
+    fourier_coefs = new std::complex<double>[num_outputs * getNumPoints()];
     for(int i=0; i<num_outputs*getNumPoints(); i++){
         fourier_coefs[i] = std::complex<double>(c[2*i], c[2*i+1]);
     }

--- a/SparseGrids/tsgGridFourier.cpp
+++ b/SparseGrids/tsgGridFourier.cpp
@@ -625,7 +625,7 @@ void GridFourier::getInterpolationWeights(const double x[], double weights[]) co
     delete[] basisFuncs;
 }
 
-double* GridFourier::getQuadratureWeights() const {
+double* GridFourier::getQuadratureWeights() const{
     int num_points = getNumPoints();
     double *w = new double[num_points];
     getQuadratureWeights(w);


### PR DESCRIPTION
* Add spaces between first two entries in `TasgridWrapper::getEvalHierarchySparse()`
* Handle integration differently in the absence of a conformal map
* Fix bug in `setHierarchicalCoefficients()` when grid has no loaded values