### PR TITLE
Cuda cleanup

### DIFF
--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -383,13 +383,13 @@ TypeAcceleration AccelerationMeta::getAvailableFallback(TypeAcceleration accel){
     // accel_gpu_default should always point to the potentially "best" option (currently MAGMA)
     if (accel == accel_gpu_default) accel = accel_gpu_magma;
     #if !defined(Tasmanian_ENABLE_CUDA) || !defined(Tasmanian_ENABLE_MAGMA) || !defined(Tasmanian_ENABLE_BLAS)
-    // if any of the 4 acceleration modes is missing, then add a switch statement to guard against setting that mode
+    // if any of the 3 acceleration modes is missing, then add a switch statement to guard against setting that mode
     switch(accel){
         #ifndef Tasmanian_ENABLE_CUDA
         // if CUDA is missing: just use the CPU
         case accel_gpu_cublas:
         case accel_gpu_cuda:
-            #if defined(Tasmanian_ENABLE_BLAS)
+            #ifdef Tasmanian_ENABLE_BLAS
             accel = accel_cpu_blas;
             #else
             accel = accel_none;
@@ -399,7 +399,7 @@ TypeAcceleration AccelerationMeta::getAvailableFallback(TypeAcceleration accel){
         #ifndef Tasmanian_ENABLE_MAGMA
         // MAGMA tries to use CUDA kernels with magma linear algebra, this CUDA is the next best thing
         case accel_gpu_magma:
-            #if defined(Tasmanian_ENABLE_CUDA)
+            #ifdef Tasmanian_ENABLE_CUDA
             accel = accel_gpu_cuda;
             #elif defined(Tasmanian_ENABLE_BLAS)
             accel = accel_cpu_blas;

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -438,11 +438,6 @@ void AccelerationMeta::cudaCheckError(void *cudaStatus, const char *info, std::o
         }
     }
 }
-#else
-void AccelerationMeta::cudaCheckError(void *, const char *, std::ostream *){}
-#endif // Tasmanian_ENABLE_CUDA
-
-#ifdef Tasmanian_ENABLE_CUDA
 void AccelerationMeta::cublasCheckError(void *cublasStatus, const char *info, std::ostream *os){
     if (*((cublasStatus_t*) cublasStatus) != CUBLAS_STATUS_SUCCESS){
         if (os != 0){
@@ -496,6 +491,7 @@ void AccelerationMeta::cusparseCheckError(void *cusparseStatus, const char *info
     }
 }
 #else
+void AccelerationMeta::cudaCheckError(void *, const char *, std::ostream *){}
 void AccelerationMeta::cublasCheckError(void *, const char *, std::ostream *){}
 void AccelerationMeta::cusparseCheckError(void *, const char *, std::ostream *){}
 #endif // Tasmanian_ENABLE_CUDA

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -122,7 +122,7 @@ bool AccelerationDataGPUFull::isCompatible(TypeAcceleration acc) const{ return A
 
 #ifdef Tasmanian_ENABLE_CUDA
 void AccelerationDataGPUFull::loadGPUValues(size_t total_entries, const double *cpu_values){
-    gpu_values = TasCUDA::cudaSend(total_entries, cpu_values, logstream);
+    gpu_values = TasCUDA::cudaSend<double>(total_entries, cpu_values, logstream);
 }
 void AccelerationDataGPUFull::resetGPULoadedData(){
     if (gpu_values != 0){ TasCUDA::cudaDel<double>(gpu_values, logstream); gpu_values = 0; }
@@ -507,8 +507,8 @@ AccelerationDomainTransform::AccelerationDomainTransform(int num_dimensions, con
         c = (c % num_dimensions);
     }
 
-    gpu_trans_a = TasCUDA::cudaSend(padded_size, rate, logstream);
-    gpu_trans_b = TasCUDA::cudaSend(padded_size, shift, logstream);
+    gpu_trans_a = TasCUDA::cudaSend<double>(padded_size, rate, logstream);
+    gpu_trans_b = TasCUDA::cudaSend<double>(padded_size, shift, logstream);
 
     delete[] rate;
     delete[] shift;

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -396,12 +396,6 @@ TypeAcceleration AccelerationMeta::getAvailableFallback(TypeAcceleration accel){
         #ifndef Tasmanian_ENABLE_CUDA
         // if CUDA is missing: just use the CPU
         case accel_gpu_cublas:
-            #if defined(Tasmanian_ENABLE_BLAS)
-            accel = accel_cpu_blas;
-            #else
-            accel = accel_none;
-            #endif
-            break;
         case accel_gpu_cuda:
             #if defined(Tasmanian_ENABLE_BLAS)
             accel = accel_cpu_blas;

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -78,7 +78,7 @@ public:
     // deletes nodes, values, and hierarchy
 
     void cublasDGEMV(int num_outputs, int num_points, const double cpu_weights[], double *cpu_result);
-    void cublasDGEMM(int num_outputs, int num_x, int num_points, const double gpu_weights[], double *gpu_result);
+    void cublasDGEMM(bool cpu_pointers, int num_outputs, int num_x, int num_points, const double weights[], double *result);
     // dense matrix-matrix or matrix-vector product using cublas, the matrix is the getGPUValues()
 
     void cusparseMatmul(bool cpu_pointers, int num_points, int num_outputs, int num_x, const int *spntr, const int *sindx, const double *svals, int num_nz, double *result);

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -84,11 +84,11 @@ public:
     // sparse matrix times dense matrix, dense matrix is getGPUValues(), sparse matrix can be given on either cpu or gpu
 
     void cusparseMatvec(int num_points, int num_x, const int *spntr, const int *sindx, const double *svals, int num_nz, double *result);
-    // sparse matrix times a dense vector, makes sense only if the matrix already sits on the gpu
+    // sparse matrix times a dense vector, makes sense only if the matrix already sits on the gpu (hence no cpu_pointers flag)
     // e.g., assumes num_points == 1, the vectors is getGPUValues(), and the sparse matrix was computed on the GPU
 
     void cusparseMatveci(int num_outputs, int num_points, int num_nz, const int *sindx, const double *svals, double *result);
-    // dense matrix times a sparse vector defined by sindx and svals
+    // dense matrix times a sparse vector defined by sindx and svals, currently the sparse vector can only be computed on the cpu
     // the dense matrix is getGPUValues()
 
     void magmaCudaDGEMM(bool cpu_pointers, int gpuID, int num_outputs, int num_x, int num_points, const double weights[], double *result);

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -77,9 +77,8 @@ public:
     void resetGPULoadedData();
     // deletes nodes, values, and hierarchy
 
-    void cublasDGEMV(int num_outputs, int num_points, const double cpu_weights[], double *cpu_result);
     void cublasDGEMM(bool cpu_pointers, int num_outputs, int num_x, int num_points, const double weights[], double *result);
-    // dense matrix-matrix or matrix-vector product using cublas, the matrix is the getGPUValues()
+    // dense matrix-matrix (dgemm) or matrix-vector (dgemv for num_x == 1) product using cublas, the matrix is the getGPUValues()
 
     void cusparseMatmul(bool cpu_pointers, int num_points, int num_outputs, int num_x, const int *spntr, const int *sindx, const double *svals, int num_nz, double *result);
     // sparse matrix times dense matrix, dense matrix is getGPUValues(), sparse matrix can be given on either cpu or gpu

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -134,23 +134,31 @@ namespace TasCUDA{
     // evaluate sequence grids (not done yet)
     //void devalseq(int dims, int num_x, int num_points, int num_nodes, const double *gpu_x, const double *gpu_nodes, const double *gpu_coeff, const int *points, double *gpu_dense);
 
+    // #define __TASMANIAN_COMPILE_FALLBACK_CUDA_KERNELS__ // uncomment to compile a bunch of custom CUDA kernels that provide some functionality similar to cuBlas
+    #ifdef __TASMANIAN_COMPILE_FALLBACK_CUDA_KERNELS__
+    // CUDA kernels that provide essentially the same functionality as cuBlas and MAGMA, but nowhere near as optimal
+    // those functions should not be used in a Release or production builds
+    // the kernels are useful because they are simple and do not depend on potentially poorly documented 3d party library
+    // since the kernels are useful for testing and some debugging, the code should not be deleted (for now), but also don't waste time compiling in most cases
+
+    void cudaDgemm(int M, int N, int K, const double *gpu_a, const double *gpu_b, double *gpu_c);
     // lazy cuda dgemm, nowhere near as powerful as cuBlas, but does not depend on cuBlas
     // gpu_a is M by K, gpu_b is K by N, gpu_c is M by N, all in column-major format
     // on exit gpu_c = gpu_a * gpu_b
-    void cudaDgemm(int M, int N, int K, const double *gpu_a, const double *gpu_b, double *gpu_c);
 
+    void cudaSparseMatmul(int M, int N, int num_nz, const int* gpu_spntr, const int* gpu_sindx, const double* gpu_svals, const double *gpu_B, double *gpu_C);
     // lazy cuda sparse dgemm, less efficient (especially for large N), but more memory conservative then cusparse as there is no need for a transpose
     // C is M x N, B is K x N (K is max(gpu_sindx)), both are given in row-major format, num_nz/spntr/sindx/svals describe row compressed A which is M by K
     // on exit C = A * B
-    void cudaSparseMatmul(int M, int N, int num_nz, const int* gpu_spntr, const int* gpu_sindx, const double* gpu_svals, const double *gpu_B, double *gpu_C);
 
+    void cudaSparseVecDenseMat(int M, int N, int num_nz, const double *A, const int *indx, const double *vals, double *C);
     // dense matrix A (column major) times a sparse vector defiend by num_nz, indx, and vals
     // A is M by N, C is M by 1,
     // on exit C = A * (indx, vals)
-    void cudaSparseVecDenseMat(int M, int N, int num_nz, const double *A, const int *indx, const double *vals, double *C);
 
-    // converts a sparse matrix to a dense representation (all data sits on the gpu and is pre-allocated)
     void convert_sparse_to_dense(int num_rows, int num_columns, const int *gpu_pntr, const int *gpu_indx, const double *gpu_vals, double *gpu_destination);
+    // converts a sparse matrix to a dense representation (all data sits on the gpu and is pre-allocated)
+    #endif
 }
 
 // generic error checking function and types I/O

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -91,9 +91,8 @@ public:
     // dense matrix times a sparse vector defined by sindx and svals
     // the dense matrix is getGPUValues()
 
-    void magmaCudaDGEMM(int gpuID, int num_outputs, int num_x, int num_points, const double gpu_weights[], double *gpu_result);
-    void magmaCudaDGEMV(int gpuID, int num_outputs, int num_points, const double cpu_weights[], double *cpu_result);
-    // dense matrix-matrix or matrix-vector product using magma, the matrix is the getGPUValues()
+    void magmaCudaDGEMM(bool cpu_pointers, int gpuID, int num_outputs, int num_x, int num_points, const double weights[], double *result);
+    // dense matrix-matrix (dgemm) or matrix-vector (dgemv for num_x == 1) product using magma, the matrix is the getGPUValues()
 
 protected:
     void makeCuBlasHandle();

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -81,8 +81,6 @@ public:
     // A is num_outputs by num_points, result is num_outputs
     void cusparseMatveci(int num_outputs, int num_points, int num_nz, const int *sindx, const double *svals, double *result);
 
-    void cusparseDCRSMM(int num_points, int num_outputs, const int *cpu_pntr, const int *cpu_indx, const double *cpu_vals, const double *values, double *surpluses);
-
     void magmaCudaDGEMM(int gpuID, int num_outputs, int num_x, int num_points, const double gpu_weights[], double *gpu_result); // multiplies by the gpu_values
     void magmaCudaDGEMV(int gpuID, int num_outputs, int num_points, const double cpu_weights[], double *cpu_result); // multiplies by the gpu_values
 
@@ -113,11 +111,6 @@ private:
 
 // namespace realized in tsgCudaKernels.cu, each function corresponds to a CUDA kernel for evaluations of basis matrix, domain transform, or fallback linear algebra
 namespace TasCUDA{
-    // matrix solve double-precision (d), level 3, general (ge), column compressed sparse (cs) (solve): C = A * B
-    // A is N by M, B is M by M, C is N by M
-    // A and C are stored in column format, B is sparse column compresses and unit triangular (the diagonal entry is no include in the pattern)
-    void d3gecss(int N, int M, int *levels, int top_level, const int *cpuBpntr, const int *cpuBindx, const double *cpuBvals, const double *cpuA, double *cpuC, std::ostream *os);
-
     // convert transformed points to the canonical domain, all inputs live on the GPU
     void dtrans2can(int dims, int num_x, int pad_size, const double *gpu_trans_a, const double *gpu_trans_b, const double *gpu_x_transformed, double *gpu_x_canonical);
 

--- a/SparseGrids/tsgCudaLinearAlgebra.hpp
+++ b/SparseGrids/tsgCudaLinearAlgebra.hpp
@@ -37,6 +37,9 @@
 
 namespace TasGrid{
 
+// NOTE: the kernels here were used for testing and debugging (and place holders before using the MAGMA library)
+//       presently, none of the templates are instantiated unless __TASMANIAN_COMPILE_FALLBACK_CUDA_KERNELS__ is defined in tsgAcceleratedDataStructures.hpp (TasCUDA namespace)
+
 // only works with SHORT = 32 and BLOCK = 96
 // using blocks, block in C has dims BLOCK by BLOCK = 3 * SHORT by 3 * SHORT,
 // blocks of A and B are both BLOCK by SHORT or 3 * SHORT by SHORT

--- a/SparseGrids/tsgCudaLinearAlgebra.hpp
+++ b/SparseGrids/tsgCudaLinearAlgebra.hpp
@@ -37,25 +37,6 @@
 
 namespace TasGrid{
 
-// sparse triangular solve using cuda kernel, does not out-perform the CPU since the values have to be moved from host to device memory
-// sparse solves are also inefficient when using cuSparse
-// double precision - triangular - general - column sparse - solve = d3gecss, probably too cryptic
-__global__
-void tasgpu_d3gecss(int N, int M, int *order, int top_level, const int *gpuBpntr, const int *gpuBindx, const double *gpuBvals, double *gpuX, int k_stride){
-    int k = blockIdx.x*blockDim.x + threadIdx.x;
-    if (k < N){
-        for(int o=0; o<M; o++){
-            int i = order[o];
-            double sum = 0.0;
-            for(int j=gpuBpntr[i]; j<gpuBpntr[i+1]; j++){
-                sum += gpuBvals[j] * gpuX[gpuBindx[j] * N + k];
-            }
-            gpuX[i*N + k] -= sum;
-        }
-        k += k_stride;
-    }
-}
-
 // only works with SHORT = 32 and BLOCK = 96
 // using blocks, block in C has dims BLOCK by BLOCK = 3 * SHORT by 3 * SHORT,
 // blocks of A and B are both BLOCK by SHORT or 3 * SHORT by SHORT

--- a/SparseGrids/tsgCudaMacros.hpp
+++ b/SparseGrids/tsgCudaMacros.hpp
@@ -70,6 +70,14 @@ namespace TasCUDA{
     }
 
     template <typename T>
+    inline const T* cudaSendConst(size_t num_entries, const T *cpu_array, T* &gpu_temp_array, std::ostream *os){
+        // takes a const cpu_array and returns a newly allocated const gpu array
+        // gpu_temp_array is an alias that can be used to delete the const gpu arrray
+        gpu_temp_array = cudaSend<T>(num_entries, cpu_array, os);
+        return gpu_temp_array;
+    }
+
+    template <typename T>
     inline void cudaRecv(size_t num_entries, const T *gpu_array, T *cpu_array, std::ostream *os){
         cudaError_t cudaStat = cudaMemcpy(cpu_array, gpu_array, num_entries * sizeof(T), cudaMemcpyDeviceToHost);
         AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaRecv(type, type)", os);
@@ -80,7 +88,6 @@ namespace TasCUDA{
         cudaError_t cudaStat = cudaFree(gpu_array);
         AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaDel(type)", os);
     }
-
 }
 #endif
 

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -700,7 +700,7 @@ void GridGlobal::evaluateFastGPUcublas(const double x[], double y[], std::ostrea
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
     double *weights = getInterpolationWeights(x);
 
-    gpu->cublasDGEMV(num_outputs, points->getNumIndexes(), weights, y);
+    gpu->cublasDGEMM(true, num_outputs, 1, points->getNumIndexes(), weights, y);
 
     delete[] weights;
 }

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -760,15 +760,7 @@ void GridGlobal::evaluateBatchGPUcublas(const double x[], int num_x, double y[],
     double *weights = new double[((size_t) num_points) * ((size_t) num_x)];
     evaluateHierarchicalFunctions(x, num_x, weights);
 
-    double *gpu_weights = TasCUDA::cudaSend(((size_t) num_points) * ((size_t) num_x), weights, os);
-    double *gpu_result = TasCUDA::cudaNew<double>(((size_t) num_outputs) * ((size_t) num_x), os);
-
-    gpu->cublasDGEMM(num_outputs, num_x, num_points, gpu_weights, gpu_result);
-
-    TasCUDA::cudaRecv<double>(num_outputs * num_x, gpu_result, y, os);
-
-    TasCUDA::cudaDel<double>(gpu_result, os);
-    TasCUDA::cudaDel<double>(gpu_weights, os);
+    gpu->cublasDGEMM(true, num_outputs, num_x, num_points, weights, y);
 
     delete[] weights;
 }

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -593,7 +593,7 @@ void GridLocalPolynomial::evaluateBatchGPUcuda(const double x[], int num_x, doub
         double *gpu_result = TasCUDA::cudaNew<double>(((size_t) num_x) * ((size_t) values->getNumOutputs()), os);
 
         buildDenseBasisMatrixGPU(gpu_x, num_x, gpu_weights, os);
-        gpu_acc->cublasDGEMM(values->getNumOutputs(), num_x, num_points, gpu_weights, gpu_result);
+        gpu_acc->cublasDGEMM(false, values->getNumOutputs(), num_x, num_points, gpu_weights, gpu_result);
         //TasCUDA::cudaDgemm(values->getNumOutputs(), num_x, num_points, gpu_acc->getGPUValues(), gpu_weights, gpu_result);
 
         TasCUDA::cudaRecv<double>(num_x * values->getNumOutputs(), gpu_result, y, os);
@@ -632,7 +632,7 @@ void GridLocalPolynomial::evaluateBatchGPUcuda(const double x[], int num_x, doub
         TasCUDA::devalpwpoly_sparse_dense(order, rule->getType(), num_dimensions, num_x, num_points, gpu_x, gpu_acc->getGPUNodes(), gpu_acc->getGPUSupport(),
                                 gpu_acc->getGPUpntr(), gpu_acc->getGPUindx(), num_roots, gpu_acc->getGPUroots(), gpu_weights);
 
-        gpu_acc->cublasDGEMM(values->getNumOutputs(), num_x, num_points, gpu_weights, gpu_result);
+        gpu_acc->cublasDGEMM(false, values->getNumOutputs(), num_x, num_points, gpu_weights, gpu_result);
         //TasCUDA::cudaDgemm(values->getNumOutputs(), num_x, num_points, gpu_acc->getGPUValues(), gpu_weights, gpu_result);
 
         TasCUDA::cudaRecv<double>(((size_t) num_x) * ((size_t) values->getNumOutputs()), gpu_result, y, os);

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -458,8 +458,9 @@ void GridLocalPolynomial::evaluate(const double x[], double y[]) const{
     delete[] monkey_count;
     delete[] monkey_tail;
 }
+void GridLocalPolynomial::evaluateFastCPUblas(const double x[], double y[]) const{ evaluate(x, y); }
+// standard BLAS cannot accelerate dense matrix times a sparse vector, fallback to regular evaluate()
 
-void GridLocalPolynomial::evaluateFastCPUblas(const double x[], double y[]) const{ evaluate(x, y); } // standard BLAS cannot accelerate dense matrix times a sparse vector
 #ifdef Tasmanian_ENABLE_CUDA
 void GridLocalPolynomial::evaluateFastGPUcublas(const double x[], double y[], std::ostream *os) const{
     if (num_outputs < 64){

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -494,7 +494,7 @@ void GridLocalPolynomial::evaluateFastGPUcublas(const double x[], double y[], st
     delete[] svals;
 }
 #else
-void GridLocalPolynomial::evaluateFastGPUcublas(const double x[], double y[], std::ostream*) const{ evaluate(x, y); }
+void GridLocalPolynomial::evaluateFastGPUcublas(const double[], double[], std::ostream*) const{}
 #endif
 // evaluation of a single x cannot be accelerated with a gpu (not parallelizable), do that on the CPU and use the GPU only for the case of many outputs
 void GridLocalPolynomial::evaluateFastGPUcuda(const double x[], double y[], std::ostream* os) const{ evaluateFastGPUcublas(x, y, os); }
@@ -548,6 +548,7 @@ void GridLocalPolynomial::evaluateBatchCPUblas(const double x[], int num_x, doub
     delete[] spntr;
     delete[] svals;
 }
+
 #ifdef Tasmanian_ENABLE_CUDA
 void GridLocalPolynomial::evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream *os) const{
     int num_points = points->getNumIndexes();
@@ -565,12 +566,7 @@ void GridLocalPolynomial::evaluateBatchGPUcublas(const double x[], int num_x, do
     delete[] sindx;
     delete[] spntr;
 }
-#else
-void GridLocalPolynomial::evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream *) const{ evaluateBatchCPUblas(x, num_x, y); }
-#endif // Tasmanian_ENABLE_CUDA
-
 void GridLocalPolynomial::evaluateBatchGPUcuda(const double x[], int num_x, double y[], std::ostream *os) const{
-    #ifdef Tasmanian_ENABLE_CUDA
     if ((order == -1) || (order > 2)){ // GPU evaluations are availabe only for order 0, 1, and 2. Cubic will come later, but higher order will not be supported
         evaluateBatchGPUcublas(x, num_x, y, os);
         return;
@@ -641,10 +637,12 @@ void GridLocalPolynomial::evaluateBatchGPUcuda(const double x[], int num_x, doub
         TasCUDA::cudaDel<double>(gpu_weights, os);
         TasCUDA::cudaDel<double>(gpu_x, os);
     }
-    #else
-    evaluateBatchGPUcublas(x, num_x, y, os);
-    #endif // Tasmanian_ENABLE_CUDA
 }
+#else
+void GridLocalPolynomial::evaluateBatchGPUcublas(const double[], int, double[], std::ostream *) const{}
+void GridLocalPolynomial::evaluateBatchGPUcuda(const double[], int, double[], std::ostream *) const{}
+#endif // Tasmanian_ENABLE_CUDA
+
 void GridLocalPolynomial::evaluateBatchGPUmagma(int, const double x[], int num_x, double y[], std::ostream *os) const{
     evaluateBatchGPUcublas(x, num_x, y, os);
 }

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -125,8 +125,6 @@ protected:
     void buildTree();
 
     void recomputeSurpluses();
-    void recomputeSurplusesGPUcublas();
-    void recomputeSurplusesGPUcuda();
 
     void buildSparseMatrixBlockForm(const double x[], int num_x, int num_chunk, int &num_blocks, int &num_last, int &stripe_size,
                                     int* &stripes, int* &last_stripe_size, int** &tpntr, int*** &tindx, double*** &tvals) const;

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -560,15 +560,7 @@ void GridSequence::evaluateBatchGPUcublas(const double x[], int num_x, double y[
     double *fvalues = new double[((size_t) num_points) * ((size_t) num_x)];
     evaluateHierarchicalFunctions(x, num_x, fvalues);
 
-    double *gpu_weights = TasCUDA::cudaSend<double>(((size_t) num_points) * ((size_t) num_x), fvalues, os);
-    double *gpu_result = TasCUDA::cudaNew<double>(((size_t) num_outputs) * ((size_t) num_x), os);
-
-    gpu->cublasDGEMM(num_outputs, num_x, num_points, gpu_weights, gpu_result);
-
-    TasCUDA::cudaRecv<double>(((size_t) num_outputs) * ((size_t) num_x), gpu_result, y, os);
-
-    TasCUDA::cudaDel<double>(gpu_result, os);
-    TasCUDA::cudaDel<double>(gpu_weights, os);
+    gpu->cublasDGEMM(true, num_outputs, num_x, num_points, fvalues, y);
 
     delete[] fvalues;
 }
@@ -588,7 +580,7 @@ void GridSequence::evaluateBatchGPUcuda(const double x[], int num_x, double y[],
     double *gpu_weights = TasCUDA::cudaSend<double>(((size_t) num_points) * ((size_t) num_x), fvalues, os);
     double *gpu_result = TasCUDA::cudaNew<double>(((size_t) num_outputs) * ((size_t) num_x), os);
 
-    gpu_acc->cublasDGEMM(num_outputs, num_x, num_points, gpu_weights, gpu_result);
+    gpu_acc->cublasDGEMM(false, num_outputs, num_x, num_points, gpu_weights, gpu_result);
     //TasCUDA::cudaDgemm(num_outputs, num_x, num_points, gpu_acc->getGPUValues(), gpu_weights, gpu_result);
 
     TasCUDA::cudaRecv<double>(((size_t) num_outputs) * ((size_t) num_x), gpu_result, y, os);

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -501,7 +501,7 @@ void GridSequence::evaluateFastGPUcublas(const double x[], double y[], std::ostr
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
     double *fvalues = evalHierarchicalFunctions(x);
 
-    gpu->cublasDGEMV(num_outputs, points->getNumIndexes(), fvalues, y);
+    gpu->cublasDGEMM(true, num_outputs, 1, points->getNumIndexes(), fvalues, y);
 
     delete[] fvalues;
 }

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -571,7 +571,7 @@ void GridSequence::evaluateBatchGPUcuda(const double x[], int num_x, double y[],
     AccelerationDataGPUFull *gpu_acc = (AccelerationDataGPUFull*) accel;
 
     double *fvalues = new double[((size_t) num_points) * ((size_t) num_x)];
-    evaluateHierarchicalFunctions(x, num_x, fvalues);
+    evaluateHierarchicalFunctions(x, num_x, fvalues); // this will be replaced by GPU eval function
 
     double *gpu_weights = TasCUDA::cudaSend<double>(((size_t) num_points) * ((size_t) num_x), fvalues, os);
     double *gpu_result = TasCUDA::cudaNew<double>(((size_t) num_outputs) * ((size_t) num_x), os);


### PR DESCRIPTION
* merged `#pragma` statements after merging Tasmanian_ENABLE_CUDA and CUBLAS
* merged dense mat-mat and mat-vec calls to cuBlas and MAGMA
* removed code from *failed experiments*
* blocked old fallback code used as placeholder for MAGMA (still potentially useful for debugging)
* removed unnecessary fallback calls for missing acceleration modes
* updated comments