### PR TITLE
Convert indexing to size_t

### DIFF
--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -584,9 +584,8 @@ void GridGlobal::loadNeededPoints(const double *vals, TypeAcceleration){
 void GridGlobal::mergeRefinement(){
     if (needed == 0) return; // nothing to do
     int num_all_points = getNumLoaded() + getNumNeeded();
-    double *vals = new double[num_all_points * num_outputs];
-    std::fill(vals, vals + num_all_points * num_outputs, 0.0);
-    values->setValuesPointer(vals, num_all_points);
+    std::vector<double> vals(((size_t) num_all_points) * ((size_t) num_outputs), 0.0);
+    values->setValues(vals);
     if (points == 0){
         points = needed;
         needed = 0;

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -1646,7 +1646,7 @@ int GridLocalPolynomial::removePointsByHierarchicalCoefficient(double tolerance,
     }
 
     // save a copy of the points and the values
-    int *point_kept = new int[num_kept * num_dimensions];
+    std::vector<int> point_kept(num_kept * num_dimensions);
     double *values_kept = new double[num_kept * num_outputs];
 
     num_kept = 0;
@@ -1663,7 +1663,7 @@ int GridLocalPolynomial::removePointsByHierarchicalCoefficient(double tolerance,
     reset(false);
     num_dimensions = dims; num_outputs = outs;
 
-    points = new IndexSet(num_dimensions, num_kept, point_kept);
+    points = new IndexSet(num_dimensions, point_kept);
     values = new StorageSet(num_outputs, num_kept);
     values->setValues(values_kept);
     delete[] values_kept;

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -605,9 +605,8 @@ void GridLocalPolynomial::mergeRefinement(){
     if (needed == 0) return; // nothing to do
     int num_all_points = getNumLoaded() + getNumNeeded();
     size_t num_vals = ((size_t) num_all_points) * ((size_t) num_outputs);
-    double *vals = new double[num_vals];
-    std::fill(vals, vals + num_vals, 0.0);
-    values->setValuesPointer(vals, num_all_points);
+    std::vector<double> vals(num_vals, 0.0);
+    values->setValues(vals);
     if (points == 0){
         points = needed;
         needed = 0;
@@ -1680,8 +1679,11 @@ int GridLocalPolynomial::removePointsByHierarchicalCoefficient(double tolerance,
 
 void GridLocalPolynomial::setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream *os){
     if (accel != 0) accel->resetGPULoadedData();
+    std::vector<double> vvals;
     double *vals = 0;
     bool aliased = false;
+    size_t num_ponits = (size_t) getNumPoints();
+    size_t num_vals = num_ponits * ((size_t) num_outputs);
     if (points != 0){
         clearRefinement();
         vals = values->aliasValues();
@@ -1689,26 +1691,25 @@ void GridLocalPolynomial::setHierarchicalCoefficients(const double c[], TypeAcce
     }else{
         points = needed;
         needed = 0;
-        vals = new double[((size_t) points->getNumIndexes()) * ((size_t) num_outputs)];
+        vvals.resize(num_vals);
+        vals = vvals.data();
     }
-    int num_ponits = points->getNumIndexes();
     if (surpluses != 0) delete[] surpluses;
-    surpluses = new double[((size_t) num_ponits) * ((size_t) num_outputs)];
-    std::copy(c, c + ((size_t) num_ponits) * ((size_t) num_outputs), surpluses);
-    double *x = new double[getNumPoints() * num_dimensions];
-    getPoints(x);
+    surpluses = new double[num_vals];
+    std::copy(c, c + num_vals, surpluses);
+    std::vector<double> x(((size_t) getNumPoints()) * ((size_t) num_dimensions));
+    getPoints(x.data());
     if (acc == accel_cpu_blas){
-        evaluateBatchCPUblas(x, points->getNumIndexes(), vals);
+        evaluateBatchCPUblas(x.data(), points->getNumIndexes(), vals);
     }else if (acc == accel_gpu_cublas){
-        evaluateBatchGPUcublas(x, points->getNumIndexes(), vals, os);
+        evaluateBatchGPUcublas(x.data(), points->getNumIndexes(), vals, os);
     }else if (acc == accel_gpu_cuda){
-        evaluateBatchGPUcuda(x, points->getNumIndexes(), vals, os);
+        evaluateBatchGPUcuda(x.data(), points->getNumIndexes(), vals, os);
     }else{
-        evaluateBatch(x, points->getNumIndexes(), vals);
+        evaluateBatch(x.data(), points->getNumIndexes(), vals);
     }
-    delete[] x;
     if (! aliased){
-        values->setValuesPointer(vals, num_ponits);
+        values->setValues(vvals);
     }
 }
 

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -1679,37 +1679,30 @@ int GridLocalPolynomial::removePointsByHierarchicalCoefficient(double tolerance,
 
 void GridLocalPolynomial::setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream *os){
     if (accel != 0) accel->resetGPULoadedData();
-    std::vector<double> vvals;
-    double *vals = 0;
-    bool aliased = false;
+    std::vector<double> *vals = 0;
     size_t num_ponits = (size_t) getNumPoints();
     size_t num_vals = num_ponits * ((size_t) num_outputs);
     if (points != 0){
         clearRefinement();
-        vals = values->aliasValues();
-        aliased = true;
     }else{
         points = needed;
         needed = 0;
-        vvals.resize(num_vals);
-        vals = vvals.data();
     }
+    vals = values->aliasValues();
+    vals->resize(num_vals);
     if (surpluses != 0) delete[] surpluses;
     surpluses = new double[num_vals];
     std::copy(c, c + num_vals, surpluses);
     std::vector<double> x(((size_t) getNumPoints()) * ((size_t) num_dimensions));
     getPoints(x.data());
     if (acc == accel_cpu_blas){
-        evaluateBatchCPUblas(x.data(), points->getNumIndexes(), vals);
+        evaluateBatchCPUblas(x.data(), points->getNumIndexes(), vals->data());
     }else if (acc == accel_gpu_cublas){
-        evaluateBatchGPUcublas(x.data(), points->getNumIndexes(), vals, os);
+        evaluateBatchGPUcublas(x.data(), points->getNumIndexes(), vals->data(), os);
     }else if (acc == accel_gpu_cuda){
-        evaluateBatchGPUcuda(x.data(), points->getNumIndexes(), vals, os);
+        evaluateBatchGPUcuda(x.data(), points->getNumIndexes(), vals->data(), os);
     }else{
-        evaluateBatch(x.data(), points->getNumIndexes(), vals);
-    }
-    if (! aliased){
-        values->setValues(vvals);
+        evaluateBatch(x.data(), points->getNumIndexes(), vals->data());
     }
 }
 

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -380,9 +380,9 @@ void GridSequence::loadNeededPoints(const double *vals, TypeAcceleration){
 void GridSequence::mergeRefinement(){
     if (needed == 0) return; // nothing to do
     int num_all_points = getNumLoaded() + getNumNeeded();
-    double *vals = new double[((size_t) num_all_points) * ((size_t) num_outputs)];
-    std::fill(vals, vals + ((size_t) num_all_points) * ((size_t) num_outputs), 0.0);
-    values->setValuesPointer(vals, num_all_points);
+    size_t num_vals = ((size_t) num_all_points) * ((size_t) num_outputs);
+    std::vector<double> vals(num_vals, 0.0);
+    values->setValues(vals);
     if (points == 0){
         points = needed;
         needed = 0;
@@ -395,8 +395,8 @@ void GridSequence::mergeRefinement(){
         int m; IM.getMaxLevels(points, max_levels, m);
     }
     if (surpluses != 0) delete[] surpluses;
-    surpluses = new double[((size_t) num_all_points) * ((size_t) num_outputs)];
-    std::fill(surpluses, surpluses + ((size_t) num_all_points) * ((size_t) num_outputs), 0.0);
+    surpluses = new double[num_vals];
+    std::fill(surpluses, surpluses + num_vals, 0.0);
 }
 
 void GridSequence::evaluate(const double x[], double y[]) const{
@@ -646,8 +646,11 @@ void GridSequence::evalHierarchicalFunctions(const double x[], double fvalues[])
 }
 void GridSequence::setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream *os){
     if (accel != 0) accel->resetGPULoadedData();
+    std::vector<double> vvals;
     double *vals = 0;
     bool aliased = false;
+    size_t num_ponits = (size_t) getNumPoints();
+    size_t num_vals = num_ponits * ((size_t) num_outputs);
     if (points != 0){
         clearRefinement();
         vals = values->aliasValues();
@@ -655,25 +658,24 @@ void GridSequence::setHierarchicalCoefficients(const double c[], TypeAcceleratio
     }else{
         points = needed;
         needed = 0;
-        vals = new double[((size_t) points->getNumIndexes()) * ((size_t) num_outputs)];
+        vvals.resize(num_vals);
+        vals = vvals.data();
     }
-    int num_ponits = points->getNumIndexes();
     if (surpluses != 0) delete[] surpluses;
-    surpluses = new double[((size_t) num_ponits) * ((size_t) num_outputs)];
-    std::copy(c, c + ((size_t) num_ponits) * ((size_t) num_outputs), surpluses);
-    double *x = new double[getNumPoints() * num_dimensions];
-    getPoints(x);
+    surpluses = new double[num_vals];
+    std::copy(c, c + num_vals, surpluses);
+    std::vector<double> x(((size_t) getNumPoints()) * ((size_t) num_dimensions));
+    getPoints(x.data());
     if (acc == accel_cpu_blas){
-        evaluateBatchCPUblas(x, points->getNumIndexes(), vals);
+        evaluateBatchCPUblas(x.data(), points->getNumIndexes(), vals);
     }else if (acc == accel_gpu_cublas){
-        evaluateBatchGPUcublas(x, points->getNumIndexes(), vals, os);
+        evaluateBatchGPUcublas(x.data(), points->getNumIndexes(), vals, os);
     }else if (acc == accel_gpu_cuda){
-        evaluateBatchGPUcuda(x, points->getNumIndexes(), vals, os);
+        evaluateBatchGPUcuda(x.data(), points->getNumIndexes(), vals, os);
     }else{
-        evaluateBatch(x, points->getNumIndexes(), vals);
+        evaluateBatch(x.data(), points->getNumIndexes(), vals);
     }
-    delete[] x;
-    if (! aliased) values->setValuesPointer(vals, num_ponits);
+    if (! aliased) values->setValues(vvals);
 }
 
 int* GridSequence::estimateAnisotropicCoefficients(TypeDepth type, int output) const{

--- a/SparseGrids/tsgGridWavelet.cpp
+++ b/SparseGrids/tsgGridWavelet.cpp
@@ -721,18 +721,17 @@ void GridWavelet::setHierarchicalCoefficients(const double c[], TypeAcceleration
     if (coefficients != 0) delete[] coefficients;
     coefficients = new double[size_coeff];
     std::copy(c, c + size_coeff, coefficients);
-    double *x = new double[getNumPoints() * num_dimensions];
-    getPoints(x);
+    std::vector<double> x(((size_t) getNumPoints()) * ((size_t) num_dimensions));
+    getPoints(x.data());
     if (acc == accel_cpu_blas){
-        evaluateBatchCPUblas(x, points->getNumIndexes(), vals->data());
+        evaluateBatchCPUblas(x.data(), points->getNumIndexes(), vals->data());
     }else if (acc == accel_gpu_cublas){
-        evaluateBatchGPUcublas(x, points->getNumIndexes(), vals->data(), os);
+        evaluateBatchGPUcublas(x.data(), points->getNumIndexes(), vals->data(), os);
     }else if (acc == accel_gpu_cuda){
-        evaluateBatchGPUcuda(x, points->getNumIndexes(), vals->data(), os);
+        evaluateBatchGPUcuda(x.data(), points->getNumIndexes(), vals->data(), os);
     }else{
-        evaluateBatch(x, points->getNumIndexes(), vals->data());
+        evaluateBatch(x.data(), points->getNumIndexes(), vals->data());
     }
-    delete[] x;
 }
 
 const int* GridWavelet::getPointIndexes() const{

--- a/SparseGrids/tsgGridWavelet.cpp
+++ b/SparseGrids/tsgGridWavelet.cpp
@@ -707,37 +707,32 @@ void GridWavelet::evaluateHierarchicalFunctions(const double x[], int num_x, dou
 }
 
 void GridWavelet::setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream *os){
-    std::vector<double> vvals;
-    double *vals = 0;
-    bool aliased = false;
+    std::vector<double> *vals = 0;
     size_t num_ponits = (size_t) getNumPoints();
     size_t size_coeff = num_ponits * ((size_t) num_outputs);
     if (points != 0){
         clearRefinement();
-        vals = values->aliasValues();
-        aliased = true;
     }else{
         points = needed;
         needed = 0;
-        vvals.resize(size_coeff);
-        vals = vvals.data();
     }
+    vals = values->aliasValues();
+    vals->resize(size_coeff);
     if (coefficients != 0) delete[] coefficients;
     coefficients = new double[size_coeff];
     std::copy(c, c + size_coeff, coefficients);
     double *x = new double[getNumPoints() * num_dimensions];
     getPoints(x);
     if (acc == accel_cpu_blas){
-        evaluateBatchCPUblas(x, points->getNumIndexes(), vals);
+        evaluateBatchCPUblas(x, points->getNumIndexes(), vals->data());
     }else if (acc == accel_gpu_cublas){
-        evaluateBatchGPUcublas(x, points->getNumIndexes(), vals, os);
+        evaluateBatchGPUcublas(x, points->getNumIndexes(), vals->data(), os);
     }else if (acc == accel_gpu_cuda){
-        evaluateBatchGPUcuda(x, points->getNumIndexes(), vals, os);
+        evaluateBatchGPUcuda(x, points->getNumIndexes(), vals->data(), os);
     }else{
-        evaluateBatch(x, points->getNumIndexes(), vals);
+        evaluateBatch(x, points->getNumIndexes(), vals->data());
     }
     delete[] x;
-    if (! aliased) values->setValues(vvals);
 }
 
 const int* GridWavelet::getPointIndexes() const{

--- a/SparseGrids/tsgGridWavelet.cpp
+++ b/SparseGrids/tsgGridWavelet.cpp
@@ -590,7 +590,7 @@ int* GridWavelet::buildUpdateMap(double tolerance, TypeRefinement criteria, int 
             int active_outputs = (output == -1) ? num_outputs : 1;
 
             double *vals = new double[nump * active_outputs];
-            int *indexes = new int[nump * num_dimensions];
+            std::vector<int> indexes(nump * num_dimensions);
 
             for(int i=0; i<nump; i++){
                 const double* v = values->getValues(pnts[i]);
@@ -603,7 +603,7 @@ int* GridWavelet::buildUpdateMap(double tolerance, TypeRefinement criteria, int 
                 std::copy(p, p + num_dimensions, &(indexes[((size_t) i) * ((size_t) num_dimensions)]));
                 global_to_pnts[pnts[i]] = i;
             }
-            IndexSet *pointset = new IndexSet(num_dimensions, nump, indexes);
+            IndexSet *pointset = new IndexSet(num_dimensions, indexes);
 
             GridWavelet direction_grid;
             direction_grid.setNodes(pointset, active_outputs, order);

--- a/SparseGrids/tsgGridWavelet.cpp
+++ b/SparseGrids/tsgGridWavelet.cpp
@@ -302,9 +302,8 @@ void GridWavelet::mergeRefinement(){
     if (needed == 0) return; // nothing to do
     int num_all_points = getNumLoaded() + getNumNeeded();
     size_t size_vals = ((size_t) num_all_points) * ((size_t) num_outputs);
-    double *vals = new double[size_vals];
-    std::fill(vals, vals + size_vals, 0.0);
-    values->setValuesPointer(vals, num_all_points);
+    std::vector<double> vals(size_vals, 0.0);
+    values->setValues(vals);
     if (points == 0){
         points = needed;
         needed = 0;
@@ -708,8 +707,11 @@ void GridWavelet::evaluateHierarchicalFunctions(const double x[], int num_x, dou
 }
 
 void GridWavelet::setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream *os){
+    std::vector<double> vvals;
     double *vals = 0;
     bool aliased = false;
+    size_t num_ponits = (size_t) getNumPoints();
+    size_t size_coeff = num_ponits * ((size_t) num_outputs);
     if (points != 0){
         clearRefinement();
         vals = values->aliasValues();
@@ -717,10 +719,9 @@ void GridWavelet::setHierarchicalCoefficients(const double c[], TypeAcceleration
     }else{
         points = needed;
         needed = 0;
-        vals = new double[((size_t) points->getNumIndexes()) * ((size_t) num_outputs)];
+        vvals.resize(size_coeff);
+        vals = vvals.data();
     }
-    int num_ponits = points->getNumIndexes();
-    size_t size_coeff = ((size_t) num_ponits) * ((size_t) num_outputs);
     if (coefficients != 0) delete[] coefficients;
     coefficients = new double[size_coeff];
     std::copy(c, c + size_coeff, coefficients);
@@ -736,7 +737,7 @@ void GridWavelet::setHierarchicalCoefficients(const double c[], TypeAcceleration
         evaluateBatch(x, points->getNumIndexes(), vals);
     }
     delete[] x;
-    if (! aliased) values->setValuesPointer(vals, num_ponits);
+    if (! aliased) values->setValues(vvals);
 }
 
 const int* GridWavelet::getPointIndexes() const{

--- a/SparseGrids/tsgIndexManipulator.cpp
+++ b/SparseGrids/tsgIndexManipulator.cpp
@@ -167,7 +167,7 @@ IndexSet* IndexManipulator::selectTensors(int offset, TypeDepth type, const int 
         }
         int num_total = ++levels[0];
         for(int j=1; j<num_dimensions; j++) num_total *= ++levels[j];
-        int *index = new int[num_total * num_dimensions];
+        std::vector<int> index(num_total * num_dimensions);
         for(int i=0; i<num_total; i++){
             int t = i;
             for(int j = num_dimensions-1; j>=0; j--){
@@ -175,7 +175,7 @@ IndexSet* IndexManipulator::selectTensors(int offset, TypeDepth type, const int 
                 t /= levels[j];
             }
         }
-        IndexSet *tensors = new IndexSet(num_dimensions, num_total, index);
+        IndexSet *tensors = new IndexSet(num_dimensions, index);
         delete[] levels;
         return tensors;
     }
@@ -549,7 +549,7 @@ IndexSet* IndexManipulator::nonzeroSubset(const IndexSet* set, const int weights
     int nz_weights = 0;
     for(int i=0; i<set->getNumIndexes(); i++){ if (weights[i] != 0) nz_weights++; }
 
-    int *index = new int[nz_weights * num_dimensions];
+    std::vector<int> index(nz_weights * num_dimensions);
     nz_weights = 0;
     for(int i=0; i<set->getNumIndexes(); i++){
         if (weights[i] != 0){
@@ -558,8 +558,7 @@ IndexSet* IndexManipulator::nonzeroSubset(const IndexSet* set, const int weights
         }
     }
 
-    IndexSet *result = new IndexSet(num_dimensions, nz_weights, index);
-    return result;
+    return new IndexSet(num_dimensions, index);
 }
 
 UnsortedIndexSet* IndexManipulator::tensorGenericPoints(const int levels[], const OneDimensionalWrapper *rule) const{
@@ -660,7 +659,7 @@ IndexSet* IndexManipulator::removeIndexesByLimit(IndexSet *set, const int limits
         if (obeys) c++;
     }
     if (c == set->getNumIndexes()) return 0;
-    int *new_idx = new int[dims * c];
+    std::vector<int> new_idx(dims * c);
     c = 0;
     for(int i=0; i<set->getNumIndexes(); i++){
         const int *idx = set->getIndex(i);
@@ -668,7 +667,8 @@ IndexSet* IndexManipulator::removeIndexesByLimit(IndexSet *set, const int limits
         for(int j=0; j<dims; j++) if ((limits[j] > -1) && (idx[j] > limits[j])) obeys = false;
         if (obeys) std::copy(idx, idx + dims, &(new_idx[dims * (c++)]));
     }
-    return (new IndexSet(dims, c, new_idx));
+
+    return new IndexSet(dims, new_idx);
 }
 UnsortedIndexSet* IndexManipulator::removeIndexesByLimit(UnsortedIndexSet *set, const int limits[]) const{
     int c = 0, dims = set->getNumDimensions();
@@ -722,7 +722,7 @@ IndexSet* IndexManipulator::tensorNestedPoints(const int levels[], const OneDime
 
         num_total *= num_points[j];
     }
-    int *index = new int[num_dimensions * num_total];
+    std::vector<int> index(num_dimensions * num_total);
 
     for(int i=0; i<num_total; i++){
         int t = i;
@@ -735,8 +735,7 @@ IndexSet* IndexManipulator::tensorNestedPoints(const int levels[], const OneDime
     delete[] offsets;
     delete[] num_points;
 
-    IndexSet* set = new IndexSet(num_dimensions, num_total, index);
-    return set;
+    return new IndexSet(num_dimensions, index);
 }
 
 IndexSet* IndexManipulator::generateNestedPoints(const IndexSet *tensors, const OneDimensionalWrapper *rule) const{
@@ -807,7 +806,7 @@ IndexSet* IndexManipulator::getPolynomialSpace(const IndexSet *tensors, TypeOneD
         int num_total = num_points[0];
         for(int j=1; j<num_dimensions; j++) num_total *= num_points[j];
 
-        int *poly = new int[num_total * num_dimensions];
+        std::vector<int> poly(num_total * num_dimensions);
 
         for(int i=0; i<num_total; i++){
             int v = i;
@@ -817,7 +816,7 @@ IndexSet* IndexManipulator::getPolynomialSpace(const IndexSet *tensors, TypeOneD
             }
         }
 
-        sets[t] = new IndexSet(num_dimensions, num_total, poly);
+        sets[t] = new IndexSet(num_dimensions, poly);
         delete[] num_points;
     }
 

--- a/SparseGrids/tsgIndexManipulator.cpp
+++ b/SparseGrids/tsgIndexManipulator.cpp
@@ -198,26 +198,21 @@ IndexSet* IndexManipulator::selectTensors(int offset, TypeDepth type, const int 
     if (known_lower){ // use fast algorithm, but only works for sets guaranteed to be lower
         int c = num_dimensions -1;
         bool outside = false;
-        int *root = new int[num_dimensions];  std::fill(root, root + num_dimensions, 0);
-        DumpIndexSet *index_dump = new DumpIndexSet(num_dimensions, 256);
+        std::vector<int> root(num_dimensions, 0);
+        std::vector<int> index_dump;
         while( !(outside && (c == 0)) ){
             if (outside){
                 for(int k=c; k<num_dimensions; k++) root[k] = 0;
                 c--;
                 root[c]++;
             }else{
-                index_dump->addIndex(root);
+                for(int i=0; i<num_dimensions; i++) index_dump.push_back(root[i]);
                 c = num_dimensions-1;
                 root[c]++;
             }
-            outside = (getIndexWeight(root, type, weights, rule) > normalized_offset);
+            outside = (getIndexWeight(root.data(), type, weights, rule) > normalized_offset);
         }
-        delete[] root;
-        int num_loaded = index_dump->getNumLoaded();
-        int *res = index_dump->ejectIndexes();
-        total = new IndexSet(num_dimensions, num_loaded, res);
-        delete index_dump;
-
+        total = new IndexSet(num_dimensions, index_dump);
     }else{ // use slower algorithm, but more general
         GranulatedIndexSet **sets;
         int *root = new int[num_dimensions];  std::fill(root, root + num_dimensions, 0);

--- a/SparseGrids/tsgIndexSets.cpp
+++ b/SparseGrids/tsgIndexSets.cpp
@@ -496,7 +496,7 @@ void StorageSet::readBinary(std::ifstream &ifs){
 
 int StorageSet::getNumOutputs() const{ return (int) num_outputs; }
 const double* StorageSet::getValues(int i) const{ return &(values[i*num_outputs]); }
-double* StorageSet::aliasValues() const{ return (double*) values.data(); }
+std::vector<double>* StorageSet::aliasValues(){ return &values; }
 
 void StorageSet::setValues(const double vals[]){
     values.resize(num_outputs * num_values);

--- a/SparseGrids/tsgIndexSets.cpp
+++ b/SparseGrids/tsgIndexSets.cpp
@@ -202,26 +202,25 @@ void GranulatedIndexSet::mergeMapped(const std::vector<int> newIndex, const std:
 
     TypeIndexRelation relation;
     num_indexes = 0;
-    size_t offsetNew = 0, offsetOld = 0;
-    while( (offsetNew < (size_t) sizeNew) || (offsetOld < sizeOld) ){
-        if (offsetNew >= (size_t) sizeNew){ // new is a
+    auto iterNew = newMap.begin();
+    auto iterOld = imap.begin();
+    while( (iterNew < newMap.end()) || (iterOld < imap.end()) ){
+        if (iterNew >= newMap.end()){ // new is a
             relation = type_bbeforea;
-        }else if (offsetOld >= sizeOld){ // old is b
+        }else if (iterOld >= imap.end()){ // old is b
             relation = type_abeforeb;
         }else{
-            relation = compareIndexes(&(newIndex[newMap[offsetNew] * num_dimensions]), &(oldIndex[imap[offsetOld] * num_dimensions]));
+            relation = compareIndexes(&(newIndex[*iterNew * num_dimensions]), &(oldIndex[*iterOld * num_dimensions]));
         }
         const int *p;
         if (relation == type_abeforeb){
-            //std::copy(&(newIndex[newMap[offsetNew] * num_dimensions]), &(newIndex[newMap[offsetNew] * num_dimensions]) + num_dimensions, &(index[num_indexes++ * num_dimensions]));
-            p = &(newIndex[newMap[offsetNew] * num_dimensions]);
-            offsetNew++;
+            p = &(newIndex[*iterNew * num_dimensions]);
+            iterNew++;
         }
         if ((relation == type_bbeforea) || (relation == type_asameb)){
-            //std::copy(&(oldIndex[imap[offsetOld] * num_dimensions]), &(oldIndex[imap[offsetOld] * num_dimensions]) + num_dimensions, &(index[num_indexes++ * num_dimensions]));
-            p = &(oldIndex[imap[offsetOld] * num_dimensions]);
-            offsetOld++;
-            offsetNew += (relation == type_asameb) ? 1 : 0;
+            p = &(oldIndex[*iterOld * num_dimensions]);
+            iterOld++;
+            if (relation == type_asameb) iterNew ++;
         }
         for(size_t i=0; i<num_dimensions; i++) index.push_back(p[i]);
         num_indexes++;

--- a/SparseGrids/tsgIndexSets.cpp
+++ b/SparseGrids/tsgIndexSets.cpp
@@ -254,13 +254,6 @@ IndexSet::IndexSet(const IndexSet *iset){
     index = *iset->getIndexes();
 }
 
-IndexSet::IndexSet(int cnum_dimensions, int cnum_indexes, int* &cindex){
-    num_dimensions = cnum_dimensions;
-    num_indexes = cnum_indexes;
-    index.resize(num_dimensions * num_indexes);
-    std::copy(cindex, cindex + num_dimensions * num_indexes, index.data());
-    delete[] cindex;
-}
 IndexSet::IndexSet(int cnum_dimensions, std::vector<int> &cindex){
     num_dimensions = cnum_dimensions;
     num_indexes = cindex.size() / num_dimensions;

--- a/SparseGrids/tsgIndexSets.cpp
+++ b/SparseGrids/tsgIndexSets.cpp
@@ -231,39 +231,6 @@ void GranulatedIndexSet::mergeMapped(const std::vector<int> newIndex, const std:
     for(size_t i=0; i<num_indexes; i++){ imap[i] = (int) i; }
 }
 
-DumpIndexSet::DumpIndexSet(int cnum_dimensions, int initial_slots) :
-    num_dimensions(cnum_dimensions), num_slots(initial_slots), num_loaded(0), index(0){
-    index = new int[num_dimensions * num_slots];
-}
-DumpIndexSet::~DumpIndexSet(){
-    if (index != 0){ delete[] index; index = 0; }
-}
-int DumpIndexSet::getNumLoaded() const{ return num_loaded; }
-void DumpIndexSet::addIndex(const int p[]){
-    if (num_loaded == num_slots){
-        int *old_index = index;
-        index = new int[2 * num_dimensions * num_slots];
-        std::copy(old_index, old_index + num_slots * num_dimensions, index);
-        num_slots *= 2;
-        delete[] old_index;
-    }
-    std::copy(p, p + num_dimensions, &(index[num_loaded * num_dimensions]));
-    num_loaded++;
-}
-int* DumpIndexSet::ejectIndexes(){
-    int *res;
-    if (num_slots == num_loaded){
-        res = index;
-        index = 0;
-        num_loaded = 0;
-        return res;
-    }else{
-        res = new int[num_dimensions * num_loaded];
-        std::copy(index, index + num_dimensions * num_loaded, res);
-    }
-    return res;
-}
-
 IndexSet::IndexSet(int cnum_dimensions){
     num_dimensions = (size_t) cnum_dimensions;
     num_indexes = 0;
@@ -294,6 +261,11 @@ IndexSet::IndexSet(int cnum_dimensions, int cnum_indexes, int* &cindex){
     index.resize(num_dimensions * num_indexes);
     std::copy(cindex, cindex + num_dimensions * num_indexes, index.data());
     delete[] cindex;
+}
+IndexSet::IndexSet(int cnum_dimensions, std::vector<int> &cindex){
+    num_dimensions = cnum_dimensions;
+    num_indexes = cindex.size() / num_dimensions;
+    index = std::move(cindex);
 }
 IndexSet::~IndexSet(){}
 

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -91,21 +91,6 @@ private:
     std::vector<int> imap;
 };
 
-class DumpIndexSet{
-public:
-    DumpIndexSet(int cnum_dimensions, int initial_slots);
-    ~DumpIndexSet();
-
-    int getNumLoaded() const;
-
-    void addIndex(const int p[]);
-    int* ejectIndexes();
-
-private:
-    int num_dimensions, num_slots, num_loaded;
-    int *index;
-};
-
 class IndexSet{ // rigid set but optimal in storage size
 public:
     IndexSet(int cnum_dimensions);
@@ -113,6 +98,7 @@ public:
     IndexSet(const GranulatedIndexSet *gset);
     IndexSet(const IndexSet *iset);
     IndexSet(int cnum_dimensions, int cnum_indexes, int* &cindex);
+    IndexSet(int cnum_dimensions, std::vector<int> &cindex);
     ~IndexSet();
 
     int getNumDimensions() const;

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -150,7 +150,7 @@ public:
     int getNumOutputs() const;
 
     void setValues(const double vals[]);
-    void setValuesPointer(double* &vals, int num_values);
+    void setValues(std::vector<double> &vals);
     void addValues(const IndexSet *old_set, const IndexSet *new_set, const double new_vals[]);
 
 protected:
@@ -158,7 +158,7 @@ protected:
 
 private:
     size_t num_outputs, num_values; // kept as size_t to avoid conversions in products, but each one is small individually
-    double *values;
+    std::vector<double> values;
 };
 
 }

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -125,7 +125,7 @@ public:
 protected:
     TypeIndexRelation compareIndexes(const int a[], const int b[]) const;
 
-    void mergeSet(const int newIndex[], int sizeNew);
+    void mergeSet(const std::vector<int> newIndex);
     void mergeMapped(const int newIndex[], const int imap[], int sizeNew);
 
 private:

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -48,7 +48,7 @@ public:
     const int* getIndex(int i) const;
 
     int* getIndexesSorted() const;
-    void getIndexesSorted(std::vector<int> sorted) const;
+    void getIndexesSorted(std::vector<int> &sorted) const;
     // returns an array of num_dimensions X num_indexes of the sorted indexes
 
 protected:
@@ -111,9 +111,9 @@ private:
 class IndexSet{ // rigid set but optimal in storage size
 public:
     IndexSet(int cnum_dimensions);
-    IndexSet(const UnsortedIndexSet *set);
-    IndexSet(const GranulatedIndexSet *set);
-    IndexSet(const IndexSet *set);
+    IndexSet(const UnsortedIndexSet *uset);
+    IndexSet(const GranulatedIndexSet *gset);
+    IndexSet(const IndexSet *iset);
     IndexSet(int cnum_dimensions, int cnum_indexes, int* &cindex);
     ~IndexSet();
 
@@ -130,23 +130,24 @@ public:
     inline int getSlot(const std::vector<int> p) const{ return getSlot(p.data()); }
 
     const int* getIndex(int i) const;
+    const std::vector<int>* getIndexes() const;
 
-    void addUnsortedSet(const UnsortedIndexSet *set);
-    void addGranulatedSet(const GranulatedIndexSet *set);
-    void addIndexSet(const IndexSet *set);
+    void addUnsortedSet(const UnsortedIndexSet *uset);
+    void addGranulatedSet(const GranulatedIndexSet *gset);
+    void addIndexSet(const IndexSet *iset);
 
-    IndexSet* diffSets(const IndexSet *set) const; // returns this set minus the points in set
+    IndexSet* diffSets(const IndexSet *iset) const; // returns this set minus the points in set
 
 protected:
     TypeIndexRelation compareIndexes(const int a[], const int b[]) const;
 
-    void merge(const int newIndex[], int sizeNew);
-    void mergeMapped(const int newIndex[], const int map[], int sizeNew);
+    void mergeSet(const int newIndex[], int sizeNew);
+    void mergeMapped(const int newIndex[], const int imap[], int sizeNew);
 
 private:
-    int num_dimensions;
-    int num_indexes;
-    int *index;
+    size_t num_dimensions;
+    size_t num_indexes;
+    std::vector<int> index;
 };
 
 class StorageSet{ // stores the values of the function

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -97,8 +97,7 @@ public:
     IndexSet(const UnsortedIndexSet *uset);
     IndexSet(const GranulatedIndexSet *gset);
     IndexSet(const IndexSet *iset);
-    IndexSet(int cnum_dimensions, int cnum_indexes, int* &cindex);
-    IndexSet(int cnum_dimensions, std::vector<int> &cindex);
+    IndexSet(int cnum_dimensions, std::vector<int> &cindex); // move assignment
     ~IndexSet();
 
     int getNumDimensions() const;

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -48,16 +48,17 @@ public:
     const int* getIndex(int i) const;
 
     int* getIndexesSorted() const;
+    void getIndexesSorted(std::vector<int> sorted) const;
     // returns an array of num_dimensions X num_indexes of the sorted indexes
 
 protected:
     TypeIndexRelation compareIndexes(const int a[], const int b[]) const;
-    void merge(const int listA[], int sizeA, const int listB[], int sizeB, int destination[]) const;
+    void merge(const int listA[], size_t sizeA, const int listB[], size_t sizeB, int destination[]) const;
 
 private:
-    int num_dimensions;
-    int num_indexes;
-    int *index;
+    size_t num_dimensions;
+    size_t num_indexes;
+    std::vector<int> index;
 };
 
 class GranulatedIndexSet{ // optimized to add one index at a time

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -52,7 +52,7 @@ public:
 
 protected:
     TypeIndexRelation compareIndexes(const int a[], const int b[]) const;
-    void merge(const int listA[], size_t sizeA, const int listB[], size_t sizeB, int destination[]) const;
+    void mergeLists(const int listA[], size_t sizeA, const int listB[], size_t sizeB, int destination[]) const;
 
 private:
     size_t num_dimensions;

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -127,8 +127,11 @@ protected:
     void mergeSet(const std::vector<int> newIndex);
     void mergeMapped(const std::vector<int> *newIndex, const std::vector<int> *imap);
 
+    void cacheNumIndexes();
+
 private:
     size_t num_dimensions;
+    int cache_num_indexes;
     std::vector<int> index;
 };
 

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -129,7 +129,6 @@ protected:
 
 private:
     size_t num_dimensions;
-    size_t num_indexes;
     std::vector<int> index;
 };
 

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -74,22 +74,21 @@ public:
 
     const int* getIndex(int j) const;
 
-    void addGranulatedSet(const GranulatedIndexSet *set);
+    void addGranulatedSet(const GranulatedIndexSet *gset);
 
-    const int* getIndexes() const;
-    const int* getMap() const;
+    const std::vector<int>* getIndexes() const;
+    const std::vector<int>* getMap() const;
 
 protected:
     TypeIndexRelation compareIndexes(const int a[], const int b[]) const;
 
-    void mergeMapped(const int newIndex[], const int newMap[], int sizeNew);
+    void mergeMapped(const std::vector<int> newIndex, const std::vector<int> newMap, int sizeNew);
 
 private:
-    int num_dimensions;
-    int num_indexes;
-    int num_slots;
-    int *index;
-    int *map;
+    size_t num_dimensions;
+    size_t num_indexes;
+    std::vector<int> index;
+    std::vector<int> imap;
 };
 
 class DumpIndexSet{

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -125,7 +125,7 @@ protected:
     TypeIndexRelation compareIndexes(const int a[], const int b[]) const;
 
     void mergeSet(const std::vector<int> newIndex);
-    void mergeMapped(const int newIndex[], const int imap[], int sizeNew);
+    void mergeMapped(const std::vector<int> *newIndex, const std::vector<int> *imap);
 
 private:
     size_t num_dimensions;

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -47,9 +47,8 @@ public:
     void addIndex(const int p[]);
     const int* getIndex(int i) const;
 
-    int* getIndexesSorted() const;
     void getIndexesSorted(std::vector<int> &sorted) const;
-    // returns an array of num_dimensions X num_indexes of the sorted indexes
+    // returns a vector of num_dimensions X num_indexes of the sorted indexes
 
 protected:
     TypeIndexRelation compareIndexes(const int a[], const int b[]) const;

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -146,7 +146,7 @@ public:
     void readBinary(std::ifstream &ifs);
 
     const double* getValues(int i) const;
-    double* aliasValues() const;
+    std::vector<double>* aliasValues(); // alternative to setValues()
     int getNumOutputs() const;
 
     void setValues(const double vals[]);


### PR DESCRIPTION
* the `IndexSet` classes and the `StorageSet` are converted to use `size_t` and `std::vector`
* many of the internal merge functions use iterators
* the I/O file format remains uchainged
* many of the functions interfacing with the sets had to be updated