### PR TITLE
Reformat Fourier coefficients

### DIFF
--- a/InterfaceFortran/TasmanianSG.f90
+++ b/InterfaceFortran/TasmanianSG.f90
@@ -109,7 +109,7 @@ PUBLIC :: tsgClearAll,          &
           tsgReceiveMatrix, &
           tsg_clenshaw_curtis     ,  tsg_rule_clenshaw_curtis_zero, &
           tsg_chebyshev           ,  tsg_chebyshev_odd        , &
-          tsg_gauss_legendre      ,  tsg_gauss_legendreodd    , & 
+          tsg_gauss_legendre      ,  tsg_gauss_legendreodd    , &
           tsg_gauss_patterson     ,  tsg_leja                 , &
           tsg_lejaodd             ,  tsg_rleja                , &
           tsg_rleja_odd           ,  tsg_rleja_double_2       , &
@@ -137,10 +137,10 @@ PUBLIC :: tsgClearAll,          &
           tsg_directional,  tsg_fds          , &
           tsg_acc_none    , tsg_acc_cpu_blas , tsg_acc_gpu_cublas, &
           tsg_acc_gpu_cuda, tsg_acc_gpu_magma
-                        
+
   integer, parameter :: tsg_clenshaw_curtis      =  1,  tsg_rule_clenshaw_curtis_zero = 2, &
                         tsg_chebyshev            =  3,  tsg_chebyshev_odd         =  4, &
-                        tsg_gauss_legendre       =  5,  tsg_gauss_legendreodd     =  6, & 
+                        tsg_gauss_legendre       =  5,  tsg_gauss_legendreodd     =  6, &
                         tsg_gauss_patterson      =  7,  tsg_leja                  =  8, &
                         tsg_lejaodd              =  9,  tsg_rleja                 = 10, &
                         tsg_rleja_odd            = 11,  tsg_rleja_double_2        = 12, &
@@ -679,7 +679,7 @@ function tsgGetComplexHierarchicalCoefficients(gridID) result(c)
     allocate(c_real(2*tsgGetNumOutputs(gridID)*tsgGetNumPoints(gridID)))
     call tsgghc(gridID, c_real)
     do i = 1,size(c)
-      c(i) = complex( c_real(2*i-1), c_real(2*i) )
+      c(i) = complex( c_real(i), c_real(i + size(c)) )
     enddo
     deallocate(c_real)
   else
@@ -696,7 +696,7 @@ subroutine tsgGetComplexHierarchicalCoefficientsStatic(gridID, c)
   if ( tsgIsFourier(gridID) ) then
     call tsgghc(gridID, c_real)
     do i = 1,size(c)
-      c(i) = complex( c_real(2*i-1), c_real(2*i) )
+      c(i) = complex( c_real(i), c_real(i + size(c)) )
     enddo
   else
     write(*,*) "ERROR: called tsgGetComplexHierarchicalCoefficientsStatic() on a non-Fourier grid, "

--- a/InterfacePython/TasmanianSG.in.py
+++ b/InterfacePython/TasmanianSG.in.py
@@ -1609,7 +1609,7 @@ class TasmanianSparseGrid:
         else:
             aSurp = np.empty([2 * iNumOuts * iNumPoints], np.float64)
             self.pLibTSG.tsgGetHierarchicalCoefficientsStatic(self.pGrid, np.ctypeslib.as_ctypes(aSurp))
-            aSurp = aSurp[0::2] + 1j * aSurp[1::2]
+            aSurp = aSurp[:(iNumOuts * iNumPoints)] + 1j * aSurp[(iNumOuts * iNumPoints):]
 
         return aSurp.reshape([iNumPoints, iNumOuts])
 
@@ -1728,9 +1728,7 @@ class TasmanianSparseGrid:
         iNumDims = llfCoefficients.shape[1]
 
         if self.isFourier():
-            llfCoefficientsTmp = np.empty([iNumPoints, 2 * iNumDims,], np.float64)
-            llfCoefficientsTmp[:,0::2] = np.real(llfCoefficients)
-            llfCoefficientsTmp[:,1::2] = np.imag(llfCoefficients)
+            llfCoefficientsTmp = np.vstack((np.real(llfCoefficients), np.imag(llfCoefficients)))
             llfCoefficients = llfCoefficientsTmp.reshape([2 * iNumPoints * iNumDims,])
         else:
             llfCoefficients = llfCoefficients.reshape([iNumPoints * iNumDims,])

