### PR TITLE
Add vector to internals of localp grids

### DIFF
--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -136,7 +136,7 @@ void AccelerationDataGPUFull::loadGPUNodesSupport(int total_entries, const doubl
     gpu_nodes   = TasCUDA::cudaSend<double>(total_entries, cpu_nodes,   logstream);
     gpu_support = TasCUDA::cudaSend<double>(total_entries, cpu_support, logstream);
 }
-void AccelerationDataGPUFull::loadGPUHierarchy(int num_points, int *pntr, int *indx, int num_roots, int *roots){
+void AccelerationDataGPUFull::loadGPUHierarchy(int num_points, const int *pntr, const int *indx, int num_roots, const int *roots){
     gpu_hpntr = TasCUDA::cudaSend<int>(num_points + 1, pntr, logstream);
     gpu_hindx = TasCUDA::cudaSend<int>(pntr[num_points], indx, logstream);
     gpu_roots = TasCUDA::cudaSend<int>(num_roots, roots, logstream);
@@ -145,7 +145,7 @@ void AccelerationDataGPUFull::loadGPUHierarchy(int num_points, int *pntr, int *i
 void AccelerationDataGPUFull::loadGPUValues(size_t, const double *){}
 void AccelerationDataGPUFull::resetGPULoadedData(){}
 void AccelerationDataGPUFull::loadGPUNodesSupport(int, const double *, const double *){}
-void AccelerationDataGPUFull::loadGPUHierarchy(int, int*, int*, int, int*){}
+void AccelerationDataGPUFull::loadGPUHierarchy(int, const int*, const int*, int, const int*){}
 #endif // Tasmanian_ENABLE_CUDA
 
 double* AccelerationDataGPUFull::getGPUValues() const{ return gpu_values; }

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -71,7 +71,7 @@ public:
     int* getGPUpntr() const;
     int* getGPUindx() const;
     int* getGPUroots() const;
-    void loadGPUHierarchy(int num_points, int *pntr, int *indx, int num_roots, int *roots);
+    void loadGPUHierarchy(int num_points, const int *pntr, const int *indx, int num_roots, const int *roots);
     // collection of trees to be used in CUDA evaluations of local polynomial grids
 
     void resetGPULoadedData();

--- a/SparseGrids/tsgCudaMacros.hpp
+++ b/SparseGrids/tsgCudaMacros.hpp
@@ -34,6 +34,7 @@
 #include "TasmanianConfig.hpp"
 
 #include <iostream>
+#include <vector>
 
 #ifdef Tasmanian_ENABLE_CUDA
 #include <cuda_runtime_api.h>
@@ -59,6 +60,14 @@ namespace TasCUDA{
     inline T* cudaSend(size_t num_entries, const T *cpu_array, std::ostream *os){
         T *x = cudaNew<T>(num_entries, os);
         cudaError_t cudaStat = cudaMemcpy(x, cpu_array, num_entries * sizeof(T), cudaMemcpyHostToDevice);
+        AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaSend(type)", os);
+        return x;
+    }
+
+    template <typename T>
+    inline T* cudaSend(std::vector<T> cpu_vector, std::ostream *os){
+        T *x = cudaNew<T>(cpu_vector.size(), os);
+        cudaError_t cudaStat = cudaMemcpy(x, cpu_vector.data(), cpu_vector.size() * sizeof(T), cudaMemcpyHostToDevice);
         AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaSend(type)", os);
         return x;
     }

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -96,7 +96,7 @@ void GridLocalPolynomial::write(std::ofstream &ofs) const{
             for(int i=0; i<rule->getMaxNumParents()*(points->getNumIndexes()); i++){ ofs << " " << parents[i]; } ofs << endl;
         }
         int num_points = (points == 0) ? needed->getNumIndexes() : points->getNumIndexes();
-        ofs << roots.size(); for(unsigned i=0; i<roots.size(); i++){  ofs << " " << roots[i];  } ofs << endl;
+        ofs << roots.size(); for(auto const &r : roots){ ofs << " " << r; } ofs << endl;
         ofs << pntr[0]; for(int i=1; i<=num_points; i++){  ofs << " " << pntr[i];  }  ofs << endl;
         ofs << indx[0]; for(int i=1; i<pntr[num_points]; i++){  ofs << " " << indx[i];  }  ofs << endl;
         if (num_outputs > 0) values->write(ofs);

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -1503,7 +1503,7 @@ void GridLocalPolynomial::buildUpdateMap(double tolerance, TypeRefinement criter
 }
 
 bool GridLocalPolynomial::addParent(const int point[], int direction, GranulatedIndexSet *destination, IndexSet *exclude) const{
-    int *dad = new int[num_dimensions];  std::copy(point, point + num_dimensions, dad);
+    std::vector<int> dad(num_dimensions);  std::copy(point, point + num_dimensions, dad.data());
     bool added = false;
     dad[direction] = rule->getParent(point[direction]);
     if ((dad[direction] != -1) && (exclude->getSlot(dad) == -1)){
@@ -1515,11 +1515,10 @@ bool GridLocalPolynomial::addParent(const int point[], int direction, Granulated
         destination->addIndex(dad);
         added = true;
     }
-    delete[] dad;
     return added;
 }
 void GridLocalPolynomial::addChild(const int point[], int direction, GranulatedIndexSet *destination, IndexSet *exclude)const{
-    int *kid = new int[num_dimensions];  std::copy(point, point + num_dimensions, kid);
+    std::vector<int> kid(num_dimensions);  std::copy(point, point + num_dimensions, kid.data());
     int max_1d_kids = rule->getMaxNumKids();
     for(int i=0; i<max_1d_kids; i++){
         kid[direction] = rule->getKid(point[direction], i);
@@ -1527,10 +1526,9 @@ void GridLocalPolynomial::addChild(const int point[], int direction, GranulatedI
             destination->addIndex(kid);
         }
     }
-    delete[] kid;
 }
 void GridLocalPolynomial::addChildLimited(const int point[], int direction, GranulatedIndexSet *destination, IndexSet *exclude, const int *level_limits) const{
-    int *kid = new int[num_dimensions];  std::copy(point, point + num_dimensions, kid);
+    std::vector<int> kid(num_dimensions);  std::copy(point, point + num_dimensions, kid.data());
     int max_1d_kids = rule->getMaxNumKids();
     for(int i=0; i<max_1d_kids; i++){
         kid[direction] = rule->getKid(point[direction], i);
@@ -1540,7 +1538,6 @@ void GridLocalPolynomial::addChildLimited(const int point[], int direction, Gran
             destination->addIndex(kid);
         }
     }
-    delete[] kid;
 }
 
 void GridLocalPolynomial::clearRefinement(){

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -483,15 +483,13 @@ void GridLocalPolynomial::evaluateBatchCPUblas(const double x[], int num_x, doub
 
     if ((sparse_affinity == -1) || ((sparse_affinity == 0) && (nnz / total_size > 0.1))){
         // potentially wastes a lot of memory
-        double *A = new double[((size_t) num_x) * ((size_t) num_points)];
-        std::fill(A, A + ((size_t) num_x) * ((size_t) num_points), 0.0);
+        std::vector<double> A(((size_t) num_x) * ((size_t) num_points), 0.0);
         for(int i=0; i<num_x; i++){
             for(int j=spntr[i]; j<spntr[i+1]; j++){
                 A[((size_t) i) * ((size_t) num_points) + ((size_t) sindx[j])] = svals[j];
             }
         }
-        TasBLAS::dgemm(num_outputs, num_x, num_points, 1.0, surpluses, A, 0.0, y);
-        delete[] A;
+        TasBLAS::dgemm(num_outputs, num_x, num_points, 1.0, surpluses, A.data(), 0.0, y);
     }else{
         #pragma omp parallel for
         for(int i=0; i<num_x; i++){

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -386,24 +386,24 @@ void GridLocalPolynomial::getPoints(double *x) const{
 }
 
 void GridLocalPolynomial::evaluate(const double x[], double y[]) const{
-    int *monkey_count = new int[top_level+1];
-    int *monkey_tail = new int[top_level+1];
+    std::vector<int> monkey_count(top_level+1);
+    std::vector<int> monkey_tail(top_level+1);
 
     bool isSupported;
     size_t offset;
 
     std::fill(y, y + num_outputs, 0.0);
 
-    for(unsigned r=0; r<roots.size(); r++){
-        double basis_value = evalBasisSupported(points->getIndex(roots[r]), x, isSupported);
+    for(auto const &r : roots){
+        double basis_value = evalBasisSupported(points->getIndex(r), x, isSupported);
 
         if (isSupported){
-            offset = roots[r] * num_outputs;
+            offset = r * num_outputs;
             for(int k=0; k<num_outputs; k++) y[k] += basis_value * surpluses[offset + k];
 
             int current = 0;
-            monkey_tail[0] = roots[r];
-            monkey_count[0] = pntr[roots[r]];
+            monkey_tail[0] = r;
+            monkey_count[0] = pntr[r];
 
             while(monkey_count[0] < pntr[monkey_tail[0]+1]){
                 if (monkey_count[current] < pntr[monkey_tail[current]+1]){
@@ -425,9 +425,6 @@ void GridLocalPolynomial::evaluate(const double x[], double y[]) const{
             }
         }
     }
-
-    delete[] monkey_count;
-    delete[] monkey_tail;
 }
 void GridLocalPolynomial::evaluateFastCPUblas(const double x[], double y[]) const{ evaluate(x, y); }
 // standard BLAS cannot accelerate dense matrix times a sparse vector, fallback to regular evaluate()

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -632,8 +632,8 @@ void GridLocalPolynomial::getInterpolationWeights(const double x[], double *weig
     std::vector<int> active_points(0);
     std::fill(weights, weights + work->getNumIndexes(), 0.0);
 
-    int *monkey_count = new int[top_level+1];
-    int *monkey_tail = new int[top_level+1];
+    std::vector<int> monkey_count(top_level+1);
+    std::vector<int> monkey_tail(top_level+1);
 
     double basis_value;
     bool isSupported;
@@ -682,19 +682,20 @@ void GridLocalPolynomial::getInterpolationWeights(const double x[], double *weig
         dagUp = IM.computeDAGupLocal(work, rule);
     }
 
-    int *level = new int[active_points.size()];
+    std::vector<int> level(active_points.size());
     int active_top_level = 0;
     for(size_t i=0; i<active_points.size(); i++){
         const int *p = work->getIndex(active_points[i]);
-        level[i] = rule->getLevel(p[0]);
+        int current_level = rule->getLevel(p[0]);
         for(int j=1; j<num_dimensions; j++){
-            level[i] += rule->getLevel(p[j]);
+            current_level += rule->getLevel(p[j]);
         }
-        if (active_top_level < level[i]) active_top_level = level[i];
+        if (active_top_level < current_level) active_top_level = current_level;
+        level[i] = current_level;
     }
 
-    bool *used = new bool[work->getNumIndexes()];
-    double *node = new double[num_dimensions];
+    std::vector<bool> used(work->getNumIndexes());
+    std::vector<double> node(num_dimensions);
     int max_parents = rule->getMaxNumParents() * num_dimensions;
 
     for(int l=active_top_level; l>0; l--){
@@ -703,7 +704,7 @@ void GridLocalPolynomial::getInterpolationWeights(const double x[], double *weig
                 const int* p = work->getIndex(active_points[i]);
                 for(int j=0; j<num_dimensions; j++) node[j] = rule->getNode(p[j]);
 
-                std::fill(used, used + work->getNumIndexes(), false);
+                std::fill(used.begin(), used.end(), false);
 
                 monkey_count[0] = 0;
                 monkey_tail[0] = active_points[i];
@@ -731,14 +732,6 @@ void GridLocalPolynomial::getInterpolationWeights(const double x[], double *weig
             }
         }
     }
-
-    delete[] used;
-    delete[] node;
-
-    delete[] level;
-
-    delete[] monkey_count;
-    delete[] monkey_tail;
 
     if (num_outputs > 0){
         delete[] dagUp;

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -1787,7 +1787,7 @@ void GridLocalPolynomial::checkAccelerationGPUNodes() const{
 void GridLocalPolynomial::checkAccelerationGPUHierarchy() const{
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
     int num_points = getNumPoints();
-    gpu->loadGPUHierarchy(num_points, pntr, indx, roots.size(), roots.data());
+    gpu->loadGPUHierarchy(num_points, pntr.data(), indx.data(), roots.size(), roots.data());
 }
 #else
 void GridLocalPolynomial::makeCheckAccelerationData(TypeAcceleration, std::ostream *) const{}

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -1378,7 +1378,7 @@ void GridLocalPolynomial::buildUpdateMap(double tolerance, TypeRefinement criter
     const double *scale = scale_correction;
     std::vector<double> temp_scale;
     if (scale == 0){
-        temp_scale = std::move(std::vector<double>(((size_t) num_points) * ((size_t) num_outputs), 1.0));
+        temp_scale = std::vector<double>(((size_t) num_points) * ((size_t) num_outputs), 1.0);
         scale = temp_scale.data();
     }
 

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -131,7 +131,7 @@ protected:
 
         num_nz = 0;
 
-        for(int r=0; r<num_roots; r++){
+        for(int r=0; r<roots.size(); r++){
             double basis_value = evalBasisSupported(points->getIndex(roots[r]), x, isSupported);
 
             if (isSupported){
@@ -300,8 +300,11 @@ private:
     int *parents;
 
     // tree for evaluation
-    int num_roots, *roots;
-    int *pntr, *indx;
+    //int num_roots, *roots;
+    //int *pntr, *indx;
+    std::vector<int> roots;
+    std::vector<int> pntr;
+    std::vector<int> indx;
 
     BaseRuleLocalPolynomial *rule;
 

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -121,7 +121,7 @@ protected:
     void buildSparseMatrixBlockForm(const double x[], int num_x, int num_chunk, int &num_blocks, int &num_last, int &stripe_size,
                                     int* &stripes, int* &last_stripe_size, int** &tpntr, int*** &tindx, double*** &tvals) const;
 
-    template<bool fill>
+    template<bool fill_data>
     void buildSparseVector(const double x[], int &num_nz, int *sindx, double *svals) const{
         std::vector<int> monkey_count(top_level+1);
         std::vector<int> monkey_tail(top_level+1);
@@ -136,7 +136,7 @@ protected:
 
             if (isSupported){
                 offset = r * num_outputs;
-                if (fill){
+                if (fill_data){
                     sindx[num_nz] = r;
                     svals[num_nz] = basis_value;
                 }
@@ -151,7 +151,7 @@ protected:
                         offset = indx[monkey_count[current]];
                         basis_value = evalBasisSupported(points->getIndex(offset), x, isSupported);
                         if (isSupported){
-                            if (fill){
+                            if (fill_data){
                                 sindx[num_nz] = offset;
                                 svals[num_nz] = basis_value;
                             }
@@ -173,7 +173,7 @@ protected:
         // "... it is assumed that the indices are provided in increasing order and that each index appears only once."
         // This may not be a requirement for cusparseDgemvi(), but it may be that I have not tested it sufficiently
         // Also, see AccelerationDataGPUFull::cusparseMatveci() for inaccuracies in Nvidia documentation
-        if (fill){
+        if (fill_data){
             bool isNotSorted = false;
             for(int i=0; i<num_nz-1; i++) if (sindx[i] > sindx[i+1]) isNotSorted = true;
             if (isNotSorted){ // sort the vector

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -122,9 +122,14 @@ protected:
                                     int* &stripes, int* &last_stripe_size, int** &tpntr, int*** &tindx, double*** &tvals) const;
 
     template<bool fill_data>
-    void buildSparseVector(const double x[], int &num_nz, int *sindx, double *svals) const{
+    void buildSparseVector(const double x[], int &num_nz, std::vector<int> &sindx, std::vector<double> &svals) const{
         std::vector<int> monkey_count(top_level+1);
         std::vector<int> monkey_tail(top_level+1);
+
+        if (fill_data){
+            sindx.resize(num_nz);
+            svals.resize(num_nz);
+        }
 
         bool isSupported;
         size_t offset;
@@ -230,8 +235,8 @@ protected:
                     std::swap(idx1, idx2);
                     std::swap(vls1, vls2);
                 }
-                std::copy(idx1.begin(), idx1.end(), sindx);
-                std::copy(vls1.begin(), vls1.end(), svals);
+                sindx = idx1;
+                svals = vls1;
             }
         }
     }

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -131,20 +131,20 @@ protected:
 
         num_nz = 0;
 
-        for(int r=0; r<roots.size(); r++){
-            double basis_value = evalBasisSupported(points->getIndex(roots[r]), x, isSupported);
+        for(const auto &r : roots){
+            double basis_value = evalBasisSupported(points->getIndex(r), x, isSupported);
 
             if (isSupported){
-                offset = roots[r] * num_outputs;
+                offset = r * num_outputs;
                 if (fill){
-                    sindx[num_nz] = roots[r];
+                    sindx[num_nz] = r;
                     svals[num_nz] = basis_value;
                 }
                 num_nz++;
 
                 int current = 0;
-                monkey_tail[0] = roots[r];
-                monkey_count[0] = pntr[roots[r]];
+                monkey_tail[0] = r;
+                monkey_count[0] = pntr[r];
 
                 while(monkey_count[0] < pntr[monkey_tail[0]+1]){
                     if (monkey_count[current] < pntr[monkey_tail[current]+1]){

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -246,9 +246,9 @@ protected:
 
     void getBasisIntegrals(double *integrals) const;
 
-    double* getNormalization() const;
+    void getNormalization(std::vector<double> &norms) const;
 
-    int* buildUpdateMap(double tolerance, TypeRefinement criteria, int output, const double *scale_correction) const;
+    void buildUpdateMap(double tolerance, TypeRefinement criteria, int output, const double *scale_correction, std::vector<int> &pmap) const;
 
     bool addParent(const int point[], int direction, GranulatedIndexSet *destination, IndexSet *exclude) const;
     void addChild(const int point[], int direction, GranulatedIndexSet *destination, IndexSet *exclude) const;

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -32,6 +32,7 @@
 #define __TASMANIAN_SPARSE_GRID_INDEX_SETS_HPP
 
 #include "tsgEnumerates.hpp"
+#include <vector>
 
 namespace TasGrid{
 
@@ -68,6 +69,7 @@ public:
     int getNumIndexes() const;
 
     void addIndex(const int p[]);
+    inline void addIndex(const std::vector<int> p){ addIndex(p.data()); }
     int getSlot(const int p[]) const;
 
     const int* getIndex(int j) const;
@@ -124,6 +126,7 @@ public:
     void readBinary(std::ifstream &ifs);
 
     int getSlot(const int p[]) const;
+    inline int getSlot(const std::vector<int> p) const{ return getSlot(p.data()); }
 
     const int* getIndex(int i) const;
 


### PR DESCRIPTION
* replaced numerous instances of `new[]` arrays with `std::vector` in `GridLocalPolynomial` class 
* had to modify several other classes to accommodate the change
* several classes now have dual API accepting `int[]` and `std::vector`