### PR TITLE
Speedup gpu2gpu tests

### DIFF
--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -905,12 +905,14 @@ void TasmanianSparseGrid::evaluateHierarchicalFunctions(const double x[], int nu
 }
 #ifdef Tasmanian_ENABLE_CUDA
 void TasmanianSparseGrid::evaluateHierarchicalFunctionsGPU(const double gpu_x[], int cpu_num_x, double gpu_y[]) const{
+    _TASMANIAN_SETGPU
     double *gpu_temp_x = 0;
     const double *gpu_canonical_x = formCanonicalPointsGPU(gpu_x, gpu_temp_x, cpu_num_x);
     pwpoly->buildDenseBasisMatrixGPU(gpu_canonical_x, cpu_num_x, gpu_y, logstream);
     if (gpu_temp_x != 0) TasCUDA::cudaDel<double>(gpu_temp_x, logstream);
 }
 void TasmanianSparseGrid::evaluateSparseHierarchicalFunctionsGPU(const double gpu_x[], int cpu_num_x, int* &gpu_pntr, int* &gpu_indx, double* &gpu_vals, int &num_nz) const{
+    _TASMANIAN_SETGPU
     double *gpu_temp_x = 0;
     const double *gpu_canonical_x = formCanonicalPointsGPU(gpu_x, gpu_temp_x, cpu_num_x);
     pwpoly->buildSparseBasisMatrixGPU(gpu_canonical_x, cpu_num_x, gpu_pntr, gpu_indx, gpu_vals, num_nz, logstream);
@@ -1465,6 +1467,7 @@ void TasmanianSparseGrid::setGPUID(int new_gpuID){
         if (AccelerationMeta::isAccTypeGPU(acceleration)){ // if using GPU acceleration
             if (base != 0) base->clearAccelerationData();
         }
+        if (acc_domain != 0){ delete acc_domain; acc_domain = 0; }
         gpuID = new_gpuID;
     }
 }

--- a/SparseGrids/tasgridExternalTests.cpp
+++ b/SparseGrids/tasgridExternalTests.cpp
@@ -1708,7 +1708,7 @@ bool ExternalTester::testGPU2GPUevaluations() const{
             }
 
             if (!dense_pass){
-                cout << "Failed when using grid: " << endl;
+                cout << "Failed evaluateHierarchicalFunctionsGPU() when using grid: " << endl;
                 grid.printStats();
             }
             pass = pass && dense_pass;
@@ -1729,7 +1729,7 @@ bool ExternalTester::testGPU2GPUevaluations() const{
             double *cvals = new double[num_nz]; TasGrid::TasCUDA::cudaRecv<double>(num_nz, gpu_vals, cvals, &cerr);
 
             if (pntr[nump] != num_nz){
-                cout << "ERROR: mismatch in the numn from cuda: " << num_nz << " and cpu " << pntr[nump] << endl;
+                cout << "ERROR: mismatch in the numnz from cuda: " << num_nz << " and cpu " << pntr[nump] << endl;
                 grid.printStats();
                 sparse_pass = false;
             }
@@ -1748,7 +1748,7 @@ bool ExternalTester::testGPU2GPUevaluations() const{
                 }
             }
             if (!sparse_pass){
-                cout << "Failed when using grid: " << endl;
+                cout << "Failed evaluateSparseHierarchicalFunctionsGPU() when using grid: " << endl;
                 grid.printStats();
             }
 


### PR DESCRIPTION
* GPU basis evaluation tests compute the CPU reference solution only once (was redundant)
* The test now correctly executes on each detected GPU
* Fixed a bug related to the switch of GPUs (GPU could be set, but changing it later resulted in crash)