### PR TITLE
updated sparse-dense logic in local grids

### DIFF
--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -1422,8 +1422,8 @@ void TasmanianSparseGrid::enableAcceleration(TypeAcceleration acc){
         if (acc_domain != 0){ delete acc_domain; acc_domain = 0; }
     }
 }
-void TasmanianSparseGrid::forceSparseAlgorithmForLocalPolynomials(){
-    if (pwpoly != 0) pwpoly->setForceSparse();
+void TasmanianSparseGrid::favorSparseAlgorithmForLocalPolynomials(bool favor){
+    if (pwpoly != 0) pwpoly->setFavorSparse(favor);
 }
 TypeAcceleration TasmanianSparseGrid::getAccelerationType() const{
     return acceleration;

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -148,7 +148,7 @@ public:
     void printStatsLog() const;
 
     void enableAcceleration(TypeAcceleration acc);
-    void forceSparseAlgorithmForLocalPolynomials();
+    void favorSparseAlgorithmForLocalPolynomials(bool favor);
     TypeAcceleration getAccelerationType() const;
     static bool isAccelerationAvailable(TypeAcceleration acc);
 

--- a/SparseGrids/tsgCudaKernels.cu
+++ b/SparseGrids/tsgCudaKernels.cu
@@ -87,52 +87,52 @@ void TasCUDA::devalpwpoly(int order, TypeOneDRule rule, int dims, int num_x, int
 }
 
 // there is a switch statement that realizes templates for each combination of rule/order
-// make one function that covers that switch, the rest is passed from devalpwpoly_sparse and devalpwpoly_sparse_dense
-template<typename T, int THREADS, int TOPLEVEL, bool fill, bool dense>
+// make one function that covers that switch, the rest is passed from devalpwpoly_sparse
+template<typename T, int THREADS, int TOPLEVEL, bool fill>
 inline void devalpwpoly_sparse_realize_rule_order(int order, TypeOneDRule rule,
                                           int dims, int num_x, int num_points,
                                           const T *x, const T *nodes, const T *support,
                                           const int *hpntr, const int *hindx, int num_roots, const int *roots,
-                                          int *spntr, int *sindx, T *svals, T *gpu_dense){
+                                          int *spntr, int *sindx, T *svals){
     int num_blocks = num_x / THREADS + ((num_x % THREADS == 0) ? 0 : 1);
     if (num_blocks >= 65536) num_blocks = 65536;
     if (rule == rule_localp){
         switch(order){
             case 0:
-                tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 0, rule_localp, fill, dense><<<num_blocks, THREADS>>>
-                    (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals, gpu_dense);
+                tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 0, rule_localp, fill><<<num_blocks, THREADS>>>
+                    (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals);
                 break;
             case 2:
-                tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 2, rule_localp, fill, dense><<<num_blocks, THREADS>>>
-                    (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals, gpu_dense);
+                tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 2, rule_localp, fill><<<num_blocks, THREADS>>>
+                    (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals);
                 break;
             default:
-                tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 1, rule_localp, fill, dense><<<num_blocks, THREADS>>>
-                    (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals, gpu_dense);
+                tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 1, rule_localp, fill><<<num_blocks, THREADS>>>
+                    (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals);
         }
     }else if (rule == rule_localp0){
         switch(order){
             case 2:
-                tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 2, rule_localp0, fill, dense><<<num_blocks, THREADS>>>
-                    (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals, gpu_dense);
+                tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 2, rule_localp0, fill><<<num_blocks, THREADS>>>
+                    (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals);
                 break;
             default:
-                tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 1, rule_localp0, fill, dense><<<num_blocks, THREADS>>>
-                    (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals, gpu_dense);
+                tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 1, rule_localp0, fill><<<num_blocks, THREADS>>>
+                    (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals);
         }
     }else if (rule == rule_localpb){
         switch(order){
             case 2:
-                tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 2, rule_localpb, fill, dense><<<num_blocks, THREADS>>>
-                    (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals, gpu_dense);
+                tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 2, rule_localpb, fill><<<num_blocks, THREADS>>>
+                    (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals);
                 break;
             default:
-                tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 1, rule_localpb, fill, dense><<<num_blocks, THREADS>>>
-                    (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals, gpu_dense);
+                tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 1, rule_localpb, fill><<<num_blocks, THREADS>>>
+                    (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals);
         }
     }else{ // rule == rule_semilocalp
-        tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 2, rule_semilocalp, fill, dense><<<num_blocks, THREADS>>>
-            (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals, gpu_dense);
+        tasgpu_devalpwpoly_sparse<T, THREADS, TOPLEVEL, 2, rule_semilocalp, fill><<<num_blocks, THREADS>>>
+            (dims, num_x, num_points, x, nodes, support, hpntr, hindx, num_roots, roots, spntr, sindx, svals);
     }
 }
 
@@ -142,8 +142,8 @@ void TasCUDA::devalpwpoly_sparse(int order, TypeOneDRule rule, int dims, int num
                                  std::ostream *os){
     gpu_spntr = cudaNew<int>(num_x + 1, os);
     // call with fill == false to count the non-zeros per row of the matrix
-    devalpwpoly_sparse_realize_rule_order<double, 64, 46, false, false>
-        (order, rule, dims, num_x, num_points, gpu_x, gpu_nodes, gpu_support, gpu_hpntr, gpu_hindx, num_roots, gpu_roots, gpu_spntr, 0, 0, 0);
+    devalpwpoly_sparse_realize_rule_order<double, 64, 46, false>
+        (order, rule, dims, num_x, num_points, gpu_x, gpu_nodes, gpu_support, gpu_hpntr, gpu_hindx, num_roots, gpu_roots, gpu_spntr, 0, 0);
 
     int *cpu_spntr = new int[num_x+1];
     cudaRecv(num_x+1, gpu_spntr, cpu_spntr, os);
@@ -155,15 +155,8 @@ void TasCUDA::devalpwpoly_sparse(int order, TypeOneDRule rule, int dims, int num
     gpu_sindx = cudaNew<int>(num_nz, os);
     gpu_svals = cudaNew<double>(num_nz, os);
     // call with fill == true to load the non-zeros
-    devalpwpoly_sparse_realize_rule_order<double, 64, 46, true, false>
-        (order, rule, dims, num_x, num_points, gpu_x, gpu_nodes, gpu_support, gpu_hpntr, gpu_hindx, num_roots, gpu_roots, gpu_spntr, gpu_sindx, gpu_svals, 0);
-}
-
-void TasCUDA::devalpwpoly_sparse_dense(int order, TypeOneDRule rule, int dims, int num_x, int num_points, const double *gpu_x, const double *gpu_nodes, const double *gpu_support,
-                                 int *gpu_hpntr, int *gpu_hindx, int num_roots, int *gpu_roots, double *gpu_dense){
-    // call with fill = false, dense = true, to load the values in the dense arrays
-    devalpwpoly_sparse_realize_rule_order<double, 64, 46, false, true>
-        (order, rule, dims, num_x, num_points, gpu_x, gpu_nodes, gpu_support, gpu_hpntr, gpu_hindx, num_roots, gpu_roots, 0, 0, 0, gpu_dense);
+    devalpwpoly_sparse_realize_rule_order<double, 64, 46, true>
+        (order, rule, dims, num_x, num_points, gpu_x, gpu_nodes, gpu_support, gpu_hpntr, gpu_hindx, num_roots, gpu_roots, gpu_spntr, gpu_sindx, gpu_svals);
 }
 
 

--- a/SparseGrids/tsgEnumerates.hpp
+++ b/SparseGrids/tsgEnumerates.hpp
@@ -121,16 +121,6 @@ enum TypeAcceleration{
     accel_gpu_magma // implies combination with CUDA kernels, if CUDA is ON
 };
 
-enum TypeLocalPolynomialBackendFlavor{
-    flavor_auto,
-    flavor_sparse_sparse,
-    flavor_sparse_dense,
-    flavor_dense_sparse,
-    flavor_dense_dense,
-    flavor_cuda
-};
-
-
 
 ////////////////////////////////////////////////////////////
 //                                                        //

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -40,10 +40,10 @@ namespace TasGrid{
 
 GridLocalPolynomial::GridLocalPolynomial() : num_dimensions(0), num_outputs(0), order(1), top_level(0),
                          surpluses(0), points(0), needed(0), values(0), parents(0), num_roots(0), roots(0), pntr(0), indx(0), rule(0),
-                         accel(0), backend_flavor(flavor_auto), force_sparse(false)  {}
+                         accel(0), sparse_affinity(0)  {}
 GridLocalPolynomial::GridLocalPolynomial(const GridLocalPolynomial &pwpoly) : num_dimensions(0), num_outputs(0), order(1), top_level(0),
                          surpluses(0), points(0), needed(0), values(0), parents(0), num_roots(0), roots(0), pntr(0), indx(0), rule(0),
-                         accel(0), backend_flavor(flavor_auto), force_sparse(false)
+                         accel(0), sparse_affinity(0)
 {
     copyGrid(&pwpoly);
 }
@@ -63,8 +63,7 @@ void GridLocalPolynomial::reset(bool clear_rule){
     if (pntr != 0){ delete[] pntr;  pntr = 0; }
     if (indx != 0){ delete[] indx;  indx = 0; }
     if (clear_rule){ rule = 0; order = 1; }
-    backend_flavor = flavor_auto;
-    force_sparse = false;
+    sparse_affinity = 0;
 }
 
 void GridLocalPolynomial::write(std::ofstream &ofs) const{
@@ -508,7 +507,7 @@ void GridLocalPolynomial::evaluateBatch(const double x[], int num_x, double y[])
     }
 }
 void GridLocalPolynomial::evaluateBatchCPUblas(const double x[], int num_x, double y[]) const{
-    if (force_sparse || (((backend_flavor == flavor_auto) || (backend_flavor == flavor_sparse_sparse)) && (num_outputs <= TSG_LOCALP_BLAS_NUM_OUTPUTS))){
+    if ((sparse_affinity == 1) || ((sparse_affinity == 0) && (num_outputs <= TSG_LOCALP_BLAS_NUM_OUTPUTS))){
         evaluateBatch(x, num_x, y);
         return;
     }
@@ -521,7 +520,7 @@ void GridLocalPolynomial::evaluateBatchCPUblas(const double x[], int num_x, doub
     double nnz = (double) spntr[num_x];
     double total_size = ((double) num_x) * ((double) num_points);
 
-    if ((backend_flavor == flavor_sparse_dense) || (backend_flavor == flavor_dense_dense) || ((backend_flavor == flavor_auto) && (nnz / total_size > 0.1))){
+    if ((sparse_affinity == -1) || ((sparse_affinity == 0) && (nnz / total_size > 0.1))){
         // potentially wastes a lot of memory
         double *A = new double[((size_t) num_x) * ((size_t) num_points)];
         std::fill(A, A + ((size_t) num_x) * ((size_t) num_points), 0.0);
@@ -578,13 +577,12 @@ void GridLocalPolynomial::evaluateBatchGPUcuda(const double x[], int num_x, doub
     checkAccelerationGPUNodes();
     AccelerationDataGPUFull *gpu_acc = (AccelerationDataGPUFull*) accel;
 
-    TypeLocalPolynomialBackendFlavor flv = backend_flavor;
-    if (backend_flavor == flavor_auto){
-        flv = (num_points > 1024) ? flavor_sparse_sparse : flavor_dense_dense;
+    bool useDense = (sparse_affinity == -1);
+    if (sparse_affinity == 0){
+        useDense = (num_points <= 1024);
     }
-    if (force_sparse) flv = flavor_sparse_sparse;
-    //flv = flavor_sparse_dense;
-    if (flv == flavor_dense_dense){
+
+    if (useDense){
         double *gpu_x = TasCUDA::cudaSend<double>(num_x * num_dimensions, x, os);
         double *gpu_weights = TasCUDA::cudaNew<double>(((size_t) num_x) * ((size_t) points->getNumIndexes()), os);
         double *gpu_result = TasCUDA::cudaNew<double>(((size_t) num_x) * ((size_t) values->getNumOutputs()), os);
@@ -598,7 +596,7 @@ void GridLocalPolynomial::evaluateBatchGPUcuda(const double x[], int num_x, doub
         TasCUDA::cudaDel<double>(gpu_result, os);
         TasCUDA::cudaDel<double>(gpu_weights, os);
         TasCUDA::cudaDel<double>(gpu_x, os);
-    }else if (flv == flavor_sparse_sparse){
+    }else if (!useDense){
         double *gpu_x = TasCUDA::cudaSend<double>(num_x * num_dimensions, x, os);
         double *gpu_y = TasCUDA::cudaNew<double>(((size_t) num_x) * ((size_t) num_outputs), os);
 
@@ -620,7 +618,7 @@ void GridLocalPolynomial::evaluateBatchGPUcuda(const double x[], int num_x, doub
         TasCUDA::cudaDel<double>(gpu_svals, os);
         TasCUDA::cudaDel<double>(gpu_y, os);
         TasCUDA::cudaDel<double>(gpu_x, os);
-    }else if (flv == flavor_sparse_dense){
+    }else{
         double *gpu_x = TasCUDA::cudaSend<double>(num_x * num_dimensions, x, os);
         double *gpu_weights = TasCUDA::cudaNew<double>(((size_t) num_x) * ((size_t) points->getNumIndexes()), os);
         double *gpu_result = TasCUDA::cudaNew<double>(((size_t) num_x) * ((size_t) values->getNumOutputs()), os);
@@ -1893,6 +1891,15 @@ void GridLocalPolynomial::clearAccelerationData(){
         delete accel;
         accel = 0;
     }
+}
+
+void GridLocalPolynomial::setFavorSparse(bool favor){
+    // sparse_affinity == -1: use dense algorithms
+    // sparse_affinity ==  1: use sparse algorithms
+    // sparse_affinity ==  0: let Tasmanian decide
+    // favor true/false bumps you upper or lower on the scale
+    if (favor && (sparse_affinity < 1)) sparse_affinity++;
+    if (!favor && (sparse_affinity > -1)) sparse_affinity--;
 }
 
 }

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -591,7 +591,7 @@ void GridLocalPolynomial::evaluateBatchGPUcuda(const double x[], int num_x, doub
         TasCUDA::cudaDel<double>(gpu_result, os);
         TasCUDA::cudaDel<double>(gpu_weights, os);
         TasCUDA::cudaDel<double>(gpu_x, os);
-    }else if (!useDense){
+    }else{
         double *gpu_x = TasCUDA::cudaSend<double>(num_x * num_dimensions, x, os);
         double *gpu_y = TasCUDA::cudaNew<double>(((size_t) num_x) * ((size_t) num_outputs), os);
 
@@ -612,23 +612,6 @@ void GridLocalPolynomial::evaluateBatchGPUcuda(const double x[], int num_x, doub
         TasCUDA::cudaDel<int>(gpu_sindx, os);
         TasCUDA::cudaDel<double>(gpu_svals, os);
         TasCUDA::cudaDel<double>(gpu_y, os);
-        TasCUDA::cudaDel<double>(gpu_x, os);
-    }else{
-        double *gpu_x = TasCUDA::cudaSend<double>(num_x * num_dimensions, x, os);
-        double *gpu_weights = TasCUDA::cudaNew<double>(((size_t) num_x) * ((size_t) points->getNumIndexes()), os);
-        double *gpu_result = TasCUDA::cudaNew<double>(((size_t) num_x) * ((size_t) values->getNumOutputs()), os);
-
-        checkAccelerationGPUHierarchy();
-        TasCUDA::devalpwpoly_sparse_dense(order, rule->getType(), num_dimensions, num_x, num_points, gpu_x, gpu_acc->getGPUNodes(), gpu_acc->getGPUSupport(),
-                                gpu_acc->getGPUpntr(), gpu_acc->getGPUindx(), num_roots, gpu_acc->getGPUroots(), gpu_weights);
-
-        gpu_acc->cublasDGEMM(false, values->getNumOutputs(), num_x, num_points, gpu_weights, gpu_result);
-        //TasCUDA::cudaDgemm(values->getNumOutputs(), num_x, num_points, gpu_acc->getGPUValues(), gpu_weights, gpu_result);
-
-        TasCUDA::cudaRecv<double>(((size_t) num_x) * ((size_t) values->getNumOutputs()), gpu_result, y, os);
-
-        TasCUDA::cudaDel<double>(gpu_result, os);
-        TasCUDA::cudaDel<double>(gpu_weights, os);
         TasCUDA::cudaDel<double>(gpu_x, os);
     }
 }

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -462,11 +462,6 @@ void GridLocalPolynomial::evaluateFastCPUblas(const double x[], double y[]) cons
 
 #ifdef Tasmanian_ENABLE_CUDA
 void GridLocalPolynomial::evaluateFastGPUcublas(const double x[], double y[], std::ostream *os) const{
-    if (num_outputs < 64){
-        evaluate(x, y);
-        return;
-    }
-
     int num_points = points->getNumIndexes();
     makeCheckAccelerationData(accel_gpu_cublas, os);
     checkAccelerationGPUValues();

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -572,10 +572,7 @@ void GridLocalPolynomial::evaluateBatchGPUcuda(const double x[], int num_x, doub
     checkAccelerationGPUNodes();
     AccelerationDataGPUFull *gpu_acc = (AccelerationDataGPUFull*) accel;
 
-    bool useDense = (sparse_affinity == -1);
-    if (sparse_affinity == 0){
-        useDense = (num_points <= 1024);
-    }
+    bool useDense = (sparse_affinity == -1) || ((sparse_affinity == 0) && (num_dimensions > 6)); // dimension is the real criteria here
 
     if (useDense){
         double *gpu_x = TasCUDA::cudaSend<double>(num_x * num_dimensions, x, os);

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -102,6 +102,7 @@ public:
     void setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream *os);
 
     void clearAccelerationData();
+    void setFavorSparse(bool favor);
 
     const double* getSurpluses() const;
     const int* getPointIndexes() const;
@@ -114,10 +115,6 @@ public:
     // EXPERIMENTAL: GPU evaluateHierarchicalFunctionsGPU()
     void buildDenseBasisMatrixGPU(const double gpu_x[], int cpu_num_x, double gpu_y[], std::ostream *os) const;
     void buildSparseBasisMatrixGPU(const double gpu_x[], int cpu_num_x, int* &gpu_spntr, int* &gpu_sindx, double* &gpu_svals, int &num_nz, std::ostream *os) const;
-
-    // EXPERIMENTAL: mostly for tuning and testing purposes, force certain backend behavior
-    inline void setBackendFlavor(TypeLocalPolynomialBackendFlavor new_flavor){ backend_flavor = new_flavor; }
-    inline void setForceSparse(){ force_sparse = true; }
 
 protected:
     void reset(bool clear_rule = true);
@@ -320,8 +317,7 @@ private:
     templRuleLocalPolynomial<rule_localp, true> rpolyc;
 
     mutable BaseAccelerationData *accel;
-    TypeLocalPolynomialBackendFlavor backend_flavor;
-    bool force_sparse;
+    int sparse_affinity;
 };
 
 }


### PR DESCRIPTION
* cleaned old experiments from sparse-dense logic in localp grids
* reworked the logic for only two algorithms (3 options, sparse, dense, auto)
* the auto switch happens based on `num_dimensions` as indicated to be the critical factor in the benchmark tests