### PR TITLE
Dream vector api

### DIFF
--- a/DREAM/Examples/example_dream.cpp
+++ b/DREAM/Examples/example_dream.cpp
@@ -42,7 +42,9 @@ int main(int argc, const char**){
         UnscaledPDF(){}
         ~UnscaledPDF(){}
         int getNumDimensions() const{ return 1; }
-        void evaluate(int num_points, const double x[], double y[], bool useLogForm){
+        void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm){
+            int num_points = x.size();
+            if (y.size() < (size_t) num_points) y.resize(num_points);
             for(int i=0; i<num_points; i++){ // set the pdf values
                 y[i] = -0.5 * x[i] * x[i];
             }
@@ -572,7 +574,9 @@ int main(int argc, const char**){
 
         int getNumDimensions() const{ return 2; }
         int getNumOutputs() const{ return N; }
-        void evaluate(const double x[], int num_points, double y[]) const{
+        void evaluate(const std::vector<double> x, std::vector<double> &y) const{
+            int num_points = x.size() / 2;
+            if (y.size() < (size_t) (N * num_points)) y.resize(N * num_points);
             for(int i=0; i<num_points; i++){
                 for(int j=0; j<N; j++){
                     y[i*N + j] = sin(x[2*i] * M_PI * (dt2 + j*dt) + x[2*i+1]);
@@ -695,7 +699,9 @@ int main(int argc, const char**){
 
         int getNumDimensions() const{ return 6; }
         int getNumOutputs() const{ return N; }
-        void evaluate(const double x[], int num_points, double y[]) const{
+        void evaluate(const std::vector<double> x, std::vector<double> &y) const{
+            int num_points = x.size() / 2;
+            if (y.size() < (size_t) (N * num_points)) y.resize(N * num_points);
             for(int i=0; i<num_points; i++){
                 for(int j=0; j<N; j++){
                     double t = snap[j];

--- a/DREAM/Examples/example_dream.cpp
+++ b/DREAM/Examples/example_dream.cpp
@@ -54,13 +54,17 @@ int main(int argc, const char**){
                 }
             }
         }
-        void getDomainBounds(bool* lower_bound, bool* upper_bound){
-            lower_bound[0] = false; // Gaussian is unbounded
-            upper_bound[0] = false;
+        void getDomainBounds(std::vector<bool> &lower, std::vector<bool> &upper){
+            if (lower.size() < 1) lower.resize(1);
+            if (upper.size() < 1) upper.resize(1);
+            lower[0] = false; // Gaussian is unbounded
+            upper[0] = false;
         }
-        void getDomainBounds(double* lower_bound, double* upper_bound){
-            lower_bound[0] = 0.0; // since bounds above give false,
-            upper_bound[0] = 0.0; // those here are dummy values
+        void getDomainBounds(std::vector<double> &lower, std::vector<double> &upper){
+            if (lower.size() < 1) lower.resize(1);
+            if (upper.size() < 1) upper.resize(1);
+            lower[0] = 0.0; // since bounds above give false,
+            upper[0] = 0.0;
         }
         void getInitialSample(double x[]){
             // initialize with samples unifromly in [-1,1]

--- a/DREAM/TasmanianDREAM.cpp
+++ b/DREAM/TasmanianDREAM.cpp
@@ -562,6 +562,10 @@ double* TasmanianDREAM::getPDFHistory() const{
     return hist;
 }
 
+void TasmanianDREAM::getPDFHistory(std::vector<double> history) const{
+    history = pdf_history; // copy assignment
+}
+
 }
 
 #endif

--- a/DREAM/TasmanianDREAM.hpp
+++ b/DREAM/TasmanianDREAM.hpp
@@ -229,7 +229,9 @@ public:
     double* collectSamples(int num_burnup, int num_samples, bool useLogForm = false);
     void collectSamples(int num_burnup, int num_samples, double *samples, bool useLogForm = false);
     void collectSamples(int num_burnup, int num_samples, std::vector<double> &samples, bool useLogForm = false);
+
     double* getPDFHistory() const;
+    void getPDFHistory(std::vector<double> history) const;
 
 protected:
     void clear();

--- a/DREAM/TasmanianDREAM.hpp
+++ b/DREAM/TasmanianDREAM.hpp
@@ -248,7 +248,7 @@ private:
 
     bool state_initialized, values_initialized, values_logform;
     //double *old_state, *new_pdf_values;
-    std::vector<double> chain_state, pdf_values, new_pdf_values, old_state;
+    std::vector<double> chain_state, pdf_values;
 
     std::vector<bool> isBoudnedBelow, isBoudnedAbove;
     std::vector<double> boundBelow, boundAbove;

--- a/DREAM/TasmanianDREAM.hpp
+++ b/DREAM/TasmanianDREAM.hpp
@@ -109,8 +109,8 @@ private:
     const CustomModelWrapper *cmodel;
 
     int num_dimensions, num_outputs;
-    std::vector<BasePDF*> priors;
-    std::vector<bool> priors_created_here;
+    std::vector<BasePDF*> internal_priors;
+    std::vector<BasePDF*> active_priors;
 
     int num_data;
     const double *data;

--- a/DREAM/TasmanianDREAM.hpp
+++ b/DREAM/TasmanianDREAM.hpp
@@ -51,6 +51,9 @@ public:
 
 
 class ProbabilityWeightFunction{ // use this class for inheritance purposes only
+// WARNING: TasmanianDREAM class holds an alias to an instance of this class,
+//      modifying the class after calling setProbabilityWeightFunction could result in undefined behavior
+//      TasmanianDREAM class does not call delete on the pointer
 public:
     ProbabilityWeightFunction();
     virtual ~ProbabilityWeightFunction();
@@ -59,9 +62,6 @@ public:
 
     virtual void evaluate(int num_points, const double x[], double y[], bool useLogForm) = 0;
     // in most cases evaluate should be const, but for caching purposes you may want it to be not a const function
-    // WARNING: TasmanianDREAM class holds an alias to an instance of this class,
-    //      modifying the class after calling setProbabilityWeightFunction could result in undefined behavior
-    //      TasmanianDREAM class does not call delete on the pointer
 
     virtual void getDomainBounds(bool* lower_bound, bool* upper_bound) = 0;
     virtual void getDomainBounds(double* lower_bound, double* upper_bound) = 0;

--- a/DREAM/TasmanianDREAM.hpp
+++ b/DREAM/TasmanianDREAM.hpp
@@ -44,9 +44,12 @@ class CustomModelWrapper{ // use this class for inheritance purposes only
 public:
     CustomModelWrapper();
     virtual ~CustomModelWrapper();
+    virtual int getAPIversion() const;
+
     virtual int getNumDimensions() const = 0;
     virtual int getNumOutputs() const = 0;
-    virtual void evaluate(const double x[], int num_points, double y[]) const = 0;
+    virtual void evaluate(const double x[], int num_points, double y[]) const;
+    virtual void evaluate(const std::vector<double> x, std::vector<double> &y) const = 0;
 };
 
 
@@ -58,9 +61,14 @@ public:
     ProbabilityWeightFunction();
     virtual ~ProbabilityWeightFunction();
 
+    virtual int getAPIversion() const;
+    // if this returns 5 or lower, TasmanianDREAM will use evaluate(int, const double[], double[], bool)
+    // if this returns 6 or more, TasmanianDREAM will use evaluate(const std::vector<double>, std::vector<double>&, bool)
+
     virtual int getNumDimensions() const = 0;
 
-    virtual void evaluate(int num_points, const double x[], double y[], bool useLogForm) = 0;
+    virtual void evaluate(int num_points, const double x[], double y[], bool useLogForm);
+    virtual void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm) = 0;
     // in most cases evaluate should be const, but for caching purposes you may want it to be not a const function
 
     virtual void getDomainBounds(bool* lower_bound, bool* upper_bound) = 0;
@@ -85,7 +93,7 @@ public:
 
     int getNumDimensions() const;
 
-    void evaluate(int num_points, const double x[], double y[], bool useLogForm);
+    void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm);
 
     void getInitialSample(double x[]);
     void setLikelihood(BaseLikelihood *likelihood);
@@ -107,9 +115,6 @@ private:
 
     BaseLikelihood *likely;
 
-    int num_cache;
-    double *model_cache;
-
     std::ostream *logstream;
 };
 
@@ -125,7 +130,7 @@ public:
     void setErrorLog(std::ostream *os);
 
     int getNumDimensions() const;
-    void evaluate(int num_points, const double x[], double y[], bool useLogForm);
+    void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm);
 
     void getInitialSample(double x[]);
 
@@ -160,7 +165,7 @@ public:
 
     int getNumDimensions() const;
 
-    void evaluate(int num_points, const double x[], double y[], bool useLogForm);
+    void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm);
 
     void getInitialSample(double x[]);
 

--- a/DREAM/TasmanianDREAM.hpp
+++ b/DREAM/TasmanianDREAM.hpp
@@ -241,7 +241,7 @@ private:
     ProbabilityWeightFunction *pdf;
 
     double jump;
-    BasePDF **corrections;
+    std::vector<BasePDF*> corrections;
 
     bool state_initialized, values_initialized, values_logform;
     //double *old_state, *new_pdf_values;

--- a/DREAM/TasmanianDREAM.hpp
+++ b/DREAM/TasmanianDREAM.hpp
@@ -31,6 +31,8 @@
 #ifndef __TASMANIAN_DREAM_HPP
 #define __TASMANIAN_DREAM_HPP
 
+#include <vector>
+
 #include "TasmanianSparseGrid.hpp"
 
 #include "tdrEnumerates.hpp"
@@ -208,6 +210,7 @@ public:
 
     // read/write chain state
     void setChainState(const double* state);
+    void setChainState(const std::vector<double> state);
     //void clearPDFValues(); // delete cached pdf values, use when the state has been saved from a different pdf
 
     void setProbabilityWeightFunction(ProbabilityWeightFunction *probability_weight);
@@ -217,6 +220,8 @@ public:
     //      TasmanianDREAM class does not call delete on the pointer
 
     double* collectSamples(int num_burnup, int num_samples, bool useLogForm = false);
+    void collectSamples(int num_burnup, int num_samples, double *samples, bool useLogForm = false);
+    void collectSamples(int num_burnup, int num_samples, std::vector<double> &samples, bool useLogForm = false);
     double* getPDFHistory() const;
 
 protected:
@@ -231,16 +236,17 @@ private:
     double jump;
     BasePDF **corrections;
 
-    double *chain_state, *pdf_values, *old_state, *new_pdf_values;
+    bool state_initialized, values_initialized, values_logform;
+    //double *old_state, *new_pdf_values;
+    std::vector<double> chain_state, pdf_values, new_pdf_values, old_state;
 
-    bool *isBoudnedBelow, *isBoudnedAbove;
-    double *boundBelow, *boundAbove;
+    std::vector<bool> isBoudnedBelow, isBoudnedAbove;
+    std::vector<double> boundBelow, boundAbove;
 
     const BaseUniform *core;
     CppUniformSampler unifrom_cpp;
 
-    int num_pdf_history;
-    double *pdf_history;
+    std::vector<double> pdf_history;
 
     std::ostream *logstream;
 };

--- a/DREAM/TasmanianDREAM.hpp
+++ b/DREAM/TasmanianDREAM.hpp
@@ -161,7 +161,7 @@ class LikelihoodTSG : public ProbabilityWeightFunction{
 public:
     LikelihoodTSG(const TasGrid::TasmanianSparseGrid *likely, bool savedLogForm, std::ostream *os = 0);
     ~LikelihoodTSG();
-    void setPDF(int dimension, BasePDF* &pdf);
+    void setPDF(int dimension, BasePDF* pdf);
 
     void setErrorLog(std::ostream *os);
 
@@ -179,7 +179,8 @@ private:
     bool savedLogarithmForm;
 
     int num_dimensions;
-    std::vector<BasePDF*> priors;
+    std::vector<BasePDF*> internal_priors;
+    std::vector<BasePDF*> active_priors;
 
     std::ostream *logstream;
 };

--- a/DREAM/TasmanianDREAM.hpp
+++ b/DREAM/TasmanianDREAM.hpp
@@ -71,8 +71,10 @@ public:
     virtual void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm) = 0;
     // in most cases evaluate should be const, but for caching purposes you may want it to be not a const function
 
-    virtual void getDomainBounds(bool* lower_bound, bool* upper_bound) = 0;
-    virtual void getDomainBounds(double* lower_bound, double* upper_bound) = 0;
+    virtual void getDomainBounds(bool* lower_bound, bool* upper_bound);
+    virtual void getDomainBounds(double* lower_bound, double* upper_bound);
+    virtual void getDomainBounds(std::vector<bool> &lower, std::vector<bool> &upper) = 0;
+    virtual void getDomainBounds(std::vector<double> &lower, std::vector<double> &upper) = 0;
     virtual void getInitialSample(double x[]) = 0;
 };
 
@@ -99,8 +101,8 @@ public:
     void setLikelihood(BaseLikelihood *likelihood);
     void setData(int num_data_samples, const double *posterior_data);
 
-    void getDomainBounds(bool* lower_bound, bool* upper_bound);
-    void getDomainBounds(double* lower_bound, double* upper_bound);
+    void getDomainBounds(std::vector<bool> &lower, std::vector<bool> &upper);
+    void getDomainBounds(std::vector<double> &lower, std::vector<double> &upper);
 
 private:
     const TasGrid::TasmanianSparseGrid *grid;
@@ -136,8 +138,8 @@ public:
 
     void setNumChanis(int num_dream_chains); // needed for MPI communication purposes
 
-    void getDomainBounds(bool* lower_bound, bool* upper_bound);
-    void getDomainBounds(double* lower_bound, double* upper_bound);
+    void getDomainBounds(std::vector<bool> &lower, std::vector<bool> &upper);
+    void getDomainBounds(std::vector<double> &lower, std::vector<double> &upper);
 
     void workerLoop(bool useLogForm);
     void endWorkerLoop();
@@ -169,8 +171,8 @@ public:
 
     void getInitialSample(double x[]);
 
-    void getDomainBounds(bool* lower_bound, bool* upper_bound);
-    void getDomainBounds(double* lower_bound, double* upper_bound);
+    void getDomainBounds(std::vector<bool> &lower, std::vector<bool> &upper);
+    void getDomainBounds(std::vector<double> &lower, std::vector<double> &upper);
 
 private:
     const TasGrid::TasmanianSparseGrid *grid;

--- a/DREAM/TasmanianDREAM.hpp
+++ b/DREAM/TasmanianDREAM.hpp
@@ -109,8 +109,8 @@ private:
     const CustomModelWrapper *cmodel;
 
     int num_dimensions, num_outputs;
-    BasePDF **priors;
-    bool *priors_created_here;
+    std::vector<BasePDF*> priors;
+    std::vector<bool> priors_created_here;
 
     int num_data;
     const double *data;
@@ -179,7 +179,7 @@ private:
     bool savedLogarithmForm;
 
     int num_dimensions;
-    BasePDF **priors;
+    std::vector<BasePDF*> priors;
 
     std::ostream *logstream;
 };

--- a/DREAM/tasdreamBenchmark.cpp
+++ b/DREAM/tasdreamBenchmark.cpp
@@ -215,15 +215,15 @@ void mpiBenchmarkBasicAlpha(int num_outputs, int depth, int num_chains, int num_
 
     if (mpi_me == 0){
 
-        TasmanianDREAM *dream = new TasmanianDREAM();
-        dream->setProbabilityWeightFunction(dist);
+        TasmanianDREAM dream;
+        dream.setProbabilityWeightFunction(dist);
 
-        dream->setNumChains(num_chains);
+        dream.setNumChains(num_chains);
         GaussianPDF gauss(0.0, 0.01);
-        dream->setCorrectionAll(&gauss);
+        dream.setCorrectionAll(&gauss);
 
         int start_time = (int) time(0);
-        double *mcmc = dream->collectSamples(num_burnup, num_mcmc, useLogForm);
+        double *mcmc = dream.collectSamples(num_burnup, num_mcmc, useLogForm);
         int end_time = (int) time(0);
 
         cout << "Elapsed time: " << end_time - start_time << endl;
@@ -231,6 +231,8 @@ void mpiBenchmarkBasicAlpha(int num_outputs, int depth, int num_chains, int num_
         if (outfilename != 0){
             writeMatrix(outfilename, num_mcmc*num_chains, grid->getNumDimensions(), mcmc);
         }
+
+        delete[] mcmc;
 
     }else{
         dist->workerLoop(useLogForm); // main runs the chains, the rest wait in a loop only to evaluate the likelihood

--- a/DREAM/tasdreamExternalTests.cpp
+++ b/DREAM/tasdreamExternalTests.cpp
@@ -164,11 +164,11 @@ bool ExternalTester::testBeta1D(){
 
     int num_cells = 10; double delta = 2.0 / ((double) num_cells);
     int num_chains = 50;
-    double *samples_true = new double[num_mc];
-    TasDREAM::BetaPDF *Btrue = new TasDREAM::BetaPDF(-1.0, 1.0, 2.0, 5.0);
-    Btrue->overwriteBaseUnifrom(&rng);
+    std::vector<double> samples_true(num_mc);
+    TasDREAM::BetaPDF Btrue(-1.0, 1.0, 2.0, 5.0);
+    Btrue.overwriteBaseUnifrom(&rng);
 
-    for(int i=0; i<num_mc; i++) samples_true[i] = Btrue->getSample();
+    for(int i=0; i<num_mc; i++) samples_true[i] = Btrue.getSample();
 
     TasDREAM::TasmanianDREAM dream;
     dream.overwriteBaseUnifrom(&rng);
@@ -178,12 +178,13 @@ bool ExternalTester::testBeta1D(){
     gauss.overwriteBaseUnifrom(&rng);
     dream.setCorrectionAll(&gauss);
 
-    double *samples_dream = dream.collectSamples(3*num_mc, num_mc / num_chains, false);
+    std::vector<double> samples_dream;
+    dream.collectSamples(3*num_mc, num_mc / num_chains, samples_dream, false);
     //for(int i=0; i<num_mc; i++) samples_dream[i] = -1.0 + 2.0 * u.getSample01();
     //for(int i=0; i<num_mc; i++) cout << samples_dream[i] << endl;
 
-    int *cells_a = new int[num_cells]; std::fill(cells_a, cells_a + num_cells, 0);
-    int *cells_b = new int[num_cells]; std::fill(cells_b, cells_b + num_cells, 0);
+    std::vector<int> cells_a(num_cells, 0);
+    std::vector<int> cells_b(num_cells, 0);
     for(int i=0; i<num_mc; i++){
         int c = floor((samples_true[i] + 1.0) / delta);
         if (c < num_cells) cells_a[c]++;
@@ -195,18 +196,12 @@ bool ExternalTester::testBeta1D(){
 
     bool pass = true;
 
-    if (testKS(num_cells, cells_a, cells_b)){
+    if (testKS(num_cells, cells_a.data(), cells_b.data())){
         cout << setw(wfirst) << "Distribution" << setw(wsecond) << "Beta 1D" << setw(wthird) << "Pass" << endl;
     }else{
         cout << setw(wfirst) << "Distribution" << setw(wsecond) << "Beta 1D" << setw(wthird) << "FAIL" << endl;
         pass = false;
     }
-
-    delete Btrue;
-    delete[] samples_dream;
-    delete[] samples_true;
-    delete[] cells_a;
-    delete[] cells_b;
 
     return pass;
 }

--- a/DREAM/tasdreamExternalTests.cpp
+++ b/DREAM/tasdreamExternalTests.cpp
@@ -120,7 +120,7 @@ bool ExternalTester::testUniform1D(){
 
     int num_cells = 16; double delta = 2.0 / ((double) num_cells);
     int num_chains = 50;
-    double *samples_true = new double[num_mc];
+    std::vector<double> samples_true(num_mc);
     for(int i=0; i<num_mc; i++) samples_true[i] = -1.0 + 2.0 * rng.getSample01();
 
     TasDREAM::TasmanianDREAM dream;
@@ -131,11 +131,12 @@ bool ExternalTester::testUniform1D(){
     gauss.overwriteBaseUnifrom(&rng);
     dream.setCorrectionAll(&gauss);
 
-    double *samples_dream = dream.collectSamples(3*num_mc, num_mc / num_chains, false);
+    std::vector<double> samples_dream;
+    dream.collectSamples(3*num_mc, num_mc / num_chains, samples_dream, false);
     //for(int i=0; i<num_mc; i++) samples_dream[i] = -1.0 + 2.0 * u.getSample01();
 
-    int *cells_a = new int[num_cells]; std::fill(cells_a, cells_a + num_cells, 0);
-    int *cells_b = new int[num_cells]; std::fill(cells_b, cells_b + num_cells, 0);
+    std::vector<int> cells_a(num_cells, 0);
+    std::vector<int> cells_b(num_cells, 0);
     for(int i=0; i<num_mc; i++){
         int c = floor((samples_true[i] + 1.0) / delta);
         if (c < num_cells) cells_a[c]++;
@@ -147,17 +148,12 @@ bool ExternalTester::testUniform1D(){
 
     bool pass = true;
 
-    if (testKS(num_cells, cells_a, cells_b)){
+    if (testKS(num_cells, cells_a.data(), cells_b.data())){
         cout << setw(wfirst) << "Distribution" << setw(wsecond) << "Uniform 1D" << setw(wthird) << "Pass" << endl;
     }else{
         cout << setw(wfirst) << "Distribution" << setw(wsecond) << "Uniform 1D" << setw(wthird) << "FAIL" << endl;
         pass = false;
     }
-
-    delete[] samples_dream;
-    delete[] samples_true;
-    delete[] cells_a;
-    delete[] cells_b;
 
     return pass;
 }

--- a/DREAM/tasdreamExternalTests.cpp
+++ b/DREAM/tasdreamExternalTests.cpp
@@ -212,11 +212,11 @@ bool ExternalTester::testGamma1D(){
 
     int num_cells = 20; double delta = 10.0 / ((double) num_cells);
     int num_chains = 50;
-    double *samples_true = new double[num_mc];
-    TasDREAM::GammaPDF *Gtrue = new TasDREAM::GammaPDF(-2.0, 9.0, 2.0);
-    Gtrue->overwriteBaseUnifrom(&rng);
+    std::vector<double> samples_true(num_mc);
+    TasDREAM::GammaPDF Gtrue(-2.0, 9.0, 2.0);
+    Gtrue.overwriteBaseUnifrom(&rng);
 
-    for(int i=0; i<num_mc; i++) samples_true[i] = Gtrue->getSample();
+    for(int i=0; i<num_mc; i++) samples_true[i] = Gtrue.getSample();
 
     TasDREAM::TasmanianDREAM dream;
     dream.overwriteBaseUnifrom(&rng);
@@ -230,8 +230,8 @@ bool ExternalTester::testGamma1D(){
     //for(int i=0; i<num_mc; i++) samples_dream[i] = -1.0 + 2.0 * u.getSample01();
     //for(int i=0; i<num_mc; i++) cout << samples_dream[i] << endl;
 
-    int *cells_a = new int[num_cells+1]; std::fill(cells_a, cells_a + num_cells + 1, 0);
-    int *cells_b = new int[num_cells+1]; std::fill(cells_b, cells_b + num_cells + 1, 0);
+    std::vector<int> cells_a(num_cells+1, 0);
+    std::vector<int> cells_b(num_cells+1, 0);
     for(int i=0; i<num_mc; i++){
         int c = floor((samples_true[i] + 2.0) / delta);
         if (c < num_cells) cells_a[c]++;
@@ -247,18 +247,14 @@ bool ExternalTester::testGamma1D(){
     bool pass = true;
 
     //if (testChi(num_cells+1, cells_a, cells_b)){
-    if (testKS(num_cells+1, cells_a, cells_b)){
+    if (testKS(num_cells+1, cells_a.data(), cells_b.data())){
         cout << setw(wfirst) << "Distribution" << setw(wsecond) << "Gamma 1D" << setw(wthird) << "Pass" << endl;
     }else{
         cout << setw(wfirst) << "Distribution" << setw(wsecond) << "Gamma 1D" << setw(wthird) << "FAIL" << endl;
         pass = false;
     }
 
-    delete Gtrue;
     delete[] samples_dream;
-    delete[] samples_true;
-    delete[] cells_a;
-    delete[] cells_b;
 
     return pass;
 }

--- a/DREAM/tasdreamTestPDFs.cpp
+++ b/DREAM/tasdreamTestPDFs.cpp
@@ -40,8 +40,18 @@ void UnscaledUniform1D::evaluate(const std::vector<double> x, std::vector<double
     if (y.size() < x.size()) y.resize(x.size());
     for(size_t i=0; i<x.size(); i++) y[i] = 1.0;
 }
-void UnscaledUniform1D::getDomainBounds(bool* lower_bound, bool* upper_bound){ lower_bound[0] = true; upper_bound[0] = true; }
-void UnscaledUniform1D::getDomainBounds(double* lower_bound, double* upper_bound){ lower_bound[0] = -1.0; upper_bound[0] = 1.0; }
+void UnscaledUniform1D::getDomainBounds(std::vector<bool> &lower, std::vector<bool> &upper){
+    if (lower.size() < 1) lower.resize(1);
+    if (upper.size() < 1) upper.resize(1);
+    lower[0] = true; // Gaussian is unbounded
+    upper[0] = true;
+}
+void UnscaledUniform1D::getDomainBounds(std::vector<double> &lower, std::vector<double> &upper){
+    if (lower.size() < 1) lower.resize(1);
+    if (upper.size() < 1) upper.resize(1);
+    lower[0] = -1.0; // since bounds above give false,
+    upper[0] =  1.0;
+}
 void UnscaledUniform1D::getInitialSample(double y[]){ y[0] = -1.0 + 2.0 * u.getSample01(); }
 
 Beta1D::Beta1D(){
@@ -60,6 +70,8 @@ void Beta1D::evaluate(int num_points, const double x[], double y[], bool useLogF
 void Beta1D::evaluate(const std::vector<double>, std::vector<double> &, bool){} // test backward compatibility
 void Beta1D::getDomainBounds(bool* lower_bound, bool* upper_bound){ lower_bound[0] = true; upper_bound[0] = true; }
 void Beta1D::getDomainBounds(double* lower_bound, double* upper_bound){ lower_bound[0] = -1.0; upper_bound[0] = 1.0; }
+void Beta1D::getDomainBounds(std::vector<bool> &, std::vector<bool> &){}
+void Beta1D::getDomainBounds(std::vector<double> &, std::vector<double> &){}
 void Beta1D::getInitialSample(double y[]){ y[0] = -1.0 + 2.0 * u.getSample01(); }
 
 Gamma1D::Gamma1D(){
@@ -76,8 +88,18 @@ void Gamma1D::evaluate(const std::vector<double> x, std::vector<double> &y, bool
         for(int i=0; i<num_points; i++) y[i] = g->getDensity(x[i]);
     }
 }
-void Gamma1D::getDomainBounds(bool* lower_bound, bool* upper_bound){ lower_bound[0] = true; upper_bound[0] = false; }
-void Gamma1D::getDomainBounds(double* lower_bound, double* upper_bound){ lower_bound[0] = -2.0; upper_bound[0] = 0.0; }
+void Gamma1D::getDomainBounds(std::vector<bool> &lower, std::vector<bool> &upper){
+    if (lower.size() < 1) lower.resize(1);
+    if (upper.size() < 1) upper.resize(1);
+    lower[0] = true;
+    upper[0] = false;
+}
+void Gamma1D::getDomainBounds(std::vector<double> &lower, std::vector<double> &upper){
+    if (lower.size() < 1) lower.resize(1);
+    if (upper.size() < 1) upper.resize(1);
+    lower[0] = -2.0;
+    upper[0] =  0.0;
+}
 void Gamma1D::getInitialSample(double y[]){ y[0] = -1.0 + 10.0 * u.getSample01(); }
 
 Gaussian2D::Gaussian2D(){
@@ -95,13 +117,17 @@ void Gaussian2D::evaluate(const std::vector<double> x, std::vector<double> &y, b
         for(int i=0; i<num_points; i++) y[i] = g1->getDensity(x[2*i]) * g2->getDensity(x[2*i+1]);
     }
 }
-void Gaussian2D::getDomainBounds(bool* lower_bound, bool* upper_bound){
-    lower_bound[0] = true; upper_bound[0] = true;
-    lower_bound[1] = true; upper_bound[1] = true;
+void Gaussian2D::getDomainBounds(std::vector<bool> &lower, std::vector<bool> &upper){
+    if (lower.size() < 2) lower.resize(2);
+    if (upper.size() < 2) upper.resize(2);
+    lower[0] = true; lower[1] = true;
+    upper[0] = true; upper[1] = true;
 }
-void Gaussian2D::getDomainBounds(double* lower_bound, double* upper_bound){
-    lower_bound[0] = -1.0; upper_bound[0] = 1.0;
-    lower_bound[1] = -1.0; upper_bound[1] = 1.0;
+void Gaussian2D::getDomainBounds(std::vector<double> &lower, std::vector<double> &upper){
+    if (lower.size() < 2) lower.resize(2);
+    if (upper.size() < 2) upper.resize(2);
+    lower[0] = -1.0; lower[1] = -1.0;
+    upper[0] =  1.0; upper[1] =  1.0;
 }
 void Gaussian2D::getInitialSample(double x[]){
     x[0] = -1.0 + 2.0 * u.getSample01();

--- a/DREAM/tasdreamTestPDFs.cpp
+++ b/DREAM/tasdreamTestPDFs.cpp
@@ -36,7 +36,10 @@
 UnscaledUniform1D::UnscaledUniform1D(){}
 UnscaledUniform1D::~UnscaledUniform1D(){}
 int UnscaledUniform1D::getNumDimensions() const{ return 1; }
-void UnscaledUniform1D::evaluate(int num_points, const double*, double y[], bool){ for(int i=0; i<num_points; i++) y[i] = 1.0; }
+void UnscaledUniform1D::evaluate(const std::vector<double> x, std::vector<double> &y, bool){
+    if (y.size() < x.size()) y.resize(x.size());
+    for(size_t i=0; i<x.size(); i++) y[i] = 1.0;
+}
 void UnscaledUniform1D::getDomainBounds(bool* lower_bound, bool* upper_bound){ lower_bound[0] = true; upper_bound[0] = true; }
 void UnscaledUniform1D::getDomainBounds(double* lower_bound, double* upper_bound){ lower_bound[0] = -1.0; upper_bound[0] = 1.0; }
 void UnscaledUniform1D::getInitialSample(double y[]){ y[0] = -1.0 + 2.0 * u.getSample01(); }
@@ -45,6 +48,7 @@ Beta1D::Beta1D(){
     b = new TasDREAM::BetaPDF(-1.0, 1.0, 2.0, 5.0);
 }
 Beta1D::~Beta1D(){ delete b; }
+int Beta1D::getAPIversion() const{ return 5; }
 int Beta1D::getNumDimensions() const{ return 1; }
 void Beta1D::evaluate(int num_points, const double x[], double y[], bool useLogForm){
     if (useLogForm){
@@ -53,6 +57,7 @@ void Beta1D::evaluate(int num_points, const double x[], double y[], bool useLogF
         for(int i=0; i<num_points; i++) y[i] = b->getDensity(x[i]);
     }
 }
+void Beta1D::evaluate(const std::vector<double>, std::vector<double> &, bool){} // test backward compatibility
 void Beta1D::getDomainBounds(bool* lower_bound, bool* upper_bound){ lower_bound[0] = true; upper_bound[0] = true; }
 void Beta1D::getDomainBounds(double* lower_bound, double* upper_bound){ lower_bound[0] = -1.0; upper_bound[0] = 1.0; }
 void Beta1D::getInitialSample(double y[]){ y[0] = -1.0 + 2.0 * u.getSample01(); }
@@ -62,7 +67,9 @@ Gamma1D::Gamma1D(){
 }
 Gamma1D::~Gamma1D(){ delete g; }
 int Gamma1D::getNumDimensions() const{ return 1; }
-void Gamma1D::evaluate(int num_points, const double x[], double y[], bool useLogForm){
+void Gamma1D::evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm){
+    int num_points = x.size();
+    if (y.size() < x.size()) y.resize(x.size());
     if (useLogForm){
         for(int i=0; i<num_points; i++) y[i] = g->getDensityLog(x[i]);
     }else{
@@ -79,8 +86,9 @@ Gaussian2D::Gaussian2D(){
 }
 Gaussian2D::~Gaussian2D(){ delete g1; delete g2; }
 int Gaussian2D::getNumDimensions() const{ return 2; }
-void Gaussian2D::evaluate(int num_points, const double x[], double y[], bool useLogForm){
-    //cout << "Eval called" << endl;
+void Gaussian2D::evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm){
+    int num_points = x.size() / 2;
+    if (y.size() < x.size()) y.resize(x.size());
     if (useLogForm){
         for(int i=0; i<num_points; i++) y[i] = g1->getDensityLog(x[2*i]) + g2->getDensityLog(x[2*i+1]);
     }else{

--- a/DREAM/tasdreamTestPDFs.hpp
+++ b/DREAM/tasdreamTestPDFs.hpp
@@ -47,8 +47,8 @@ public:
     ~UnscaledUniform1D();
     int getNumDimensions() const;
     void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm);
-    void getDomainBounds(bool* lower_bound, bool* upper_bound);
-    void getDomainBounds(double* lower_bound, double* upper_bound);
+    void getDomainBounds(std::vector<bool> &lower, std::vector<bool> &upper);
+    void getDomainBounds(std::vector<double> &lower, std::vector<double> &upper);
     void getInitialSample(double x[]);
 private:
     TasDREAM::CppUniformSampler u;
@@ -66,6 +66,8 @@ public:
     void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm);
     void getDomainBounds(bool* lower_bound, bool* upper_bound);
     void getDomainBounds(double* lower_bound, double* upper_bound);
+    void getDomainBounds(std::vector<bool> &lower, std::vector<bool> &upper);
+    void getDomainBounds(std::vector<double> &lower, std::vector<double> &upper);
     void getInitialSample(double x[]);
 private:
     TasDREAM::BetaPDF *b;
@@ -78,8 +80,8 @@ public:
     ~Gamma1D();
     int getNumDimensions() const;
     void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm);
-    void getDomainBounds(bool* lower_bound, bool* upper_bound);
-    void getDomainBounds(double* lower_bound, double* upper_bound);
+    void getDomainBounds(std::vector<bool> &lower, std::vector<bool> &upper);
+    void getDomainBounds(std::vector<double> &lower, std::vector<double> &upper);
     void getInitialSample(double x[]);
 private:
     TasDREAM::GammaPDF *g;
@@ -92,8 +94,8 @@ public:
     ~Gaussian2D();
     int getNumDimensions() const;
     void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm);
-    void getDomainBounds(bool* lower_bound, bool* upper_bound);
-    void getDomainBounds(double* lower_bound, double* upper_bound);
+    void getDomainBounds(std::vector<bool> &lower, std::vector<bool> &upper);
+    void getDomainBounds(std::vector<double> &lower, std::vector<double> &upper);
     void getInitialSample(double x[]);
 private:
     TasDREAM::TruncatedGaussianPDF *g1, *g2;

--- a/DREAM/tasdreamTestPDFs.hpp
+++ b/DREAM/tasdreamTestPDFs.hpp
@@ -46,7 +46,7 @@ public:
     UnscaledUniform1D();
     ~UnscaledUniform1D();
     int getNumDimensions() const;
-    void evaluate(int num_points, const double x[], double y[], bool useLogForm);
+    void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm);
     void getDomainBounds(bool* lower_bound, bool* upper_bound);
     void getDomainBounds(double* lower_bound, double* upper_bound);
     void getInitialSample(double x[]);
@@ -58,8 +58,12 @@ class Beta1D : public TasDREAM::ProbabilityWeightFunction{
 public:
     Beta1D();
     ~Beta1D();
+    int getAPIversion() const;
+
     int getNumDimensions() const;
+
     void evaluate(int num_points, const double x[], double y[], bool useLogForm);
+    void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm);
     void getDomainBounds(bool* lower_bound, bool* upper_bound);
     void getDomainBounds(double* lower_bound, double* upper_bound);
     void getInitialSample(double x[]);
@@ -73,7 +77,7 @@ public:
     Gamma1D();
     ~Gamma1D();
     int getNumDimensions() const;
-    void evaluate(int num_points, const double x[], double y[], bool useLogForm);
+    void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm);
     void getDomainBounds(bool* lower_bound, bool* upper_bound);
     void getDomainBounds(double* lower_bound, double* upper_bound);
     void getInitialSample(double x[]);
@@ -87,7 +91,7 @@ public:
     Gaussian2D();
     ~Gaussian2D();
     int getNumDimensions() const;
-    void evaluate(int num_points, const double x[], double y[], bool useLogForm);
+    void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm);
     void getDomainBounds(bool* lower_bound, bool* upper_bound);
     void getDomainBounds(double* lower_bound, double* upper_bound);
     void getInitialSample(double x[]);

--- a/DREAM/tdrCorePDF.cpp
+++ b/DREAM/tdrCorePDF.cpp
@@ -258,8 +258,10 @@ double BetaPDF::getDensityLog(double x) const{
 }
 TypeDistribution BetaPDF::getType() const{ return dist_beta; }
 
-void SparseGridDomainToPDF::assumeDefaultPDF(const TasGrid::TasmanianSparseGrid *grid, BasePDF **priors){
+void SparseGridDomainToPDF::assumeDefaultPDF(const TasGrid::TasmanianSparseGrid *grid, std::vector<BasePDF*> &priors){
     int num_dimensions = grid->getNumDimensions();
+    if (priors.size() < (size_t) num_dimensions) priors.resize(num_dimensions);
+
     TasGrid::TypeOneDRule rule = grid->getRule();
 
     std::vector<double> a, b;

--- a/DREAM/tdrCorePDF.cpp
+++ b/DREAM/tdrCorePDF.cpp
@@ -258,9 +258,6 @@ double BetaPDF::getDensityLog(double x) const{
 }
 TypeDistribution BetaPDF::getType() const{ return dist_beta; }
 
-SparseGridDomainToPDF::SparseGridDomainToPDF(){}
-SparseGridDomainToPDF::~SparseGridDomainToPDF(){}
-
 void SparseGridDomainToPDF::assumeDefaultPDF(const TasGrid::TasmanianSparseGrid *grid, BasePDF **priors){
     int num_dimensions = grid->getNumDimensions();
     TasGrid::TypeOneDRule rule = grid->getRule();

--- a/DREAM/tdrCorePDF.cpp
+++ b/DREAM/tdrCorePDF.cpp
@@ -262,10 +262,8 @@ void SparseGridDomainToPDF::assumeDefaultPDF(const TasGrid::TasmanianSparseGrid 
     int num_dimensions = grid->getNumDimensions();
     TasGrid::TypeOneDRule rule = grid->getRule();
 
-    double *a = 0, *b = 0;
+    std::vector<double> a, b;
     if (grid->isSetDomainTransfrom()){
-        a = new double[num_dimensions];
-        b = new double[num_dimensions];
         grid->getDomainTransform(a, b);
     }
 
@@ -294,9 +292,6 @@ void SparseGridDomainToPDF::assumeDefaultPDF(const TasGrid::TasmanianSparseGrid 
             for(int i=0; i<num_dimensions; i++) priors[i] = new UniformPDF(-1.0, 1.0);
         }
     }
-
-    if (a != 0) delete[] a;
-    if (b != 0) delete[] b;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/DREAM/tdrCorePDF.hpp
+++ b/DREAM/tdrCorePDF.hpp
@@ -260,7 +260,7 @@ private:
 };
 
 namespace SparseGridDomainToPDF{
-    void assumeDefaultPDF(const TasGrid::TasmanianSparseGrid *grid, BasePDF **priors);
+    void assumeDefaultPDF(const TasGrid::TasmanianSparseGrid *grid, std::vector<BasePDF*> &priors);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/DREAM/tdrCorePDF.hpp
+++ b/DREAM/tdrCorePDF.hpp
@@ -259,13 +259,9 @@ private:
     CppUniformSampler unifrom_cpp;
 };
 
-class SparseGridDomainToPDF{
-public:
-    SparseGridDomainToPDF();
-    ~SparseGridDomainToPDF();
-
-    static void assumeDefaultPDF(const TasGrid::TasmanianSparseGrid *grid, BasePDF **priors);
-};
+namespace SparseGridDomainToPDF{
+    void assumeDefaultPDF(const TasGrid::TasmanianSparseGrid *grid, BasePDF **priors);
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
* `std::vector` API for DREAM and most internal arrays are converted
* old API is still supported with implementing `int getAPIversion()` that returns `5` or less
* if using API version prior to 6, the vector functions can be left empty
* the new API applies to classes inheriting from `ProbabilityWeightFunction` and `CustomModelWrapper`
* many rests and internal API has also been converted to `std::vectors`