### PR TITLE
Python fixes

### DIFF
--- a/Config/AltBuildSystems/TasmanianSG.py
+++ b/Config/AltBuildSystems/TasmanianSG.py
@@ -48,7 +48,7 @@ lsTsgGlobalRules = ["clenshaw-curtis", "clenshaw-curtis-zero", "chebyshev", "che
 lsTsgGlobalTypes = ["level", "curved", "iptotal", "ipcurved", "qptotal", "qpcurved", "hyperbolic", "iphyperbolic", "qphyperbolic", "tensor", "iptensor", "qptensor"]
 lsTsgCurvedTypes = ["curved", "ipcurved", "qpcurved"]
 lsTsgSequenceRules = ["leja", "rleja", "rleja-shifted", "max-lebesgue", "min-lebesgue", "min-delta"]
-lsTsgLocalRules = ["localp", "semi-localp", "localp-zero"]
+lsTsgLocalRules = ["localp", "semi-localp", "localp-zero", "localp-boundary"]
 lsTsgAccelTypes = ["none", "cpu-blas", "gpu-default", "gpu-cublas", "gpu-cuda", "gpu-magma"]
 
 class TasmanianInputError(Exception):
@@ -581,7 +581,7 @@ class TasmanianSparseGrid:
                    to double for the other cases)
 
         sRule: string (defines the 1-D rule that induces the grid)
-              'localp'   'localp-zero'   'semi-localp'
+              'localp'  'localp-zero'  'semi-localp'  'localp-boundary'
 
         '''
         if (iDimension <= 0):

--- a/Config/AltBuildSystems/TasmanianSG.windows.py
+++ b/Config/AltBuildSystems/TasmanianSG.windows.py
@@ -48,7 +48,7 @@ lsTsgGlobalRules = ["clenshaw-curtis", "clenshaw-curtis-zero", "chebyshev", "che
 lsTsgGlobalTypes = ["level", "curved", "iptotal", "ipcurved", "qptotal", "qpcurved", "hyperbolic", "iphyperbolic", "qphyperbolic", "tensor", "iptensor", "qptensor"]
 lsTsgCurvedTypes = ["curved", "ipcurved", "qpcurved"]
 lsTsgSequenceRules = ["leja", "rleja", "rleja-shifted", "max-lebesgue", "min-lebesgue", "min-delta"]
-lsTsgLocalRules = ["localp", "semi-localp", "localp-zero"]
+lsTsgLocalRules = ["localp", "semi-localp", "localp-zero", "localp-boundary"]
 lsTsgAccelTypes = ["none", "cpu-blas", "gpu-default", "gpu-cublas", "gpu-cuda", "gpu-magma"]
 
 class TasmanianInputError(Exception):
@@ -581,7 +581,7 @@ class TasmanianSparseGrid:
                    to double for the other cases)
 
         sRule: string (defines the 1-D rule that induces the grid)
-              'localp'   'localp-zero'   'semi-localp'
+              'localp'  'localp-zero'  'semi-localp'  'localp-boundary'
 
         '''
         if (iDimension <= 0):

--- a/Config/AltBuildSystems/testTSG.py
+++ b/Config/AltBuildSystems/testTSG.py
@@ -710,7 +710,7 @@ class TestTasmanian(unittest.TestCase):
         grid.makeGlobalGrid(2, 0, 4, 'ipcurved', 'leja', [20, 10, 0, 7])
         aA = np.array([[0.0, 0.0], [0.0, 1.0], [0.0, -1.0], [0.0, math.sqrt(1.0/3.0)], [1.0, 0.0], [1.0, 1.0], [-1.0, 0.0]])
         aP = grid.getPoints()
-        np.testing.assert_equal(aA, aP, 'Anisotropy Global not equal', True)
+        np.testing.assert_almost_equal(aA, aP, 12, 'Anisotropy Global not equal', True)
 
         grid.makeSequenceGrid(2, 1, 2, 'level', 'leja', [2, 1])
         aA = np.array([[0.0, 0.0], [0.0, 1.0], [0.0, -1.0], [1.0, 0.0]])
@@ -720,12 +720,12 @@ class TestTasmanian(unittest.TestCase):
         grid.makeSequenceGrid(2, 1, 4, 'ipcurved', 'leja', [20, 10, 0, 7])
         aA = np.array([[0.0, 0.0], [0.0, 1.0], [0.0, -1.0], [0.0, math.sqrt(1.0/3.0)], [1.0, 0.0], [1.0, 1.0], [-1.0, 0.0]])
         aP = grid.getPoints()
-        np.testing.assert_equal(aA, aP, 'Anisotropy Sequence not equal', True)
+        np.testing.assert_almost_equal(aA, aP, 12, 'Anisotropy Sequence not equal', True)
 
         grid.makeFourierGrid(2, 1, 2, 'level', [1, 2])
         aA = np.array([[0.0, 0.0], [0.0, 1.0/3.0], [0.0, 2.0/3.0], [1.0/3.0, 0.0], [2.0/3.0, 0.0], [1.0/9.0, 0.0], [2.0/9.0, 0.0], [4.0/9.0, 0.0], [5.0/9.0, 0.0], [7.0/9.0, 0.0], [8.0/9.0, 0.0]])
         aP = grid.getPoints()
