### PR TITLE
Changes to MATLAB source do not trigger reconfigure of cmake

### DIFF
--- a/InterfaceMATLAB/CMakeLists.txt
+++ b/InterfaceMATLAB/CMakeLists.txt
@@ -45,8 +45,14 @@ set(Tasmanian_matlab_source_files tsgCancelRefine.m
                                   tsgWriteMatrix.m)
 
 foreach(Tasmanian_matlab_source_file ${Tasmanian_matlab_source_files})
-    configure_file(${Tasmanian_matlab_source_file} "matlab/${Tasmanian_matlab_source_file}" COPYONLY)
+    add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/matlab/${Tasmanian_matlab_source_file}"
+                       COMMAND "${CMAKE_COMMAND}"
+                       ARGS -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${Tasmanian_matlab_source_file} ${CMAKE_CURRENT_BINARY_DIR}/matlab/${Tasmanian_matlab_source_file}
+                       DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${Tasmanian_matlab_source_file}"
+                       COMMENT "Copying ${CMAKE_CURRENT_SOURCE_DIR}/${Tasmanian_matlab_source_file}")
+    list(APPEND Tasmanian_matlab_pre_install_files "${CMAKE_CURRENT_BINARY_DIR}/matlab/${Tasmanian_matlab_source_file}")
 endforeach()
+add_custom_target(Tasmanian_matlab_interface ALL DEPENDS "${Tasmanian_matlab_pre_install_files}")
 
 # set MATLAB (tasgrid and temp folder) for the build folder (stage 1)
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/tempMATLAB/") # put temp files if running matlab from the build location


### PR DESCRIPTION
added cmake MATLAB target and proper copy dependence for the MATLAB script files, now changes to the source propagate to the build directory without reconfiguring the build system