### PR TITLE
fixed fourier copy, const pointer is returned to the internal data

### DIFF
--- a/SparseGrids/tasgridExternalTests.cpp
+++ b/SparseGrids/tasgridExternalTests.cpp
@@ -1063,7 +1063,6 @@ bool ExternalTester::testAllFourier() const{
         delete[] pntr;
         delete[] vals;
         delete[] pnts;
-        delete[] coeff;
         delete[] y;
         delete[] v;
     }

--- a/SparseGrids/tsgGridFourier.cpp
+++ b/SparseGrids/tsgGridFourier.cpp
@@ -809,12 +809,7 @@ const IndexSet* GridFourier::getExponents() const{
     return exponents;
 }
 const double* GridFourier::getFourierCoefs() const{
-    double* fc = new double[2 * getNumPoints() * num_outputs];
-    for(int i=0; i<getNumPoints() * num_outputs; i++){
-        fc[2*i] = fourier_coefs[i].real();
-        fc[2*i+1] = fourier_coefs[i].imag();
-    }
-    return fc;
+    return ((double*) fourier_coefs);
 }
 
 } // end TasGrid


### PR DESCRIPTION
* Fourier grids is set to return const pointer to the internal coefficients data structure, consistent behavior with other grids