### PR TITLE
flagged by werror

### DIFF
--- a/SparseGrids/tsgIndexSets.cpp
+++ b/SparseGrids/tsgIndexSets.cpp
@@ -216,8 +216,7 @@ void GranulatedIndexSet::mergeMapped(const std::vector<int> newIndex, const std:
         if (relation == type_abeforeb){
             p = &(newIndex[*iterNew * num_dimensions]);
             iterNew++;
-        }
-        if ((relation == type_bbeforea) || (relation == type_asameb)){
+        }else{
             p = &(oldIndex[*iterOld * num_dimensions]);
             iterOld++;
             if (relation == type_asameb) iterNew ++;


### PR DESCRIPTION
* technically a false positive as `p` is always initialized, but must be fixed