-        np.testing.assert_equal(aA, aP, 'Anisotropy Fourier not equal', True)
+        np.testing.assert_almost_equal(aA, aP, 12, 'Anisotropy Fourier not equal', True)
 
         # this is a very important test, checks the curved rule and covers the non-lower-set index selection code
         grid.makeGlobalGrid(2, 1, 1, 'ipcurved', 'rleja', [10, 10, -21, -21])

--- a/InterfacePython/TasmanianSG.in.py
+++ b/InterfacePython/TasmanianSG.in.py
@@ -48,7 +48,7 @@ lsTsgGlobalRules = ["clenshaw-curtis", "clenshaw-curtis-zero", "chebyshev", "che
 lsTsgGlobalTypes = ["level", "curved", "iptotal", "ipcurved", "qptotal", "qpcurved", "hyperbolic", "iphyperbolic", "qphyperbolic", "tensor", "iptensor", "qptensor"]
 lsTsgCurvedTypes = ["curved", "ipcurved", "qpcurved"]
 lsTsgSequenceRules = ["leja", "rleja", "rleja-shifted", "max-lebesgue", "min-lebesgue", "min-delta"]
-lsTsgLocalRules = ["localp", "semi-localp", "localp-zero"]
+lsTsgLocalRules = ["localp", "semi-localp", "localp-zero", "localp-boundary"]
 lsTsgAccelTypes = ["none", "cpu-blas", "gpu-default", "gpu-cublas", "gpu-cuda", "gpu-magma"]
 
 class TasmanianInputError(Exception):
@@ -581,7 +581,7 @@ class TasmanianSparseGrid:
                    to double for the other cases)
 
         sRule: string (defines the 1-D rule that induces the grid)
-              'localp'   'localp-zero'   'semi-localp'
+              'localp'  'localp-zero'  'semi-localp'  'localp-boundary'
 
         '''
         if (iDimension <= 0):

--- a/InterfacePython/testTSG.in.py
+++ b/InterfacePython/testTSG.in.py
@@ -710,7 +710,7 @@ class TestTasmanian(unittest.TestCase):
         grid.makeGlobalGrid(2, 0, 4, 'ipcurved', 'leja', [20, 10, 0, 7])
         aA = np.array([[0.0, 0.0], [0.0, 1.0], [0.0, -1.0], [0.0, math.sqrt(1.0/3.0)], [1.0, 0.0], [1.0, 1.0], [-1.0, 0.0]])
         aP = grid.getPoints()
-        np.testing.assert_equal(aA, aP, 'Anisotropy Global not equal', True)
+        np.testing.assert_almost_equal(aA, aP, 12, 'Anisotropy Global not equal', True)
 
         grid.makeSequenceGrid(2, 1, 2, 'level', 'leja', [2, 1])
         aA = np.array([[0.0, 0.0], [0.0, 1.0], [0.0, -1.0], [1.0, 0.0]])
@@ -720,12 +720,12 @@ class TestTasmanian(unittest.TestCase):
         grid.makeSequenceGrid(2, 1, 4, 'ipcurved', 'leja', [20, 10, 0, 7])
         aA = np.array([[0.0, 0.0], [0.0, 1.0], [0.0, -1.0], [0.0, math.sqrt(1.0/3.0)], [1.0, 0.0], [1.0, 1.0], [-1.0, 0.0]])
         aP = grid.getPoints()
-        np.testing.assert_equal(aA, aP, 'Anisotropy Sequence not equal', True)
+        np.testing.assert_almost_equal(aA, aP, 12, 'Anisotropy Sequence not equal', True)
 
         grid.makeFourierGrid(2, 1, 2, 'level', [1, 2])
         aA = np.array([[0.0, 0.0], [0.0, 1.0/3.0], [0.0, 2.0/3.0], [1.0/3.0, 0.0], [2.0/3.0, 0.0], [1.0/9.0, 0.0], [2.0/9.0, 0.0], [4.0/9.0, 0.0], [5.0/9.0, 0.0], [7.0/9.0, 0.0], [8.0/9.0, 0.0]])
         aP = grid.getPoints()
-        np.testing.assert_equal(aA, aP, 'Anisotropy Fourier not equal', True)
+        np.testing.assert_almost_equal(aA, aP, 12, 'Anisotropy Fourier not equal', True)
 
         # this is a very important test, checks the curved rule and covers the non-lower-set index selection code
         grid.makeGlobalGrid(2, 1, 1, 'ipcurved', 'rleja', [10, 10, -21, -21])


### PR DESCRIPTION
* added the new rule to the python interface (not sure how the commit dropped from the large pull-request)
* fixed python tests so that bit-wise reproducibility is not expected for Fourier grids and other grids that are tested with non-integer nodes