### PR TITLE
Fix cusparse buffer and order bug

### DIFF
--- a/SparseGrids/tasgridExternalTests.cpp
+++ b/SparseGrids/tasgridExternalTests.cpp
@@ -1782,7 +1782,7 @@ bool ExternalTester::testAllAcceleration() const{
     // for order 0, regardless of the selected rule, thegrid should switch to localp
     TasGrid::TypeOneDRule pwp_rule[3] = {TasGrid::rule_localp, TasGrid::rule_localp0, TasGrid::rule_semilocalp};
     for(int t=0; t<9; t++){
-        grid.makeLocalPolynomialGrid(f->getNumInputs(), f->getNumOutputs(), ((t / 3 == 0) ? 4 : 5), (t / 3), pwp_rule[t % 3]);
+        grid.makeLocalPolynomialGrid(f->getNumInputs(), f->getNumOutputs(), ((t / 3 == 0) ? 5 : 6), (t / 3), pwp_rule[t % 3]);
         pass = pass && testAcceleration(f, &grid);
     }
     // test cusparse sparse mat times dense vec used in accel_type cuda


### PR DESCRIPTION
* added buffer for `cusparseDmatveci()`, which is needed even though CUDA manual indicates otherwise
* added sort for the sparse vectors in `tsgGridLocalPolynomial.hpp`
* increased the size of the tests to that vectors with more non-zeros will be tested