### PR TITLE
Remove redundant internal api

### DIFF
--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -337,13 +337,9 @@ void TasmanianSparseGrid::getPoints(double *x) const{
 }
 
 double* TasmanianSparseGrid::getQuadratureWeights() const{
-    double *w = base->getQuadratureWeights();
-    mapConformalWeights(base->getNumDimensions(), base->getNumPoints(), w);
-    if (domain_transform_a != 0){
-        double scale = getQuadratureScale(base->getNumDimensions(), base->getRule());
-        #pragma omp parallel for schedule(static)
-        for(int i=0; i<getNumPoints(); i++) w[i] *= scale;
-    }
+    if (getNumPoints() == 0) return 0;
+    double *w = new double[getNumPoints()];
+    getQuadratureWeights(w);
     return w;
 }
 void TasmanianSparseGrid::getQuadratureWeights(double *weights) const{
@@ -356,9 +352,9 @@ void TasmanianSparseGrid::getQuadratureWeights(double *weights) const{
     }
 }
 double* TasmanianSparseGrid::getInterpolationWeights(const double x[]) const{
-    double *x_tmp = 0;
-    double *w = base->getInterpolationWeights(formCanonicalPoints(x, x_tmp, 1));
-    clearCanonicalPoints(x_tmp);
+    if (getNumPoints() == 0) return 0;
+    double *w = new double[getNumPoints()];
+    getInterpolationWeights(x, w);
     return w;
 }
 void TasmanianSparseGrid::getInterpolationWeights(const double x[], double *weights) const{

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -306,8 +306,9 @@ int TasmanianSparseGrid::getNumNeeded() const{ return (base == 0) ? 0 : base->ge
 int TasmanianSparseGrid::getNumPoints() const{ return (base == 0) ? 0 : base->getNumPoints(); }
 
 double* TasmanianSparseGrid::getLoadedPoints() const{
-    double *x = base->getLoadedPoints();
-    formTransformedPoints(base->getNumLoaded(), x);
+    if (base->getNumLoaded() == 0) return 0;
+    double *x = new double[base->getNumLoaded() * base->getNumDimensions()];
+    getLoadedPoints(x);
     return x;
 }
 void TasmanianSparseGrid::getLoadedPoints(double *x) const{
@@ -315,8 +316,9 @@ void TasmanianSparseGrid::getLoadedPoints(double *x) const{
     formTransformedPoints(base->getNumLoaded(), x);
 }
 double* TasmanianSparseGrid::getNeededPoints() const{
-    double *x = base->getNeededPoints();
-    formTransformedPoints(base->getNumNeeded(), x);
+    if (base->getNumNeeded() == 0) return 0;
+    double *x = new double[base->getNumNeeded() * base->getNumDimensions()];
+    getNeededPoints(x);
     return x;
 }
 void TasmanianSparseGrid::getNeededPoints(double *x) const{
@@ -324,8 +326,9 @@ void TasmanianSparseGrid::getNeededPoints(double *x) const{
     formTransformedPoints(base->getNumNeeded(), x);
 }
 double* TasmanianSparseGrid::getPoints() const{
-    double *x = base->getPoints();
-    formTransformedPoints(base->getNumPoints(), x);
+    if (base->getNumPoints() == 0) return 0;
+    double *x = new double[base->getNumPoints() * base->getNumDimensions()];
+    getPoints(x);
     return x;
 }
 void TasmanianSparseGrid::getPoints(double *x) const{
@@ -728,7 +731,8 @@ void TasmanianSparseGrid::mapConformalTransformedToCanonical(int num_dimensions,
 void TasmanianSparseGrid::mapConformalWeights(int num_dimensions, int num_points, double weights[]) const{
     if (conformal_asin_power != 0){
         // precompute constants, transform is sum exp(c_k + p_k * log(x))
-        double *x = base->getPoints();
+        double *x = new double[base->getNumPoints() * base->getNumDimensions()];
+        base->getPoints(x);
         double **c = new double*[num_dimensions], **p = new double*[num_dimensions];
         int sum_powers = 0; for(int j=0; j<num_dimensions; j++) sum_powers += (conformal_asin_power[j] + 1);
         c[0] = new double[sum_powers]; p[0] = new double[sum_powers];

--- a/SparseGrids/tsgGridCore.hpp
+++ b/SparseGrids/tsgGridCore.hpp
@@ -49,11 +49,8 @@ public:
     virtual int getNumNeeded() const = 0;
     virtual int getNumPoints() const = 0;
 
-    virtual double* getLoadedPoints() const = 0;
     virtual void getLoadedPoints(double *x) const = 0;
-    virtual double* getNeededPoints() const = 0;
     virtual void getNeededPoints(double *x) const = 0;
-    virtual double* getPoints() const = 0;
     virtual void getPoints(double *x) const = 0;
 
     virtual double* getQuadratureWeights() const = 0;

--- a/SparseGrids/tsgGridCore.hpp
+++ b/SparseGrids/tsgGridCore.hpp
@@ -53,9 +53,7 @@ public:
     virtual void getNeededPoints(double *x) const = 0;
     virtual void getPoints(double *x) const = 0;
 
-    virtual double* getQuadratureWeights() const = 0;
     virtual void getQuadratureWeights(double weights[]) const = 0;
-    virtual double* getInterpolationWeights(const double x[]) const = 0;
     virtual void getInterpolationWeights(const double x[], double weights[]) const = 0;
 
     virtual void loadNeededPoints(const double *vals, TypeAcceleration acc) = 0;

--- a/SparseGrids/tsgGridFourier.cpp
+++ b/SparseGrids/tsgGridFourier.cpp
@@ -571,11 +571,6 @@ void GridFourier::getBasisFunctions(const double x[], double weights[]) const {
     delete[] tmp;
 }
 
-double* GridFourier::getInterpolationWeights(const double x[]) const {
-    double *w = new double[getNumPoints()];
-    getInterpolationWeights(x,w);
-    return w;
-}
 void GridFourier::getInterpolationWeights(const double x[], double weights[]) const {
     /*
     I[f](x) = c^T * \Phi(x) = (U*P*f)^T * \Phi(x)           (U represents normalized forward Fourier transform; P represents reordering of f_i before going into FT)
@@ -617,12 +612,6 @@ void GridFourier::getInterpolationWeights(const double x[], double weights[]) co
     delete[] basisFuncs;
 }
 
-double* GridFourier::getQuadratureWeights() const {
-    int num_points = getNumPoints();
-    double *w = new double[num_points];
-    getQuadratureWeights(w);
-    return w;
-}
 void GridFourier::getQuadratureWeights(double weights[]) const{
 
     /*
@@ -739,7 +728,8 @@ void GridFourier::integrate(double q[], double *conformal_correction) const{
         delete[] zeros_num_dim;
     }else{
         // Do the expensive computation if we have a conformal map
-        double *w = getQuadratureWeights();
+        double *w = new double[getNumPoints()];
+        getQuadratureWeights(w);
         for(int i=0; i<points->getNumIndexes(); i++){
             w[i] *= conformal_correction[i];
             const double *v = values->getValues(i);

--- a/SparseGrids/tsgGridFourier.cpp
+++ b/SparseGrids/tsgGridFourier.cpp
@@ -434,12 +434,6 @@ void GridFourier::loadNeededPoints(const double *vals, TypeAcceleration){
     calculateFourierCoefficients();
 }
 
-double* GridFourier::getLoadedPoints() const{
-    if (points == 0) return 0;
-    double *x = new double[num_dimensions * points->getNumIndexes()];
-    getLoadedPoints(x);
-    return x;
-}
 void GridFourier::getLoadedPoints(double *x) const{
     int num_points = points->getNumIndexes();
     #pragma omp parallel for schedule(static)
@@ -450,14 +444,6 @@ void GridFourier::getLoadedPoints(double *x) const{
         }
     }
 }
-double* GridFourier::getNeededPoints() const{
-    if (needed == 0) return 0;
-    int num_points = needed->getNumIndexes();
-    if (num_points == 0) return 0;
-    double *x = new double[num_dimensions * num_points];
-    getNeededPoints(x);
-    return x;
-}
 void GridFourier::getNeededPoints(double *x) const{
     int num_points = needed->getNumIndexes();
     #pragma omp parallel for schedule(static)
@@ -467,9 +453,6 @@ void GridFourier::getNeededPoints(double *x) const{
             x[i*num_dimensions + j] = wrapper->getNode(p[j]);
         }
     }
-}
-double* GridFourier::getPoints() const{
-    return ((points == 0) ? getNeededPoints() : getLoadedPoints());
 }
 void GridFourier::getPoints(double *x) const{
     if (points == 0){ getNeededPoints(x); }else{ getLoadedPoints(x); };

--- a/SparseGrids/tsgGridFourier.hpp
+++ b/SparseGrids/tsgGridFourier.hpp
@@ -75,11 +75,8 @@ public:
 
     void loadNeededPoints(const double *vals, TypeAcceleration acc = accel_none);
 
-    double* getLoadedPoints() const;
     void getLoadedPoints(double *x) const;
-    double* getNeededPoints() const;
     void getNeededPoints(double *x) const;
-    double* getPoints() const;
     void getPoints(double *x) const; // returns the loaded points unless no points are loaded, then returns the needed points
 
     double* getInterpolationWeights(const double x[]) const;

--- a/SparseGrids/tsgGridFourier.hpp
+++ b/SparseGrids/tsgGridFourier.hpp
@@ -79,10 +79,8 @@ public:
     void getNeededPoints(double *x) const;
     void getPoints(double *x) const; // returns the loaded points unless no points are loaded, then returns the needed points
 
-    double* getInterpolationWeights(const double x[]) const;
     void getInterpolationWeights(const double x[], double weights[]) const;
 
-    double* getQuadratureWeights() const;
     void getQuadratureWeights(double weights[]) const;
 
     void evaluate(const double x[], double y[]) const;

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -482,13 +482,6 @@ void GridGlobal::getPoints(double *x) const{
     if (points == 0){ getNeededPoints(x); }else{ getLoadedPoints(x); };
 }
 
-double* GridGlobal::getQuadratureWeights() const{
-    IndexSet *work = (points == 0) ? needed : points;
-    int num_points = work->getNumIndexes();
-    double *weights = new double[num_points];
-    getQuadratureWeights(weights);
-    return weights;
-}
 void GridGlobal::getQuadratureWeights(double weights[]) const{
     IndexSet *work = (points == 0) ? needed : points;
     int num_points = work->getNumIndexes();
@@ -520,16 +513,6 @@ void GridGlobal::getQuadratureWeights(double weights[]) const{
     work = 0;
 }
 
-double* GridGlobal::getInterpolationWeights(const double x[]) const{
-    IndexSet *work = (points == 0) ? needed : points;
-
-    int num_points = work->getNumIndexes();
-    double *weights = new double[num_points];
-
-    getInterpolationWeights(x, weights);
-
-    return weights;
-}
 void GridGlobal::getInterpolationWeights(const double x[], double weights[]) const{
     IndexSet *work = (points == 0) ? needed : points;
 
@@ -642,7 +625,8 @@ const double* GridGlobal::getLoadedValues() const{
 }
 
 void GridGlobal::evaluate(const double x[], double y[]) const{
-    double *w = getInterpolationWeights(x);
+    double *w = new double[points->getNumIndexes()];
+    getInterpolationWeights(x, w);
     TasBLAS::setzero(num_outputs, y);
     for(int k=0; k<num_outputs; k++){
         for(int i=0; i<points->getNumIndexes(); i++){
@@ -655,7 +639,8 @@ void GridGlobal::evaluate(const double x[], double y[]) const{
 
 #ifdef Tasmanian_ENABLE_BLAS
 void GridGlobal::evaluateFastCPUblas(const double x[], double y[]) const{
-    double *w = getInterpolationWeights(x);
+    double *w = new double[points->getNumIndexes()];
+    getInterpolationWeights(x, w);
     TasBLAS::dgemv(num_outputs, points->getNumIndexes(), values->getValues(0), w, y);
     delete[] w;
 }
@@ -668,7 +653,8 @@ void GridGlobal::evaluateFastGPUcublas(const double x[], double y[], std::ostrea
     makeCheckAccelerationData(accel_gpu_cublas, os);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
-    double *weights = getInterpolationWeights(x);
+    double *weights = new double[points->getNumIndexes()];
+    getInterpolationWeights(x, weights);
 
     gpu->cublasDGEMM(true, num_outputs, 1, points->getNumIndexes(), weights, y);
 
@@ -686,7 +672,8 @@ void GridGlobal::evaluateFastGPUmagma(int gpuID, const double x[], double y[], s
     makeCheckAccelerationData(accel_gpu_magma, os);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
-    double *weights = getInterpolationWeights(x);
+    double *weights = new double[points->getNumIndexes()];
+    getInterpolationWeights(x, weights);
 
     gpu->magmaCudaDGEMM(true, gpuID, num_outputs, 1, points->getNumIndexes(), weights, y);
 
@@ -776,7 +763,8 @@ void GridGlobal::makeCheckAccelerationData(TypeAcceleration, std::ostream *) con
 #endif // Tasmanian_ENABLE_CUDA
 
 void GridGlobal::integrate(double q[], double *conformal_correction) const{
-    double *w = getQuadratureWeights();
+    double *w = new double[getNumPoints()];
+    getQuadratureWeights(w);
     if (conformal_correction != 0) for(int i=0; i<points->getNumIndexes(); i++) w[i] *= conformal_correction[i];
     std::fill(q, q+num_outputs, 0.0);
     #pragma omp parallel for schedule(static)
@@ -904,7 +892,8 @@ double* GridGlobal::computeSurpluses(int output, bool normalize) const{
         delete polynomial_set;
 
         int qn = gg->getNumPoints();
-        double *w = gg->getQuadratureWeights();
+        double *w = new double[qn];
+        gg->getQuadratureWeights(w);
         double *x = new double[getNumPoints() * num_dimensions];
         gg->getPoints(x);
         double *I = new double[qn];

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -77,11 +77,8 @@ public:
     int getNumNeeded() const;
     int getNumPoints() const; // returns the number of loaded points unless no points are loaded, then returns the number of needed points
 
-    double* getLoadedPoints() const;
     void getLoadedPoints(double *x) const;
-    double* getNeededPoints() const;
     void getNeededPoints(double *x) const;
-    double* getPoints() const;
     void getPoints(double *x) const; // returns the loaded points unless no points are loaded, then returns the needed points
 
     double* getQuadratureWeights() const;

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -81,9 +81,7 @@ public:
     void getNeededPoints(double *x) const;
     void getPoints(double *x) const; // returns the loaded points unless no points are loaded, then returns the needed points
 
-    double* getQuadratureWeights() const;
     void getQuadratureWeights(double weights[]) const;
-    double* getInterpolationWeights(const double x[]) const;
     void getInterpolationWeights(const double x[], double weights[]) const;
 
     void loadNeededPoints(const double *vals, TypeAcceleration acc = accel_none);

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -626,14 +626,6 @@ void GridLocalPolynomial::mergeRefinement(){
     std::fill(surpluses, surpluses + num_vals, 0.0);
 }
 
-
-double* GridLocalPolynomial::getInterpolationWeights(const double x[]) const{
-    IndexSet *work = (points == 0) ? needed : points;
-    double *weights = new double[work->getNumIndexes()];
-    getInterpolationWeights(x, weights);
-    return weights;
-}
-
 void GridLocalPolynomial::getInterpolationWeights(const double x[], double *weights) const{
     IndexSet *work = (points == 0) ? needed : points;
 
@@ -1294,12 +1286,6 @@ void GridLocalPolynomial::getBasisIntegrals(double *integrals) const{
         delete[] w;
     }
 }
-double* GridLocalPolynomial::getQuadratureWeights() const{
-    IndexSet *work = (points == 0) ? needed : points;
-    double *weights = new double[work->getNumIndexes()];
-    getQuadratureWeights(weights);
-    return weights;
-}
 void GridLocalPolynomial::getQuadratureWeights(double *weights) const{
     IndexSet *work = (points == 0) ? needed : points;
     getBasisIntegrals(weights);
@@ -1391,7 +1377,8 @@ void GridLocalPolynomial::integrate(double q[], double *conformal_correction) co
         }
         delete[] integrals;
     }else{
-        double *w = getQuadratureWeights();
+        double *w = new double[num_points];
+        getQuadratureWeights(w);
         for(int i=0; i<num_points; i++){
             w[i] *= conformal_correction[i];
             const double *vals = values->getValues(i);

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -358,20 +358,6 @@ int GridLocalPolynomial::getNumLoaded() const{ return (((points == 0) || (num_ou
 int GridLocalPolynomial::getNumNeeded() const{ return ((needed == 0) ? 0 : needed->getNumIndexes()); }
 int GridLocalPolynomial::getNumPoints() const{ return ((points == 0) ? getNumNeeded() : points->getNumIndexes()); }
 
-double* GridLocalPolynomial::getLoadedPoints() const{
-    if (points == 0) return 0;
-    int num_points = points->getNumIndexes();
-    if (num_points == 0) return 0;
-    double *x = new double[num_dimensions * num_points];
-    #pragma omp parallel for schedule(static)
-    for(int i=0; i<num_points; i++){
-        const int *p = points->getIndex(i);
-        for(int j=0; j<num_dimensions; j++){
-            x[i*num_dimensions + j] = rule->getNode(p[j]);
-        }
-    }
-    return x;
-}
 void GridLocalPolynomial::getLoadedPoints(double *x) const{
     int num_points = points->getNumIndexes();
     #pragma omp parallel for schedule(static)
@@ -382,20 +368,6 @@ void GridLocalPolynomial::getLoadedPoints(double *x) const{
         }
     }
 }
-double* GridLocalPolynomial::getNeededPoints() const{
-    if (needed == 0) return 0;
-    int num_points = needed->getNumIndexes();
-    if (num_points == 0) return 0;
-    double *x = new double[num_dimensions * num_points];
-    #pragma omp parallel for schedule(static)
-    for(int i=0; i<num_points; i++){
-        const int *p = needed->getIndex(i);
-        for(int j=0; j<num_dimensions; j++){
-            x[i*num_dimensions + j] = rule->getNode(p[j]);
-        }
-    }
-    return x;
-}
 void GridLocalPolynomial::getNeededPoints(double *x) const{
     int num_points = needed->getNumIndexes();
     #pragma omp parallel for schedule(static)
@@ -405,9 +377,6 @@ void GridLocalPolynomial::getNeededPoints(double *x) const{
             x[i*num_dimensions + j] = rule->getNode(p[j]);
         }
     }
-}
-double* GridLocalPolynomial::getPoints() const{
-    return ((points == 0) ? getNeededPoints() : getLoadedPoints());
 }
 void GridLocalPolynomial::getPoints(double *x) const{
     if (points == 0){ getNeededPoints(x); }else{ getLoadedPoints(x); }
@@ -1785,7 +1754,8 @@ void GridLocalPolynomial::setHierarchicalCoefficients(const double c[], TypeAcce
     if (surpluses != 0) delete[] surpluses;
     surpluses = new double[((size_t) num_ponits) * ((size_t) num_outputs)];
     std::copy(c, c + ((size_t) num_ponits) * ((size_t) num_outputs), surpluses);
-    double *x = getPoints();
+    double *x = new double[getNumPoints() * num_dimensions];
+    getPoints(x);
     if (acc == accel_cpu_blas){
         evaluateBatchCPUblas(x, points->getNumIndexes(), vals);
     }else if (acc == accel_gpu_cublas){
@@ -1822,7 +1792,8 @@ void GridLocalPolynomial::checkAccelerationGPUNodes() const{
     if (gpu->getGPUNodes() == 0){
         IndexSet *work = (points == 0) ? needed : points;
         int num_entries = num_dimensions * work->getNumIndexes();
-        double *cpu_nodes = getPoints();
+        double *cpu_nodes = new double[getNumPoints() * num_dimensions];
+        getPoints(cpu_nodes);
         double *cpu_support = new double[num_entries];
         if (rule->getType() == rule_localp){
             switch(order){

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -69,9 +69,7 @@ public:
     void getNeededPoints(double *x) const;
     void getPoints(double *x) const; // returns the loaded points unless no points are loaded, then returns the needed points
 
-    double* getQuadratureWeights() const;
     void getQuadratureWeights(double weights[]) const;
-    double* getInterpolationWeights(const double x[]) const;
     void getInterpolationWeights(const double x[], double weights[]) const;
 
     void loadNeededPoints(const double *vals, TypeAcceleration acc = accel_none);

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -65,11 +65,8 @@ public:
     int getNumNeeded() const;
     int getNumPoints() const;
 
-    double* getLoadedPoints() const;
     void getLoadedPoints(double *x) const;
-    double* getNeededPoints() const;
     void getNeededPoints(double *x) const;
-    double* getPoints() const;
     void getPoints(double *x) const; // returns the loaded points unless no points are loaded, then returns the needed points
 
     double* getQuadratureWeights() const;

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -324,26 +324,6 @@ void GridSequence::getPoints(double *x) const{
     if (points == 0){ getNeededPoints(x); }else{ getLoadedPoints(x); }
 }
 
-double* GridSequence::getQuadratureWeights() const{
-    IndexSet *work = (points == 0) ? needed : points;
-    double *integ = cacheBasisIntegrals();
-
-    int n = work->getNumIndexes();
-    double *weights = new double[n];
-
-    for(int i=0; i<n; i++){
-        const int* p = work->getIndex(i);
-        weights[i] = integ[p[0]];
-        for(int j=1; j<num_dimensions; j++){
-            weights[i] *= integ[p[j]];
-        }
-    }
-    delete[] integ;
-
-    applyTransformationTransposed(weights);
-
-    return weights;
-}
 void GridSequence::getQuadratureWeights(double *weights) const{
     IndexSet *work = (points == 0) ? needed : points;
     double *integ = cacheBasisIntegrals();
@@ -360,16 +340,6 @@ void GridSequence::getQuadratureWeights(double *weights) const{
     applyTransformationTransposed(weights);
 }
 
-double* GridSequence::getInterpolationWeights(const double x[]) const{
-    IndexSet *work = (points == 0) ? needed : points;
-    int n = work->getNumIndexes();
-
-    double *weights = new double[n];
-
-    getInterpolationWeights(x, weights);
-
-    return weights;
-}
 void GridSequence::getInterpolationWeights(const double x[], double *weights) const{
     double **cache = cacheBasisValues<double>(x);
     IndexSet *work = (points == 0) ? needed : points;
@@ -616,7 +586,8 @@ void GridSequence::integrate(double q[], double *conformal_correction) const{
         }
         delete[] integ;
     }else{
-        double *w = getQuadratureWeights();
+        double *w = new double[num_points];
+        getQuadratureWeights(w);
         for(int i=0; i<num_points; i++){
             w[i] *= conformal_correction[i];
             const double *vals = values->getValues(i);

--- a/SparseGrids/tsgGridSequence.hpp
+++ b/SparseGrids/tsgGridSequence.hpp
@@ -73,11 +73,8 @@ public:
     int getNumNeeded() const;
     int getNumPoints() const; // returns the number of loaded points unless no points are loaded, then returns the number of needed points
 
-    double* getLoadedPoints() const;
     void getLoadedPoints(double *x) const;
-    double* getNeededPoints() const;
     void getNeededPoints(double *x) const;
-    double* getPoints() const;
     void getPoints(double *x) const; // returns the loaded points unless no points are loaded, then returns the needed points
 
     double* getQuadratureWeights() const;

--- a/SparseGrids/tsgGridSequence.hpp
+++ b/SparseGrids/tsgGridSequence.hpp
@@ -77,9 +77,7 @@ public:
     void getNeededPoints(double *x) const;
     void getPoints(double *x) const; // returns the loaded points unless no points are loaded, then returns the needed points
 
-    double* getQuadratureWeights() const;
     void getQuadratureWeights(double weights[]) const;
-    double* getInterpolationWeights(const double x[]) const;
     void getInterpolationWeights(const double x[], double weights[]) const;
 
     void loadNeededPoints(const double *vals, TypeAcceleration acc = accel_none);

--- a/SparseGrids/tsgGridWavelet.cpp
+++ b/SparseGrids/tsgGridWavelet.cpp
@@ -265,13 +265,6 @@ void GridWavelet::getPoints(double *x) const{
     if (points == 0){ getNeededPoints(x); }else{ getLoadedPoints(x); }
 }
 
-double* GridWavelet::getQuadratureWeights() const{
-    IndexSet *work = (points == 0) ? needed : points;
-    int num_points = work->getNumIndexes();
-	double *weights = new double[num_points];
-	getQuadratureWeights(weights);
-	return weights;
-}
 void GridWavelet::getQuadratureWeights(double *weights) const{
     IndexSet *work = (points == 0) ? needed : points;
     int num_points = work->getNumIndexes();
@@ -280,13 +273,6 @@ void GridWavelet::getQuadratureWeights(double *weights) const{
 		weights[i] = evalIntegral(work->getIndex(i));
 	}
 	solveTransposed(weights);
-}
-double* GridWavelet::getInterpolationWeights(const double x[]) const{
-    IndexSet *work = (points == 0) ? needed : points;
-    int num_points = work->getNumIndexes();
-	double *weights = new double[num_points];
-	getInterpolationWeights(x, weights);
-	return weights;
 }
 void GridWavelet::getInterpolationWeights(const double x[], double *weights) const{
     IndexSet *work = (points == 0) ? needed : points;
@@ -393,7 +379,8 @@ void GridWavelet::integrate(double q[], double *conformal_correction) const{
         delete[] basis_integrals;
     }else{
         std::fill(q, q + num_outputs, 0.0);
-        double *w = getQuadratureWeights();
+        double *w = new double[num_points];
+        getQuadratureWeights(w);
         for(int i=0; i<num_points; i++){
             w[i] *= conformal_correction[i];
             const double *vals = values->getValues(i);

--- a/SparseGrids/tsgGridWavelet.hpp
+++ b/SparseGrids/tsgGridWavelet.hpp
@@ -69,9 +69,7 @@ public:
     void getNeededPoints(double *x) const;
     void getPoints(double *x) const; // returns the loaded points unless no points are loaded, then returns the needed points
 
-    double* getQuadratureWeights() const;
     void getQuadratureWeights(double weights[]) const;
-    double* getInterpolationWeights(const double x[]) const;
     void getInterpolationWeights(const double x[], double weights[]) const;
 
     void loadNeededPoints(const double *vals, TypeAcceleration acc);

--- a/SparseGrids/tsgGridWavelet.hpp
+++ b/SparseGrids/tsgGridWavelet.hpp
@@ -65,11 +65,8 @@ public:
     int getNumNeeded() const;
     int getNumPoints() const;
 
-    double* getLoadedPoints() const;
     void getLoadedPoints(double *x) const;
-    double* getNeededPoints() const;
     void getNeededPoints(double *x) const;
-    double* getPoints() const;
     void getPoints(double *x) const; // returns the loaded points unless no points are loaded, then returns the needed points
 
     double* getQuadratureWeights() const;


### PR DESCRIPTION
* only the interface of `TasmanianSparseGrid` should return dynamically allocated pointers for backwards compatibility, e.g., `double* getPoints()`
* the individual grids do not need to implement such methods, e.g., there should be no `double *GridGlobal::getPoints()`, only `void GridGlobal::getPoints(double x[])`