### PR TITLE
add cxx 11 standard for the examples (post install)

### DIFF
--- a/Config/CMakeLists.examples.txt
+++ b/Config/CMakeLists.examples.txt
@@ -27,6 +27,9 @@ endif()
 add_executable(example_sparse_grids  example_sparse_grids.cpp)
 add_executable(example_dream         example_dream.cpp)
 
+set_property(TARGET example_sparse_grids PROPERTY CXX_STANDARD 11)
+set_property(TARGET example_dream PROPERTY CXX_STANDARD 11)
+
 target_link_libraries(example_sparse_grids  ${Tasmanian_libsparsegrid})
 target_link_libraries(example_dream         ${Tasmanian_libdream})
 


### PR DESCRIPTION
* C++ standard 2011 is now mandatory for Tasmanian
* C++11 directives are included in the headers (in templates)
* set the standard for the examples when they are compiled post-install