### PR TITLE
moved the OpenMP hack to the package confing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,12 @@ endif()
 # The current setup allows the parent project to append more targets to "${CMAKE_PROJECT_NAME}-exports" and install in a different spot
 # The parent project can also completely ignore any Tasmanian exports and config files and make thier own files
 # END NOTE
+# NOTE: see the OpenMP remark in the SparseGirds sub-directory
+# unset(OpenMP_CXX_LIBRARIES) # use this to test on newer cmake
+set(Tasmanian_openmp_hack "")
+if (Tasmanian_ENABLE_OPENMP AND (NOT (DEFINED OpenMP_CXX_LIBRARIES)))
+    set(Tasmanian_openmp_hack "set(Tasmanian_CXX_FLAGS \"${OpenMP_CXX_FLAGS}\")")
+endif()
 configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/Config/TasmanianConfig.in.cmake"
                               "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianConfig.cmake"
                               INSTALL_DESTINATION "lib/Tasmanian/")
@@ -193,12 +199,6 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianConfig.hpp"
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 
 # cmake file for the examples, to be used post-install
-# see the OpenMP remark in the SparseGirds sub-directory
-# unset(OpenMP_CXX_LIBRARIES) # use this to test on newer cmake
-set(Tasmanian_openmp_hack "# ALL GOOD, the commands above are sufficient to link any external project to Tasmanian")
-if (Tasmanian_ENABLE_OPENMP AND (NOT (DEFINED OpenMP_CXX_LIBRARIES)))
-    set(Tasmanian_openmp_hack "set(CMAKE_CXX_FLAGS \"\$\{CMAKE_CXX_FLAGS\} ${OpenMP_CXX_FLAGS}\") # see the long comment below")
-endif()
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Config/CMakeLists.examples.txt" "${CMAKE_CURRENT_BINARY_DIR}/configured/CMakeLists.txt" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/CMakeLists.txt"
         DESTINATION "share/Tasmanian/examples/"

--- a/Config/CMakeLists.examples.txt
+++ b/Config/CMakeLists.examples.txt
@@ -41,7 +41,9 @@ elseif (TARGET Tasmanian_libfortran90_shared)
     target_link_libraries(example_sparse_grids_f90  Tasmanian_libfortran90_shared)
 endif()
 
-@Tasmanian_openmp_hack@
+# this is needed only if Tasmanian was build with cmake older than 3.9.6
+# see if the long comment below
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Tasmanian_CXX_FLAGS}")
 
 # OpenMP is a CXX language extension which is usually enabled with a compiler flag and a library
 # the flag tells the compiler to interpret the OpenMP language directives
@@ -54,13 +56,10 @@ endif()
 # calls to older find_package(OpenMP) do not return the library used by the compiler
 #
 # if Tasmanian was compiled with Tasmanian_ENABLE_OPENMP=ON and an older version of cmake
-# then, further up, you will see the OpenMP compiler flag used during the Tasmanian build process
-# the flag can be added to any project that imports Tasmanian, which will tell the compiler to
-# use the proper OpenMP library
+# then, find_package(Tasmanian) will create variable Tasmanian_CXX_FLAGS which is needed
+# to link to the Tasmanian libraries
 # BUT NOTE that this will only work if Tasmanian and the user project both call the same compiler
 # using a different compiler means that you must manually link to the OpenMP library
 # (usually, the library is libgom for gcc, and libiomp for clang)
 #
-# if you don't see a flag, then either OpenMP was disabled, or Tasmanian was build with
-# a newer version of cmake and the OpenMP dependence was properly propagated by the
-# calls to "include()" and "target_link_libraries()", i.e., you don't have to do anything extra
+# if newer cmake was used to build Tasmanian, then Tasmanian_CXX_FLAGS will not be defined

--- a/Config/TasmanianConfig.in.cmake
+++ b/Config/TasmanianConfig.in.cmake
@@ -8,3 +8,5 @@ cmake_minimum_required(VERSION 3.5)
 include("@CMAKE_INSTALL_PREFIX@/lib/@CMAKE_PROJECT_NAME@/@CMAKE_PROJECT_NAME@.cmake")
 
 check_required_components(Tasmanian)
+
+@Tasmanian_openmp_hack@


### PR DESCRIPTION
* the package config offers a more elegant way to handle this
* if old version of cmake is used to build Tasmanian, then package config will define `Tasmanian_CXX_FLAGS` to compensate for the missing `OpenMP_CXX_LIBRARIES`