--- a/SparseGrids/tasgridExternalTests.cpp
+++ b/SparseGrids/tasgridExternalTests.cpp
@@ -976,11 +976,11 @@ bool ExternalTester::testAllFourier() const{
         double *y = new double[num_eval];
         grid.evaluateBatch(pnts, num_eval, y);
 
+        int num_points = grid.getNumPoints();
+        int num_outputs = grid.getNumOutputs();
         for(int i=0; i<num_eval; i++){
             for(int j=pntr[i]; j<pntr[i+1]; j++){
-                std::complex<double> fourier_coeff(coeff[2*indx[j]], coeff[2*indx[j]+1]);    //reformat as complex number
-                std::complex<double> phi(vals[2*j], vals[2*j+1]);                            //reformat as complex number
-                y[i] -= (fourier_coeff*phi).real();
+                y[i] -= (coeff[indx[j]] * vals[2*j] - coeff[indx[j] + num_points*num_outputs]*vals[2*j+1]);
             }
         }
         for(int i=0; i<num_eval; i++){
@@ -991,15 +991,13 @@ bool ExternalTester::testAllFourier() const{
             }
         }
 
-        double *v = new double[2 * num_eval * grid.getNumPoints()];
+        double *v = new double[2 * num_eval * num_points];
         getError(&f21expsincos, &grid, type_internal_interpolation);
         grid.evaluateHierarchicalFunctions(pnts, num_eval, v);
         grid.evaluateBatch(pnts, num_eval, y);
         for(int i=0; i<num_eval; i++){
             for(int j=0; j<grid.getNumPoints(); j++){
-                std::complex<double> fourier_coeff(coeff[2*j], coeff[2*j+1]);
-                std::complex<double> phi(v[2*(i*grid.getNumPoints()+j)], v[2*(i*grid.getNumPoints()+j)+1]);
-                y[i] -= (fourier_coeff * phi).real();
+                y[i] -= (coeff[j] * v[2*(i*num_points+j)] - coeff[j+num_points] * v[2*(i*num_points+j)+1]);
             }
         }
         for(int i=0; i<num_eval; i++){

--- a/SparseGrids/tasgridWrapper.cpp
+++ b/SparseGrids/tasgridWrapper.cpp
@@ -443,11 +443,27 @@ void TasgridWrapper::outputHierarchicalCoefficients() const{
     const double *coeff = grid->getHierarchicalCoefficients();
     int num_p = grid->getNumPoints();
     int num_d = grid->getNumOutputs();
-    if (outfilename != 0){
-        writeMatrix(outfilename, num_p, ((grid->isFourier()) ? 2 * num_d : num_d), coeff, useASCII);
-    }
-    if (printCout){
-        printMatrix(num_p, num_d, coeff, grid->isFourier());
+    if (grid->isFourier()){
+        // use interwoven format for complex coefficients
+        double *coeff_fourier = new double[2 * num_p * num_d];
+        for(int i=0; i<num_p*num_d; i++){
+            coeff_fourier[2*i] = coeff[i];
+            coeff_fourier[2*i+1] = coeff[i + num_d*num_p];
+        }
+        if (outfilename != 0){
+            writeMatrix(outfilename, num_p, 2*num_d, coeff_fourier, useASCII);
+        }
+        if (printCout){
+            printMatrix(num_p, num_d, coeff_fourier, true);
+        }
+        delete[] coeff_fourier;
+    }else{
+        if (outfilename != 0){
+            writeMatrix(outfilename, num_p, num_d, coeff, useASCII);
+        }
+        if (printCout){
+            printMatrix(num_p, num_d, coeff);
+        }
     }
 }
 bool TasgridWrapper::setConformalTransformation(){
@@ -766,11 +782,27 @@ bool TasgridWrapper::getSurpluses(){
     const double *surp = grid->getHierarchicalCoefficients();
     int num_p = grid->getNumLoaded();
     int num_o = grid->getNumOutputs();
-    if (outfilename != 0){
-        writeMatrix(outfilename, num_p, ((grid->isFourier()) ? 2 * num_o : num_o), surp, useASCII);
-    }
-    if (printCout){
-        printMatrix(num_p, num_o, surp, grid->isFourier());
+    if (grid->isFourier()){
+        // use interwoven format for complex coefficients
+        double *surp_fourier = new double[2 * num_p * num_o];
+        for(int i=0; i<num_p*num_o; i++){
+            surp_fourier[2*i] = surp[i];
+            surp_fourier[2*i+1] = surp[i + num_p*num_o];
+        }
+        if (outfilename != 0){
+            writeMatrix(outfilename, num_p, 2*num_o, surp_fourier, useASCII);
+        }
+        if (printCout){
+            printMatrix(num_p, num_o, surp_fourier, true);
+        }
+        delete[] surp_fourier;
+    }else{
+        if (outfilename != 0){
+            writeMatrix(outfilename, num_p, num_o, surp, useASCII);
+        }
+        if (printCout){
+            printMatrix(num_p, num_o, surp);
+        }
     }
     return true;
 }
@@ -1065,9 +1097,9 @@ void TasgridWrapper::printMatrix(int rows, int cols, const double mat[], bool is
     for(size_t i=0; i<((size_t) rows); i++){
         if (isComplex){
             for(size_t j=0; j<((size_t) cols); j++){
-                cout << setw(25) << mat[i* ((size_t) cols) + ((size_t) 2*j)];   // real part
-                cout << (mat[i* ((size_t) cols) + ((size_t) 2*j+1)] < 0.0 ? " -" : " +");
-                cout << setw(24) << fabs(mat[i* ((size_t) cols) + ((size_t) 2*j+1)]) << "i  ";     // imag part
+                cout << setw(25) << mat[((size_t) 2*(i*cols + j))];   // real part
+                cout << (mat[((size_t) 2*(i*cols + j) + 1)] < 0.0 ? " -" : " +");
+                cout << setw(24) << fabs(mat[((size_t) 2*(i*cols + j) + 1)]) << "i  ";     // imag part
             }
         }else{
             for(size_t j=0; j<((size_t) cols); j++){

--- a/SparseGrids/tsgGridFourier.hpp
+++ b/SparseGrids/tsgGridFourier.hpp
@@ -173,7 +173,7 @@ private:
     IndexSet *needed;
     IndexSet *exponents;
 
-    std::complex<double> *fourier_coefs;
+    double *fourier_coefs;
     int **exponent_refs;
     int **tensor_refs;
 


### PR DESCRIPTION
This branch reformats the internal storage of `fourier_coefs`. Internally, the coefficients are arranged so that all real parts are in the first block, and all imaginary parts are in the second block. In CLI-write, `fourier_coefs` is written to a file in the usual interwoven format. MATLAB, Python, and CLI-print will report the coefficients to the user as complex numbers.

(There were no edits to the MATLAB files because they already assumed that CLI-write uses the interwoven format.)