### PR TITLE
Fix warnings

### DIFF
--- a/DREAM/Examples/example_dream.cpp
+++ b/DREAM/Examples/example_dream.cpp
@@ -17,7 +17,7 @@ int main(int argc, const char**){
  *
  */
 
-    srand(time(0));
+    srand((int) time(0));
 
     bool limit_examples = false;
     if (argc > 1){
@@ -43,13 +43,13 @@ int main(int argc, const char**){
         ~UnscaledPDF(){}
         int getNumDimensions() const{ return 1; }
         void evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm){
-            int num_points = x.size();
-            if (y.size() < (size_t) num_points) y.resize(num_points);
-            for(int i=0; i<num_points; i++){ // set the pdf values
+            size_t num_points = x.size();
+            if (y.size() < num_points) y.resize(num_points);
+            for(size_t i=0; i<num_points; i++){ // set the pdf values
                 y[i] = -0.5 * x[i] * x[i];
             }
             if (!useLogForm){
-                for(int i=0; i<num_points; i++){ // take exponential (if not working with logForm)
+                for(size_t i=0; i<num_points; i++){ // take exponential (if not working with logForm)
                     y[i] = exp(y[i]);
                 }
             }
@@ -579,9 +579,9 @@ int main(int argc, const char**){
         int getNumDimensions() const{ return 2; }
         int getNumOutputs() const{ return N; }
         void evaluate(const std::vector<double> x, std::vector<double> &y) const{
-            int num_points = x.size() / 2;
-            if (y.size() < (size_t) (N * num_points)) y.resize(N * num_points);
-            for(int i=0; i<num_points; i++){
+            size_t num_points = x.size() / 2;
+            if (y.size() < N * num_points) y.resize(N * num_points);
+            for(size_t i=0; i<num_points; i++){
                 for(int j=0; j<N; j++){
                     y[i*N + j] = sin(x[2*i] * M_PI * (dt2 + j*dt) + x[2*i+1]);
                 }
@@ -704,9 +704,9 @@ int main(int argc, const char**){
         int getNumDimensions() const{ return 6; }
         int getNumOutputs() const{ return N; }
         void evaluate(const std::vector<double> x, std::vector<double> &y) const{
-            int num_points = x.size() / 2;
-            if (y.size() < (size_t) (N * num_points)) y.resize(N * num_points);
-            for(int i=0; i<num_points; i++){
+            size_t num_points = x.size() / 2;
+            if (y.size() < N * num_points) y.resize(N * num_points);
+            for(size_t i=0; i<num_points; i++){
                 for(int j=0; j<N; j++){
                     double t = snap[j];
                     y[i*N + j] = x[6*i];

--- a/DREAM/TasmanianDREAM.cpp
+++ b/DREAM/TasmanianDREAM.cpp
@@ -96,7 +96,7 @@ void PosteriorFromModel::setErrorLog(std::ostream *os){ logstream = os; }
 int PosteriorFromModel::getNumDimensions() const{ return num_dimensions; }
 
 void PosteriorFromModel::evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm){
-    int num_points = x.size() / num_dimensions;
+    size_t num_points = x.size() / num_dimensions;
 
     std::vector<double> model_output;
     if (grid != 0){
@@ -108,21 +108,21 @@ void PosteriorFromModel::evaluate(const std::vector<double> x, std::vector<doubl
     }else{
         if (cmodel->getAPIversion() < 6){
             model_output.resize(num_points * num_outputs);
-            cmodel->evaluate(x.data(), num_points, model_output.data()); // fastest
+            cmodel->evaluate(x.data(), (int) num_points, model_output.data()); // fastest
         }else{
             cmodel->evaluate(x, model_output);
         }
     }
 
-    if (y.size() < (size_t) num_points) y.resize(num_points);
-    likely->getLikelihood(num_points, model_output.data(), num_data, data, y.data(), useLogForm);
+    if (y.size() < num_points) y.resize(num_points);
+    likely->getLikelihood((int) num_points, model_output.data(), num_data, data, y.data(), useLogForm);
 
     if (useLogForm){
-        for(int i=0; i<num_points; i++){
+        for(size_t i=0; i<num_points; i++){
             for(int j=0; j<num_dimensions; j++) y[i] += active_priors[j]->getDensityLog(x[i*num_dimensions +j]);
         }
     }else{
-        for(int i=0; i<num_points; i++){
+        for(size_t i=0; i<num_points; i++){
             for(int j=0; j<num_dimensions; j++) y[i] *= active_priors[j]->getDensity(x[i*num_dimensions +j]);
         }
     }
@@ -254,7 +254,7 @@ void LikelihoodTSG::setErrorLog(std::ostream *os){ logstream = os; }
 int LikelihoodTSG::getNumDimensions() const{ return num_dimensions; }
 
 void LikelihoodTSG::evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm){
-    int num_points = x.size() / num_dimensions;
+    size_t num_points = x.size() / num_dimensions;
 
     grid->evaluateBatch(x, y); // fastest
 //    for(int i=0; i<num_points; i++){
@@ -263,18 +263,18 @@ void LikelihoodTSG::evaluate(const std::vector<double> x, std::vector<double> &y
 //    }
     if (savedLogarithmForm ^ useLogForm){ // using form other than the one saved
         if (savedLogarithmForm){
-            for(int i=0; i<num_points; i++) y[i] = exp(y[i]);
+            for(size_t i=0; i<num_points; i++) y[i] = exp(y[i]);
         }else{
-            for(int i=0; i<num_points; i++) y[i] = log(y[i]);
+            for(size_t i=0; i<num_points; i++) y[i] = log(y[i]);
         }
     }
 
     if (useLogForm){
-        for(int i=0; i<num_points; i++){
+        for(size_t i=0; i<num_points; i++){
             for(int j=0; j<num_dimensions; j++) y[i] += active_priors[j]->getDensityLog(x[i*num_dimensions +j]);
         }
     }else{
-        for(int i=0; i<num_points; i++){
+        for(size_t i=0; i<num_points; i++){
             for(int j=0; j<num_dimensions; j++) y[i] *= active_priors[j]->getDensity(x[i*num_dimensions +j]);
         }
     }
@@ -405,7 +405,7 @@ void TasmanianDREAM::setChainState(const double* state){
 }
 void TasmanianDREAM::setChainState(const std::vector<double> state){
     chain_state = state; // copy assignment
-    if (chain_state.size() != (size_t) (num_dimensions * num_chains)) num_chains = chain_state.size() / num_dimensions;
+    if (chain_state.size() != (size_t) (num_dimensions * num_chains)) num_chains = (int) (chain_state.size() / num_dimensions);
     state_initialized = true;
     values_initialized = false;
 }

--- a/DREAM/tasdreamExternalTests.cpp
+++ b/DREAM/tasdreamExternalTests.cpp
@@ -115,7 +115,7 @@ bool ExternalTester::Test(TestList test){
 }
 
 bool ExternalTester::testUniform1D(){
-    int s = (rngseed == -1) ? 12 : rngseed;
+    int s = (rngseed == -1) ? 12 : ((int) rngseed);
     TestRNG rng(s);
 
     int num_cells = 16; double delta = 2.0 / ((double) num_cells);
@@ -138,9 +138,9 @@ bool ExternalTester::testUniform1D(){
     std::vector<int> cells_a(num_cells, 0);
     std::vector<int> cells_b(num_cells, 0);
     for(int i=0; i<num_mc; i++){
-        int c = floor((samples_true[i] + 1.0) / delta);
+        int c = (int) floor((samples_true[i] + 1.0) / delta);
         if (c < num_cells) cells_a[c]++;
-        c = floor((samples_dream[i] + 1.0) / delta);
+        c = (int) floor((samples_dream[i] + 1.0) / delta);
         if (c < num_cells) cells_b[c]++;
         //if ( c >= num_cells ) cout << samples_dream[i] << endl;
     }
@@ -159,7 +159,7 @@ bool ExternalTester::testUniform1D(){
 }
 
 bool ExternalTester::testBeta1D(){
-    int s = (rngseed == -1) ? 12 : rngseed;
+    int s = (rngseed == -1) ? 12 : ((int) rngseed);
     TestRNG rng(s);
 
     int num_cells = 10; double delta = 2.0 / ((double) num_cells);
@@ -186,9 +186,9 @@ bool ExternalTester::testBeta1D(){
     std::vector<int> cells_a(num_cells, 0);
     std::vector<int> cells_b(num_cells, 0);
     for(int i=0; i<num_mc; i++){
-        int c = floor((samples_true[i] + 1.0) / delta);
+        int c = (int) floor((samples_true[i] + 1.0) / delta);
         if (c < num_cells) cells_a[c]++;
-        c = floor((samples_dream[i] + 1.0) / delta);
+        c = (int) floor((samples_dream[i] + 1.0) / delta);
         if (c < num_cells) cells_b[c]++;
         //if ( c >= num_cells ) cout << samples_dream[i] << endl;
     }
@@ -207,7 +207,7 @@ bool ExternalTester::testBeta1D(){
 }
 
 bool ExternalTester::testGamma1D(){
-    int s = (rngseed == -1) ? 12 : rngseed;
+    int s = (rngseed == -1) ? 12 : ((int) rngseed);
     TestRNG rng(s);
 
     int num_cells = 20; double delta = 10.0 / ((double) num_cells);
@@ -233,10 +233,10 @@ bool ExternalTester::testGamma1D(){
     std::vector<int> cells_a(num_cells+1, 0);
     std::vector<int> cells_b(num_cells+1, 0);
     for(int i=0; i<num_mc; i++){
-        int c = floor((samples_true[i] + 2.0) / delta);
+        int c = (int) floor((samples_true[i] + 2.0) / delta);
         if (c < num_cells) cells_a[c]++;
         if (c >= num_cells) cells_a[num_cells]++;
-        c = floor((samples_dream[i] + 2.0) / delta);
+        c = (int) floor((samples_dream[i] + 2.0) / delta);
         if (c < num_cells) cells_b[c]++;
         if (c >= num_cells) cells_b[num_cells]++;
         if (samples_dream[i] < -2.0 ) cout << "ERROR: bad value: " << samples_dream[i] << endl;
@@ -260,7 +260,7 @@ bool ExternalTester::testGamma1D(){
 }
 
 bool ExternalTester::testGaussian2D(){
-    int s = (rngseed == -1) ? 25 : rngseed;
+    int s = (rngseed == -1) ? 25 : ((int) rngseed);
     TestRNG rng(s);
 
     int num_cells1d = 4; double delta = 2.0 / ((double) num_cells1d);
@@ -289,13 +289,13 @@ bool ExternalTester::testGaussian2D(){
     std::vector<int> cells_b(num_cells, 0);
     for(int i=0; i<num_mc; i++){
         if ((fabs(samples_true[2*i]) > 1.0) || (fabs(samples_true[2*i+1]) > 1.0)) cout << "ERROR: bad value: " << samples_true[2*i] << "  " << samples_true[2*i + 1] << endl;
-        int cx = floor((samples_true[2*i  ] + 1.0) / delta);
-        int cy = floor((samples_true[2*i+1] + 1.0) / delta);
+        int cx = (int) floor((samples_true[2*i  ] + 1.0) / delta);
+        int cy = (int) floor((samples_true[2*i+1] + 1.0) / delta);
         cells_a[cx*num_cells1d + cy]++;
 
         if ((fabs(samples_dream[2*i]) > 1.0) || (fabs(samples_dream[2*i+1]) > 1.0)) cout << "ERROR: bad value: " << samples_dream[2*i] << "  " << samples_dream[2*i + 1] << endl;
-        cx = floor((samples_dream[2*i  ] + 1.0) / delta);
-        cy = floor((samples_dream[2*i+1] + 1.0) / delta);
+        cx = (int) floor((samples_dream[2*i  ] + 1.0) / delta);
+        cy = (int) floor((samples_dream[2*i+1] + 1.0) / delta);
         cells_b[cx*num_cells1d + cy]++;
     }
     //for(int i=0; i<num_cells; i++){ cout << cells_a[i] << "  " << cells_b[i] << endl; }
@@ -328,8 +328,8 @@ bool ExternalTester::testGaussian2D(){
     std::fill(cells_b.begin(), cells_b.end(), 0);
     for(int i=0; i<num_mc; i++){
         if ((fabs(samples_dream[2*i]) > 1.0) || (fabs(samples_dream[2*i+1]) > 1.0)) cout << "ERROR: bad value: " << samples_dream[2*i] << "  " << samples_dream[2*i + 1] << endl;
-        int cx = floor((samples_dream[2*i  ] + 1.0) / delta);
-        int cy = floor((samples_dream[2*i+1] + 1.0) / delta);
+        int cx = (int) floor((samples_dream[2*i  ] + 1.0) / delta);
+        int cy = (int) floor((samples_dream[2*i+1] + 1.0) / delta);
         cells_b[cx*num_cells1d + cy]++;
         //cout << samples_dream[2*i] << "  " << samples_dream[2*i+1] << endl;
     }
@@ -350,7 +350,7 @@ bool ExternalTester::testGaussian2D(){
 }
 
 bool ExternalTester::testModelLikelihoodAlpha(){
-    int s = (rngseed == -1) ? 12 : rngseed;
+    int s = (rngseed == -1) ? 12 : ((int) rngseed);
     TestRNG rng(s);
 
     // model sin(p_0 t M_PI + p_1), data cos(M_PI t) / cos(M_PI t) + cos(5 M_PI y)

--- a/DREAM/tasdreamExternalTests.hpp
+++ b/DREAM/tasdreamExternalTests.hpp
@@ -84,7 +84,7 @@ private:
     int num_mc;
     int wfirst, wsecond, wthird;
     bool verbose;
-    int rngseed;
+    long int rngseed;
 
     TasDREAM::CppUniformSampler u;
 

--- a/DREAM/tasdreamTestPDFs.cpp
+++ b/DREAM/tasdreamTestPDFs.cpp
@@ -80,12 +80,12 @@ Gamma1D::Gamma1D(){
 Gamma1D::~Gamma1D(){ delete g; }
 int Gamma1D::getNumDimensions() const{ return 1; }
 void Gamma1D::evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm){
-    int num_points = x.size();
+    size_t num_points = x.size();
     if (y.size() < x.size()) y.resize(x.size());
     if (useLogForm){
-        for(int i=0; i<num_points; i++) y[i] = g->getDensityLog(x[i]);
+        for(size_t i=0; i<num_points; i++) y[i] = g->getDensityLog(x[i]);
     }else{
-        for(int i=0; i<num_points; i++) y[i] = g->getDensity(x[i]);
+        for(size_t i=0; i<num_points; i++) y[i] = g->getDensity(x[i]);
     }
 }
 void Gamma1D::getDomainBounds(std::vector<bool> &lower, std::vector<bool> &upper){
@@ -109,12 +109,12 @@ Gaussian2D::Gaussian2D(){
 Gaussian2D::~Gaussian2D(){ delete g1; delete g2; }
 int Gaussian2D::getNumDimensions() const{ return 2; }
 void Gaussian2D::evaluate(const std::vector<double> x, std::vector<double> &y, bool useLogForm){
-    int num_points = x.size() / 2;
+    size_t num_points = x.size() / 2;
     if (y.size() < x.size()) y.resize(x.size());
     if (useLogForm){
-        for(int i=0; i<num_points; i++) y[i] = g1->getDensityLog(x[2*i]) + g2->getDensityLog(x[2*i+1]);
+        for(size_t i=0; i<num_points; i++) y[i] = g1->getDensityLog(x[2*i]) + g2->getDensityLog(x[2*i+1]);
     }else{
-        for(int i=0; i<num_points; i++) y[i] = g1->getDensity(x[2*i]) * g2->getDensity(x[2*i+1]);
+        for(size_t i=0; i<num_points; i++) y[i] = g1->getDensity(x[2*i]) * g2->getDensity(x[2*i+1]);
     }
 }
 void Gaussian2D::getDomainBounds(std::vector<bool> &lower, std::vector<bool> &upper){

--- a/SparseGrids/Examples/example_sparse_grids.cpp
+++ b/SparseGrids/Examples/example_sparse_grids.cpp
@@ -318,7 +318,7 @@ int main(int argc, const char**){
     }
 
     // generate 4000 random points between -1 and 1
-    srand(clock());
+    srand((int) clock());
     double *pnts = new double[4000];
     for(int i=0; i<4000; i++)  pnts[i] = 2.0 * ((double) rand()) / ((double) RAND_MAX) -1.0;
 
@@ -329,7 +329,7 @@ int main(int argc, const char**){
     int dim = 4;
     int out = 1;
     int prec = 15;
-    int start_clock, end_clock;
+    long int start_clock, end_clock;
 
     // generate the true values of the funciton (for error checking)
     double *tres = new double[1000];
@@ -346,7 +346,7 @@ int main(int argc, const char**){
     start_clock = clock();
     grid.makeGlobalGrid(dim, out, prec, TasGrid::type_iptotal, TasGrid::rule_leja);
     end_clock = clock();
-    int gstage1 = end_clock - start_clock;
+    long int gstage1 = end_clock - start_clock;
 
     int num_points = grid.getNumPoints();
     double *points = grid.getPoints();
@@ -370,14 +370,14 @@ int main(int argc, const char**){
     start_clock = clock();
     grid.loadNeededPoints(vals);
     end_clock = clock();
-    int gstage2 = end_clock - start_clock;
+    long int gstage2 = end_clock - start_clock;
 
     double *res = new double[1000];
 
     start_clock = clock();
     grid.evaluateBatch(pnts, 1000, res);
     end_clock = clock();
-    int gstage3 = end_clock - start_clock;
+    long int gstage3 = end_clock - start_clock;
 
     double gerr = 0.0;
     for(int i=0; i<1000; i++)  if (gerr < fabs(res[i] - tres[i])) gerr = fabs(res[i] - tres[i]);
@@ -386,17 +386,17 @@ int main(int argc, const char**){
     start_clock = clock();
     sgrid.makeSequenceGrid(dim, out, prec, TasGrid::type_iptotal, TasGrid::rule_leja);
     end_clock = clock();
-    int sstage1 = end_clock - start_clock;
+    long int sstage1 = end_clock - start_clock;
 
     start_clock = clock();
     sgrid.loadNeededPoints(vals);
     end_clock = clock();
-    int sstage2 = end_clock - start_clock;
+    long int sstage2 = end_clock - start_clock;
 
     start_clock = clock();
     sgrid.evaluateBatch(pnts, 1000, res);
     end_clock = clock();
-    int sstage3 = end_clock - start_clock;
+    long int sstage3 = end_clock - start_clock;
 
     cout << setw(15) << "Stage"       << setw(15) << "Global Grid" << setw(15) << "Sequence Grid" << endl;
     cout << setw(15) << "make grid"   << setw(15) << gstage1 << setw(15) << sstage1 << "   cycles" << endl;

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -480,10 +480,10 @@ void TasmanianSparseGrid::evaluateFast(const std::vector<double> x, std::vector<
     evaluateFast(x.data(), y.data());
 }
 void TasmanianSparseGrid::evaluateBatch(const std::vector<double> x, std::vector<double> &y) const{
-    size_t num_outputs = getNumOutputs();
+    int num_outputs = getNumOutputs();
     size_t num_x = x.size() / getNumDimensions();
     if (y.size() < num_outputs * num_x) y.resize(num_outputs * num_x);
-    evaluateBatch(x.data(), num_x, y.data());
+    evaluateBatch(x.data(), (int) num_x, y.data());
 }
 void TasmanianSparseGrid::integrate(std::vector<double> &q) const{
     size_t num_outputs = getNumOutputs();
@@ -958,9 +958,9 @@ void TasmanianSparseGrid::evaluateHierarchicalFunctions(const double x[], int nu
 }
 void TasmanianSparseGrid::evaluateHierarchicalFunctions(const std::vector<double> x, std::vector<double> &y) const{
     int num_points = getNumPoints();
-    int num_x = x.size() / getNumDimensions();
-    if (y.size() < (size_t) (num_points * num_x)) y.resize(num_points * num_x);
-    evaluateHierarchicalFunctions(x.data(), num_x, y.data());
+    size_t num_x = x.size() / getNumDimensions();
+    if (y.size() < num_points * num_x) y.resize(num_points * num_x);
+    evaluateHierarchicalFunctions(x.data(), (int) num_x, y.data());
 }
 #ifdef Tasmanian_ENABLE_CUDA
 void TasmanianSparseGrid::evaluateHierarchicalFunctionsGPU(const double gpu_x[], int cpu_num_x, double gpu_y[]) const{

--- a/SparseGrids/tasgridExternalTests.cpp
+++ b/SparseGrids/tasgridExternalTests.cpp
@@ -37,7 +37,7 @@
 
 ExternalTester::ExternalTester(int in_num_mc) : num_mc(in_num_mc), verbose(false), gpuid(-1){ srand(10); }
 ExternalTester::~ExternalTester(){}
-void ExternalTester::resetRandomSeed(){ srand(time(0)); }
+void ExternalTester::resetRandomSeed(){ srand((int) time(0)); }
 
 void ExternalTester::setVerbose(bool new_verbose){ verbose = new_verbose; }
 void ExternalTester::setGPUID(int gpu_id){ gpuid = gpu_id; }
@@ -1785,7 +1785,7 @@ bool ExternalTester::testAllAcceleration() const{
 extern "C" double gettime(){
     struct timeval t;
     gettimeofday(&t, NULL);
-    return t.tv_sec + t.tv_usec * 1.0E-6;
+    return ((double) t.tv_sec) + ((double) t.tv_usec) * 1.0E-6;
 }
 #else
     double gettime(){ return ((double) time(0)); }

--- a/SparseGrids/tasgridWrapper.cpp
+++ b/SparseGrids/tasgridWrapper.cpp
@@ -513,10 +513,10 @@ bool TasgridWrapper::getInterWeights(){
         delete[] r;
     }
     if (outfilename != 0){
-        writeMatrix(outfilename, rows, num_p, res, useASCII);
+        writeMatrix(outfilename, (int) rows, (int) num_p, res, useASCII);
     }
     if (printCout){
-        printMatrix(rows, num_p, res);
+        printMatrix((int) rows, (int) num_p, res);
     }
     delete[] x;
     delete[] res;
@@ -554,13 +554,13 @@ bool TasgridWrapper::getEvaluate(){
         }
     }
 
-    grid->evaluateBatch(x, rows, res);
+    grid->evaluateBatch(x, (int) rows, res);
 
     if (outfilename != 0){
-        writeMatrix(outfilename, rows, num_out, res, useASCII);
+        writeMatrix(outfilename, (int) rows, (int) num_out, res, useASCII);
     }
     if (printCout){
-        printMatrix(rows, num_out, res);
+        printMatrix((int) rows, (int) num_out, res);
     }
     delete[] x;
     delete[] res;
@@ -789,12 +789,12 @@ bool TasgridWrapper::getEvalHierarchyDense(){
     }
     int num_p = grid->getNumPoints();
     res = new double[((size_t) (grid->isFourier() ? 2 : 1) * num_p) * ((size_t) rows)];
-    grid->evaluateHierarchicalFunctions(x, rows, res);
+    grid->evaluateHierarchicalFunctions(x, (int) rows, res);
     if (outfilename != 0){
         writeMatrix(outfilename, (int) rows, ((grid->isFourier()) ? 2 * num_p : num_p), res, useASCII);
     }
     if (printCout){
-        printMatrix(rows, num_p, res, grid->isFourier());
+        printMatrix((int) rows, (int) num_p, res, grid->isFourier());
     }
     delete[] x;
     delete[] res;
@@ -814,7 +814,7 @@ bool TasgridWrapper::getEvalHierarchySparse(){
     }
     int *pntr = 0, *indx = 0;
     double *vals = 0;
-    grid->evaluateSparseHierarchicalFunctions(x, rows, pntr, indx, vals);
+    grid->evaluateSparseHierarchicalFunctions(x, (int) rows, pntr, indx, vals);
     int num_p = grid->getNumPoints();
     int num_nz = pntr[rows];
     if (outfilename != 0){
@@ -842,7 +842,7 @@ bool TasgridWrapper::getEvalHierarchySparse(){
             char charTSG[3] = {'T', 'S', 'G'};
             ofs.write(charTSG, 3 * sizeof(char));
             int matrix_dims[3];
-            matrix_dims[0] = rows;
+            matrix_dims[0] = (int) rows;
             matrix_dims[1] = num_p;
             matrix_dims[2] = num_nz;
             ofs.write((char*) matrix_dims, 3 * sizeof(int));

--- a/SparseGrids/tsgCoreOneDimensional.cpp
+++ b/SparseGrids/tsgCoreOneDimensional.cpp
@@ -77,7 +77,7 @@ void CustomTabulated::write(std::ofstream &ofs) const{
     }
 }
 void CustomTabulated::writeBinary(std::ofstream &ofs) const{
-    int num_description = description->size();
+    int num_description = (int) description->size();
     ofs.write((char*) &num_description, sizeof(int));
     ofs.write(description->c_str(), num_description * sizeof(char));
     ofs.write((char*) &num_levels, sizeof(int));

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -140,7 +140,7 @@ void GridLocalPolynomial::writeBinary(std::ofstream &ofs) const{
         }
 
         int num_points = (points == 0) ? needed->getNumIndexes() : points->getNumIndexes();
-        int num_roots = roots.size();
+        int num_roots = (int) roots.size();
         ofs.write((char*) &num_roots, sizeof(int));
         ofs.write((char*) roots.data(), num_roots * sizeof(int));
         ofs.write((char*) pntr.data(), (num_points+1) * sizeof(int));
@@ -390,7 +390,7 @@ void GridLocalPolynomial::evaluate(const double x[], double y[]) const{
     std::vector<int> monkey_tail(top_level+1);
 
     bool isSupported;
-    size_t offset;
+    int offset;
 
     std::fill(y, y + num_outputs, 0.0);
 

--- a/SparseGrids/tsgIndexSets.cpp
+++ b/SparseGrids/tsgIndexSets.cpp
@@ -553,7 +553,7 @@ void StorageSet::readBinary(std::ifstream &ifs){
     }
 }
 
-int StorageSet::getNumOutputs() const{ return num_outputs; }
+int StorageSet::getNumOutputs() const{ return (int) num_outputs; }
 const double* StorageSet::getValues(int i) const{ return &(values[i*num_outputs]); }
 double* StorageSet::aliasValues() const{ return values; }
 
@@ -584,7 +584,7 @@ void StorageSet::addValues(const IndexSet *old_set, const IndexSet *new_set, con
         }else if (offsetOld >= old_num_values){ // old is b
             relation = type_abeforeb;
         }else{
-            relation = compareIndexes(num_dimensions, new_set->getIndex(offsetNew), old_set->getIndex(offsetOld));
+            relation = compareIndexes(num_dimensions, new_set->getIndex((int) offsetNew), old_set->getIndex((int) offsetOld));
         }
         if (relation == type_abeforeb){
             std::copy(&(new_vals[num_outputs * offsetNew]), &(new_vals[num_outputs * offsetNew]) + num_outputs, &(values[num_outputs * num_values++]));

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -171,7 +171,7 @@ protected:
     TypeIndexRelation compareIndexes(int num_dimensions, const int a[], const int b[]) const;
 
 private:
-    size_t num_outputs, num_values;
+    size_t num_outputs, num_values; // kept as size_t to avoid conversions in products, but each one is small individually
     double *values;
 };
 


### PR DESCRIPTION
* fixed conversion warnings
* whenever there is a chance to multiply two large numbers and overflow `int`, set one of them to `size_t`
* `-Wconversions` helps keep track of types and forces one to think