### PR TITLE
Enable Fortran in GCC builds on Jenkins CI

### DIFF
--- a/docker/Dockerfile_nvidia-cuda9.0-ubuntu16.04
+++ b/docker/Dockerfile_nvidia-cuda9.0-ubuntu16.04
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         python \
         python-numpy \
         cmake \
+        gfortran \
         git \
         && \
     apt-get clean && \

--- a/docker/Dockerfile_stack
+++ b/docker/Dockerfile_stack
@@ -8,6 +8,7 @@ RUN apt update && apt install --no-install-recommends -y \
         python3 \
         python3-numpy \
         cmake \
+        gfortran \
         git \
         && \
     apt-get clean && \

--- a/docker/jenkins/build.sh
+++ b/docker/jenkins/build.sh
@@ -24,6 +24,7 @@ then
       -D CMAKE_CXX_FLAGS="-Wall -Wextra -Wshadow -pedantic" \
       -D CMAKE_CXX_COMPILER=g++ \
       -D Tasmanian_ENABLE_RECOMMENDED=ON \
+      -D Tasmanian_ENABLE_FORTRAN=ON \
       -D PYTHON_EXECUTABLE=/usr/bin/python2 \
       -D Tasmanian_TESTS_OMP_NUM_THREADS=4 \
       ..
@@ -45,7 +46,7 @@ then
       -D Tasmanian_ENABLE_MAGMA=OFF \
       -D Tasmanian_ENABLE_PYTHON=ON \
       -D Tasmanian_ENABLE_MPI=OFF \
-      -D Tasmanian_ENABLE_FORTRAN=OFF \
+      -D Tasmanian_ENABLE_FORTRAN=ON \
       -D Tasmanian_TESTS_OMP_NUM_THREADS=4 \
       ..
 else


### PR DESCRIPTION
I already built the new images and uploaded them on Docker Hub.
This is safe to merge if the CI passes.