### PR TITLE
Cuda exceptions

### DIFF
--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -968,14 +968,14 @@ void TasmanianSparseGrid::evaluateHierarchicalFunctionsGPU(const double gpu_x[],
     double *gpu_temp_x = 0;
     const double *gpu_canonical_x = formCanonicalPointsGPU(gpu_x, gpu_temp_x, cpu_num_x);
     pwpoly->buildDenseBasisMatrixGPU(gpu_canonical_x, cpu_num_x, gpu_y, logstream);
-    if (gpu_temp_x != 0) TasCUDA::cudaDel<double>(gpu_temp_x, logstream);
+    if (gpu_temp_x != 0) TasCUDA::cudaDel<double>(gpu_temp_x);
 }
 void TasmanianSparseGrid::evaluateSparseHierarchicalFunctionsGPU(const double gpu_x[], int cpu_num_x, int* &gpu_pntr, int* &gpu_indx, double* &gpu_vals, int &num_nz) const{
     _TASMANIAN_SETGPU
     double *gpu_temp_x = 0;
     const double *gpu_canonical_x = formCanonicalPointsGPU(gpu_x, gpu_temp_x, cpu_num_x);
     pwpoly->buildSparseBasisMatrixGPU(gpu_canonical_x, cpu_num_x, gpu_pntr, gpu_indx, gpu_vals, num_nz, logstream);
-    if (gpu_temp_x != 0) TasCUDA::cudaDel<double>(gpu_temp_x, logstream);
+    if (gpu_temp_x != 0) TasCUDA::cudaDel<double>(gpu_temp_x);
 }
 #else
 void TasmanianSparseGrid::evaluateHierarchicalFunctionsGPU(const double*, int, double*) const{

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -850,7 +850,7 @@ void TasmanianSparseGrid::formTransformedPoints(int num_points, double x[]) cons
 #ifdef Tasmanian_ENABLE_CUDA
 const double* TasmanianSparseGrid::formCanonicalPointsGPU(const double *gpu_x, double* &gpu_x_temp, int num_x) const{
     if (domain_transform_a != 0){
-        if (acc_domain == 0) acc_domain = new AccelerationDomainTransform(base->getNumDimensions(), domain_transform_a, domain_transform_b, logstream);
+        if (acc_domain == 0) acc_domain = new AccelerationDomainTransform(base->getNumDimensions(), domain_transform_a, domain_transform_b);
         gpu_x_temp = acc_domain->getCanonicalPoints(base->getNumDimensions(), num_x, gpu_x);
         return gpu_x_temp;
     }else{

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -407,15 +407,15 @@ void TasmanianSparseGrid::evaluateFast(const double x[], double y[]) const{
         case accel_gpu_default:
         case accel_gpu_cublas:
             _TASMANIAN_SETGPU
-            base->evaluateFastGPUcublas(x_canonical, y, logstream);
+            base->evaluateFastGPUcublas(x_canonical, y);
             break;
         case accel_gpu_cuda:
             _TASMANIAN_SETGPU
-            base->evaluateFastGPUcuda(x_canonical, y, logstream);
+            base->evaluateFastGPUcuda(x_canonical, y);
             break;
         case accel_gpu_magma:
             _TASMANIAN_SETGPU
-            base->evaluateFastGPUmagma(gpuID, x_canonical, y, logstream);
+            base->evaluateFastGPUmagma(gpuID, x_canonical, y);
             break;
         case accel_cpu_blas:
             base->evaluateFastCPUblas(x_canonical, y);
@@ -434,15 +434,15 @@ void TasmanianSparseGrid::evaluateBatch(const double x[], int num_x, double y[])
         case accel_gpu_default:
         case accel_gpu_cublas:
             _TASMANIAN_SETGPU
-            base->evaluateBatchGPUcublas(x_canonical, num_x, y, logstream);
+            base->evaluateBatchGPUcublas(x_canonical, num_x, y);
             break;
         case accel_gpu_cuda:
             _TASMANIAN_SETGPU
-            base->evaluateBatchGPUcuda(x_canonical, num_x, y, logstream);
+            base->evaluateBatchGPUcuda(x_canonical, num_x, y);
             break;
         case accel_gpu_magma:
             _TASMANIAN_SETGPU
-            base->evaluateBatchGPUmagma(gpuID, x_canonical, num_x, y, logstream);
+            base->evaluateBatchGPUmagma(gpuID, x_canonical, num_x, y);
             break;
         case accel_cpu_blas:
             base->evaluateBatchCPUblas(x_canonical, num_x, y);
@@ -967,14 +967,14 @@ void TasmanianSparseGrid::evaluateHierarchicalFunctionsGPU(const double gpu_x[],
     _TASMANIAN_SETGPU
     double *gpu_temp_x = 0;
     const double *gpu_canonical_x = formCanonicalPointsGPU(gpu_x, gpu_temp_x, cpu_num_x);
-    pwpoly->buildDenseBasisMatrixGPU(gpu_canonical_x, cpu_num_x, gpu_y, logstream);
+    pwpoly->buildDenseBasisMatrixGPU(gpu_canonical_x, cpu_num_x, gpu_y);
     if (gpu_temp_x != 0) TasCUDA::cudaDel<double>(gpu_temp_x);
 }
 void TasmanianSparseGrid::evaluateSparseHierarchicalFunctionsGPU(const double gpu_x[], int cpu_num_x, int* &gpu_pntr, int* &gpu_indx, double* &gpu_vals, int &num_nz) const{
     _TASMANIAN_SETGPU
     double *gpu_temp_x = 0;
     const double *gpu_canonical_x = formCanonicalPointsGPU(gpu_x, gpu_temp_x, cpu_num_x);
-    pwpoly->buildSparseBasisMatrixGPU(gpu_canonical_x, cpu_num_x, gpu_pntr, gpu_indx, gpu_vals, num_nz, logstream);
+    pwpoly->buildSparseBasisMatrixGPU(gpu_canonical_x, cpu_num_x, gpu_pntr, gpu_indx, gpu_vals, num_nz);
     if (gpu_temp_x != 0) TasCUDA::cudaDel<double>(gpu_temp_x);
 }
 #else
@@ -1080,7 +1080,7 @@ void TasmanianSparseGrid::evaluateSparseHierarchicalFunctionsStatic(const double
 }
 
 void TasmanianSparseGrid::setHierarchicalCoefficients(const double c[]){
-    base->setHierarchicalCoefficients(c, acceleration, logstream);
+    base->setHierarchicalCoefficients(c, acceleration);
 }
 void TasmanianSparseGrid::setHierarchicalCoefficients(const std::vector<double> c){ setHierarchicalCoefficients(c.data()); }
 

--- a/SparseGrids/tasgridExternalTests.cpp
+++ b/SparseGrids/tasgridExternalTests.cpp
@@ -1633,15 +1633,15 @@ bool ExternalTester::testGPU2GPUevaluations() const{
             bool dense_pass = true;
 
             cudaSetDevice(gpuID);
-            double *gpux = TasGrid::TasCUDA::cudaSend<double>(xt, &cerr);
-            double *gpuy = TasGrid::TasCUDA::cudaNew<double>(grid.getNumPoints() * nump, &cerr);
+            double *gpux = TasGrid::TasCUDA::cudaSend<double>(xt);
+            double *gpuy = TasGrid::TasCUDA::cudaNew<double>(grid.getNumPoints() * nump);
 
             grid.enableAcceleration(TasGrid::accel_gpu_cuda);
             grid.setGPUID(gpuID);
             grid.evaluateHierarchicalFunctionsGPU(gpux, nump, gpuy);
 
             double *y = new double[grid.getNumPoints() * nump];
-            TasGrid::TasCUDA::cudaRecv<double>(grid.getNumPoints() * nump, gpuy, y, &cerr);
+            TasGrid::TasCUDA::cudaRecv<double>(grid.getNumPoints() * nump, gpuy, y);
 
             for(int i=0; i<grid.getNumPoints() * nump; i++){
                 if (fabs(y[i] - y_true_dense[i]) > 1.E-11){
@@ -1655,7 +1655,7 @@ bool ExternalTester::testGPU2GPUevaluations() const{
             }
             pass = pass && dense_pass;
 
-            TasGrid::TasCUDA::cudaDel<double>(gpuy, &cerr);
+            TasGrid::TasCUDA::cudaDel<double>(gpuy);
             delete[] y;
 
             // Sparse version:
@@ -1666,9 +1666,9 @@ bool ExternalTester::testGPU2GPUevaluations() const{
             grid.setGPUID(gpuID);
             grid.evaluateSparseHierarchicalFunctionsGPU(gpux, nump, gpu_pntr, gpu_indx, gpu_vals, num_nz);
 
-            std::vector<int> cpntr; TasGrid::TasCUDA::cudaRecv<int>(nump+1, gpu_pntr, cpntr, &cerr);
-            std::vector<int> cindx; TasGrid::TasCUDA::cudaRecv<int>(num_nz, gpu_indx, cindx, &cerr);
-            std::vector<double> cvals; TasGrid::TasCUDA::cudaRecv<double>(num_nz, gpu_vals, cvals, &cerr);
+            std::vector<int> cpntr; TasGrid::TasCUDA::cudaRecv<int>(nump+1, gpu_pntr, cpntr);
+            std::vector<int> cindx; TasGrid::TasCUDA::cudaRecv<int>(num_nz, gpu_indx, cindx);
+            std::vector<double> cvals; TasGrid::TasCUDA::cudaRecv<double>(num_nz, gpu_vals, cvals);
 
             if (pntr[nump] != num_nz){
                 cout << "ERROR: mismatch in the numnz from cuda: " << num_nz << " and cpu " << pntr[nump] << endl;
@@ -1696,10 +1696,10 @@ bool ExternalTester::testGPU2GPUevaluations() const{
 
             pass = pass && sparse_pass;
 
-            TasGrid::TasCUDA::cudaDel<double>(gpux, &cerr);
-            TasGrid::TasCUDA::cudaDel<int>(gpu_pntr, &cerr);
-            TasGrid::TasCUDA::cudaDel<int>(gpu_indx, &cerr);
-            TasGrid::TasCUDA::cudaDel<double>(gpu_vals, &cerr);
+            TasGrid::TasCUDA::cudaDel<double>(gpux);
+            TasGrid::TasCUDA::cudaDel<int>(gpu_pntr);
+            TasGrid::TasCUDA::cudaDel<int>(gpu_indx);
+            TasGrid::TasCUDA::cudaDel<double>(gpu_vals);
         }
 
         delete[] pntr;

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -47,7 +47,7 @@ BaseAccelerationData::~BaseAccelerationData(){}
 
 AccelerationDataGPUFull::AccelerationDataGPUFull() :
     gpu_values(0), gpu_nodes(0), gpu_support(0),
-    gpu_hpntr(0), gpu_hindx(0), gpu_roots(0), logstream(0){
+    gpu_hpntr(0), gpu_hindx(0), gpu_roots(0){
 #ifdef Tasmanian_ENABLE_CUDA
     cublasHandle = 0;
     cusparseHandle = 0;
@@ -110,8 +110,6 @@ void AccelerationDataGPUFull::initializeMagma(int gpuID){
 #else
 void AccelerationDataGPUFull::initializeMagma(int){}
 #endif
-
-void AccelerationDataGPUFull::setLogStream(std::ostream *os){ logstream = os; }
 
 bool AccelerationDataGPUFull::isCompatible(TypeAcceleration acc) const{ return AccelerationMeta::isAccTypeFullMemoryGPU(acc); }
 
@@ -481,15 +479,15 @@ void AccelerationMeta::cusparseCheckError(void *cusparseStatus, const char *info
     }
 }
 #else
-void AccelerationMeta::cudaCheckError(void *, const char *, std::ostream *){}
-void AccelerationMeta::cublasCheckError(void *, const char *, std::ostream *){}
-void AccelerationMeta::cusparseCheckError(void *, const char *, std::ostream *){}
+void AccelerationMeta::cudaCheckError(void *, const char *){}
+void AccelerationMeta::cublasCheckError(void *, const char *){}
+void AccelerationMeta::cusparseCheckError(void *, const char *){}
 #endif // Tasmanian_ENABLE_CUDA
 
 
 #ifdef Tasmanian_ENABLE_CUDA
-AccelerationDomainTransform::AccelerationDomainTransform(int num_dimensions, const double *transform_a, const double *transform_b, std::ostream *os) :
-    gpu_trans_a(0), gpu_trans_b(0), padded_size(0), logstream(os)
+AccelerationDomainTransform::AccelerationDomainTransform(int num_dimensions, const double *transform_a, const double *transform_b) :
+    gpu_trans_a(0), gpu_trans_b(0), padded_size(0)
 {
     padded_size = num_dimensions;
     while(padded_size < 512) padded_size += num_dimensions;
@@ -521,7 +519,7 @@ double* AccelerationDomainTransform::getCanonicalPoints(int num_dimensions, int 
     return gpu_x_canonical;
 }
 #else
-AccelerationDomainTransform::AccelerationDomainTransform(int, const double*, const double*, std::ostream *){}
+AccelerationDomainTransform::AccelerationDomainTransform(int, const double*, const double*){}
 AccelerationDomainTransform::~AccelerationDomainTransform(){}
 double* AccelerationDomainTransform::getCanonicalPoints(int, int, const double*){ return 0; }
 #endif // Tasmanian_ENABLE_CUDA

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -419,62 +419,65 @@ TypeAcceleration AccelerationMeta::getAvailableFallback(TypeAcceleration accel){
 #ifdef Tasmanian_ENABLE_CUDA
 void AccelerationMeta::cudaCheckError(void *cudaStatus, const char *info, std::ostream *os){
     if (*((cudaError_t*) cudaStatus) != cudaSuccess){
-        if (os != 0){
-            (*os) << "ERROR: cuda failed at " << info << " with error: " << endl;
-            (*os) << cudaGetErrorString(*((cudaError_t*) cudaStatus)) << endl;
-        }
+        std::string message = "ERROR: cuda failed at ";
+        message += info;
+        message += " with error: ";
+        message += cudaGetErrorString(*((cudaError_t*) cudaStatus));
+        throw std::runtime_error(message);
     }
 }
 void AccelerationMeta::cublasCheckError(void *cublasStatus, const char *info, std::ostream *os){
     if (*((cublasStatus_t*) cublasStatus) != CUBLAS_STATUS_SUCCESS){
-        if (os != 0){
-            (*os) << "ERROR: cublas failed with code: ";
-            if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_NOT_INITIALIZED){
-                (*os) << "CUBLAS_STATUS_NOT_INITIALIZED";
-            }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_ALLOC_FAILED){
-                (*os) << "CUBLAS_STATUS_ALLOC_FAILED";
-            }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_INVALID_VALUE){
-                (*os) << "CUBLAS_STATUS_INVALID_VALUE";
-            }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_ARCH_MISMATCH){
-                (*os) << "CUBLAS_STATUS_ARCH_MISMATCH";
-            }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_MAPPING_ERROR){
-                (*os) << "CUBLAS_STATUS_MAPPING_ERROR";
-            }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_EXECUTION_FAILED){
-                (*os) << "CUBLAS_STATUS_EXECUTION_FAILED";
-            }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_INTERNAL_ERROR){
-                (*os) << "CUBLAS_STATUS_INTERNAL_ERROR";
-            }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_NOT_SUPPORTED){
-                (*os) << "CUBLAS_STATUS_NOT_SUPPORTED";
-            }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_LICENSE_ERROR){
-                (*os) << "CUBLAS_STATUS_LICENSE_ERROR";
-            }else{
-                (*os) << "UNKNOWN";
-            }
-            (*os) << " at " << info << endl;
+        std::string message = "ERROR: cuBlas failed with code: ";
+        if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_NOT_INITIALIZED){
+            message += "CUBLAS_STATUS_NOT_INITIALIZED";
+        }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_ALLOC_FAILED){
+            message += "CUBLAS_STATUS_ALLOC_FAILED";
+        }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_INVALID_VALUE){
+            message += "CUBLAS_STATUS_INVALID_VALUE";
+        }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_ARCH_MISMATCH){
+            message += "CUBLAS_STATUS_ARCH_MISMATCH";
+        }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_MAPPING_ERROR){
+            message += "CUBLAS_STATUS_MAPPING_ERROR";
+        }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_EXECUTION_FAILED){
+            message += "CUBLAS_STATUS_EXECUTION_FAILED";
+        }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_INTERNAL_ERROR){
+            message += "CUBLAS_STATUS_INTERNAL_ERROR";
+        }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_NOT_SUPPORTED){
+            message += "CUBLAS_STATUS_NOT_SUPPORTED";
+        }else if (*((cublasStatus_t*) cublasStatus) == CUBLAS_STATUS_LICENSE_ERROR){
+            message += "CUBLAS_STATUS_LICENSE_ERROR";
+        }else{
+            message += "UNKNOWN";
         }
+        message += " at ";
+        message += info;
+        throw std::runtime_error(message);
     }
 }
 void AccelerationMeta::cusparseCheckError(void *cusparseStatus, const char *info, std::ostream *os){
     if (*((cusparseStatus_t*) cusparseStatus) != CUSPARSE_STATUS_SUCCESS){
-        if (os != 0){
-            (*os)  << "ERROR: cusparse failed with code: ";
-            if (*((cusparseStatus_t*) cusparseStatus) == CUSPARSE_STATUS_NOT_INITIALIZED){
-                (*os) << "CUSPARSE_STATUS_NOT_INITIALIZED";
-            }else if (*((cusparseStatus_t*) cusparseStatus) == CUSPARSE_STATUS_ALLOC_FAILED){
-                (*os) << "CUSPARSE_STATUS_ALLOC_FAILED";
-            }else if (*((cusparseStatus_t*) cusparseStatus) == CUSPARSE_STATUS_INVALID_VALUE){
-                (*os) << "CUSPARSE_STATUS_INVALID_VALUE";
-            }else if (*((cusparseStatus_t*) cusparseStatus) == CUSPARSE_STATUS_ARCH_MISMATCH){
-                (*os) << "CUSPARSE_STATUS_ARCH_MISMATCH";
-            }else if (*((cusparseStatus_t*) cusparseStatus) == CUSPARSE_STATUS_INTERNAL_ERROR){
-                (*os) << "CUSPARSE_STATUS_INTERNAL_ERROR";
-            }else if (*((cusparseStatus_t*) cusparseStatus) == CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED){
-                (*os) << "CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED";
-            }else if (*((cusparseStatus_t*) cusparseStatus) == CUSPARSE_STATUS_EXECUTION_FAILED){
-                (*os) << "CUSPARSE_STATUS_EXECUTION_FAILED";
-            }
-            (*os) << " at " << info << endl;
+        std::string message = "ERROR: cuSparse failed with code: ";
+        if (*((cusparseStatus_t*) cusparseStatus) == CUSPARSE_STATUS_NOT_INITIALIZED){
+            message += "CUSPARSE_STATUS_NOT_INITIALIZED";
+        }else if (*((cusparseStatus_t*) cusparseStatus) == CUSPARSE_STATUS_ALLOC_FAILED){
+            message += "CUSPARSE_STATUS_ALLOC_FAILED";
+        }else if (*((cusparseStatus_t*) cusparseStatus) == CUSPARSE_STATUS_INVALID_VALUE){
+            message += "CUSPARSE_STATUS_INVALID_VALUE";
+        }else if (*((cusparseStatus_t*) cusparseStatus) == CUSPARSE_STATUS_ARCH_MISMATCH){
+            message += "CUSPARSE_STATUS_ARCH_MISMATCH";
+        }else if (*((cusparseStatus_t*) cusparseStatus) == CUSPARSE_STATUS_INTERNAL_ERROR){
+            message += "CUSPARSE_STATUS_INTERNAL_ERROR";
+        }else if (*((cusparseStatus_t*) cusparseStatus) == CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED){
+            message += "CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED";
+        }else if (*((cusparseStatus_t*) cusparseStatus) == CUSPARSE_STATUS_EXECUTION_FAILED){
+            message += "CUSPARSE_STATUS_EXECUTION_FAILED";
+        }else{
+            message += "UNKNOWN";
         }
+        message += " at ";
+        message += info;
+        throw std::runtime_error(message);
     }
 }
 #else

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -130,7 +130,7 @@ namespace TasCUDA{
     // evaluate local polynomial rules
     void devalpwpoly(int order, TypeOneDRule rule, int dims, int num_x, int num_points, const double *gpu_x, const double *gpu_nodes, const double *gpu_support, double *gpu_y);
     void devalpwpoly_sparse(int order, TypeOneDRule rule, int dims, int num_x, int num_points, const double *gpu_x, const double *gpu_nodes, const double *gpu_support,
-                            int *gpu_hpntr, int *gpu_hindx, int num_roots, int *gpu_roots, int* &gpu_spntr, int* &gpu_sindx, double* &gpu_svals, int &num_nzm, std::ostream *os);
+                            int *gpu_hpntr, int *gpu_hindx, int num_roots, int *gpu_roots, int* &gpu_spntr, int* &gpu_sindx, double* &gpu_svals, int &num_nzm);
     void devalpwpoly_sparse_dense(int order, TypeOneDRule rule, int dims, int num_x, int num_points, const double *gpu_x, const double *gpu_nodes, const double *gpu_support,
                                  int *gpu_hpntr, int *gpu_hindx, int num_roots, int *gpu_roots, double *gpu_dense);
 
@@ -174,9 +174,9 @@ namespace AccelerationMeta{
 
     TypeAcceleration getAvailableFallback(TypeAcceleration accel);
 
-    void cudaCheckError(void *cudaStatus, const char *info, std::ostream *os);
-    void cublasCheckError(void *cublasStatus, const char *info, std::ostream *os);
-    void cusparseCheckError(void *cusparseStatus, const char *info, std::ostream *os);
+    void cudaCheckError(void *cudaStatus, const char *info);
+    void cublasCheckError(void *cublasStatus, const char *info);
+    void cusparseCheckError(void *cusparseStatus, const char *info);
 }
 
 // stores domain transforms, to be used by the top class TasmanianSparseGrid

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -56,9 +56,6 @@ public:
     AccelerationDataGPUFull();
     ~AccelerationDataGPUFull();
 
-    void setLogStream(std::ostream *os);
-    // for GPU error messages/codes
-
     bool isCompatible(TypeAcceleration acc) const;
     // when setting a new acceleration, check if we need to also set a new object or can reuse this one
 
@@ -118,8 +115,6 @@ private:
     void *magmaCudaStream;
     void *magmaCudaQueue;
     #endif
-
-    std::ostream *logstream;
 };
 
 // namespace realized in tsgCudaKernels.cu, each function corresponds to a CUDA kernel for evaluations of basis matrix, domain transform, or fallback linear algebra
@@ -182,7 +177,7 @@ namespace AccelerationMeta{
 // stores domain transforms, to be used by the top class TasmanianSparseGrid
 class AccelerationDomainTransform{
 public:
-    AccelerationDomainTransform(int num_dimensions, const double *transform_a, const double *transform_b, std::ostream *os);
+    AccelerationDomainTransform(int num_dimensions, const double *transform_a, const double *transform_b);
     ~AccelerationDomainTransform();
 
     double* getCanonicalPoints(int num_dimensions, int num_x, const double *gpu_transformed_x);
@@ -192,8 +187,6 @@ private:
     #ifdef Tasmanian_ENABLE_CUDA
     double *gpu_trans_a, *gpu_trans_b;
     int padded_size;
-
-    std::ostream *logstream;
     #endif // Tasmanian_ENABLE_CUDA
 };
 

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -31,6 +31,9 @@
 #ifndef __TASMANIAN_SPARSE_GRID_ACCELERATED_DATA_STRUCTURES_HPP
 #define __TASMANIAN_SPARSE_GRID_ACCELERATED_DATA_STRUCTURES_HPP
 
+#include <stdexcept>
+#include <string>
+
 #include "tsgEnumerates.hpp"
 
 namespace TasGrid{

--- a/SparseGrids/tsgCudaMacros.hpp
+++ b/SparseGrids/tsgCudaMacros.hpp
@@ -49,59 +49,59 @@ namespace TasGrid{
 namespace TasCUDA{
     // general GPU/CPU I/O, new/delete vectors, send/recv data
     template <typename T>
-    inline T* cudaNew(size_t num_entries, std::ostream *os){
+    inline T* cudaNew(size_t num_entries){
         T* x = 0;
         cudaError_t cudaStat = cudaMalloc(((void**) &x), num_entries * sizeof(T));
-        AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaNew()", os);
+        AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaNew()");
         return x;
     }
 
     template <typename T>
-    inline T* cudaSend(size_t num_entries, const T *cpu_array, std::ostream *os){
-        T *x = cudaNew<T>(num_entries, os);
+    inline T* cudaSend(size_t num_entries, const T *cpu_array){
+        T *x = cudaNew<T>(num_entries);
         cudaError_t cudaStat = cudaMemcpy(x, cpu_array, num_entries * sizeof(T), cudaMemcpyHostToDevice);
-        AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaSend(type)", os);
+        AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaSend(type)");
         return x;
     }
 
     template <typename T>
-    inline T* cudaSend(std::vector<T> cpu_vector, std::ostream *os){
-        T *x = cudaNew<T>(cpu_vector.size(), os);
+    inline T* cudaSend(std::vector<T> cpu_vector){
+        T *x = cudaNew<T>(cpu_vector.size());
         cudaError_t cudaStat = cudaMemcpy(x, cpu_vector.data(), cpu_vector.size() * sizeof(T), cudaMemcpyHostToDevice);
-        AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaSend(type)", os);
+        AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaSend(type)");
         return x;
     }
 
     template <typename T>
-    inline void cudaSend(size_t num_entries, const T *cpu_array, T *gpu_array, std::ostream *os){
+    inline void cudaSend(size_t num_entries, const T *cpu_array, T *gpu_array){
         cudaError_t cudaStat = cudaMemcpy(gpu_array, cpu_array, num_entries * sizeof(T), cudaMemcpyHostToDevice);
-        AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaSend(type, type)", os);
+        AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaSend(type, type)");
     }
 
     template <typename T>
-    inline const T* cudaSendConst(size_t num_entries, const T *cpu_array, T* &gpu_temp_array, std::ostream *os){
+    inline const T* cudaSendConst(size_t num_entries, const T *cpu_array, T* &gpu_temp_array){
         // takes a const cpu_array and returns a newly allocated const gpu array
         // gpu_temp_array is an alias that can be used to delete the const gpu arrray
-        gpu_temp_array = cudaSend<T>(num_entries, cpu_array, os);
+        gpu_temp_array = cudaSend<T>(num_entries, cpu_array);
         return gpu_temp_array;
     }
 
     template <typename T>
-    inline void cudaRecv(size_t num_entries, const T *gpu_array, T *cpu_array, std::ostream *os){
+    inline void cudaRecv(size_t num_entries, const T *gpu_array, T *cpu_array){
         cudaError_t cudaStat = cudaMemcpy(cpu_array, gpu_array, num_entries * sizeof(T), cudaMemcpyDeviceToHost);
-        AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaRecv(type, type)", os);
+        AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaRecv(type, type)");
     }
 
     template <typename T>
-    inline void cudaRecv(size_t num_entries, const T *gpu_array, std::vector<T> &cpu_vector, std::ostream *os){
+    inline void cudaRecv(size_t num_entries, const T *gpu_array, std::vector<T> &cpu_vector){
         if (cpu_vector.size() < num_entries) cpu_vector.resize(num_entries);
-        cudaRecv<T>(num_entries, gpu_array, cpu_vector.data(), os);
+        cudaRecv<T>(num_entries, gpu_array, cpu_vector.data());
     }
 
     template <typename T>
-    inline void cudaDel(T *gpu_array, std::ostream *os){
+    inline void cudaDel(T *gpu_array){
         cudaError_t cudaStat = cudaFree(gpu_array);
-        AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaDel(type)", os);
+        AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaDel(type)");
     }
 }
 #endif

--- a/SparseGrids/tsgGridCore.hpp
+++ b/SparseGrids/tsgGridCore.hpp
@@ -63,22 +63,22 @@ public:
 
     virtual void evaluateFastCPUblas(const double x[], double y[]) const = 0;
 
-    virtual void evaluateFastGPUcublas(const double x[], double y[], std::ostream *os) const = 0;
-    virtual void evaluateFastGPUcuda(const double x[], double y[], std::ostream *os) const = 0;
-    virtual void evaluateFastGPUmagma(int gpuID, const double x[], double y[], std::ostream *os) const = 0;
+    virtual void evaluateFastGPUcublas(const double x[], double y[]) const = 0;
+    virtual void evaluateFastGPUcuda(const double x[], double y[]) const = 0;
+    virtual void evaluateFastGPUmagma(int gpuID, const double x[], double y[]) const = 0;
 
     virtual void evaluateBatch(const double x[], int num_x, double y[]) const = 0;
     virtual void evaluateBatchCPUblas(const double x[], int num_x, double y[]) const = 0;
 
-    virtual void evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream *os) const = 0;
-    virtual void evaluateBatchGPUcuda(const double x[], int num_x, double y[], std::ostream *os) const = 0;
-    virtual void evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[], std::ostream *os) const = 0;
+    virtual void evaluateBatchGPUcublas(const double x[], int num_x, double y[]) const = 0;
+    virtual void evaluateBatchGPUcuda(const double x[], int num_x, double y[]) const = 0;
+    virtual void evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[]) const = 0;
 
     virtual void clearRefinement() = 0;
     virtual void mergeRefinement() = 0;
 
     virtual void evaluateHierarchicalFunctions(const double x[], int num_x, double y[]) const = 0; // add acceleration here
-    virtual void setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream *os) = 0;
+    virtual void setHierarchicalCoefficients(const double c[], TypeAcceleration acc) = 0;
 
     virtual void clearAccelerationData() = 0;
 };

--- a/SparseGrids/tsgGridFourier.cpp
+++ b/SparseGrids/tsgGridFourier.cpp
@@ -666,26 +666,26 @@ void GridFourier::evaluateBatch(const double x[], int num_x, double y[]) const{
 void GridFourier::evaluateFastCPUblas(const double x[], double y[]) const{
     evaluate(x,y);
 }
-void GridFourier::evaluateFastGPUcublas(const double x[], double y[], std::ostream*) const{
+void GridFourier::evaluateFastGPUcublas(const double x[], double y[]) const{
     evaluate(x,y);
 }
-void GridFourier::evaluateFastGPUcuda(const double x[], double y[], std::ostream*) const{
+void GridFourier::evaluateFastGPUcuda(const double x[], double y[]) const{
     evaluate(x,y);
 }
-void GridFourier::evaluateFastGPUmagma(int, const double x[], double y[], std::ostream*) const{
+void GridFourier::evaluateFastGPUmagma(int, const double x[], double y[]) const{
     evaluate(x,y);
 }
 
 void GridFourier::evaluateBatchCPUblas(const double x[], int num_x, double y[]) const{
     evaluateBatch(x, num_x, y);
 }
-void GridFourier::evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream*) const {
+void GridFourier::evaluateBatchGPUcublas(const double x[], int num_x, double y[]) const {
     evaluateBatch(x, num_x, y);
 }
-void GridFourier::evaluateBatchGPUcuda(const double x[], int num_x, double y[], std::ostream*) const {
+void GridFourier::evaluateBatchGPUcuda(const double x[], int num_x, double y[]) const {
     evaluateBatch(x, num_x, y);
 }
-void GridFourier::evaluateBatchGPUmagma(int, const double x[], int num_x, double y[], std::ostream*) const {
+void GridFourier::evaluateBatchGPUmagma(int, const double x[], int num_x, double y[]) const {
     evaluateBatch(x, num_x, y);
 }
 
@@ -737,7 +737,7 @@ void GridFourier::evaluateHierarchicalFunctionsInternal(const double x[], int nu
     }
 }
 
-void GridFourier::setHierarchicalCoefficients(const double c[], TypeAcceleration, std::ostream*){
+void GridFourier::setHierarchicalCoefficients(const double c[], TypeAcceleration){
     // takes c to be length 2*num_outputs*num_points
     // first num_points*num_outputs are the real part; second num_points*num_outputs are the imaginary part
 

--- a/SparseGrids/tsgGridFourier.hpp
+++ b/SparseGrids/tsgGridFourier.hpp
@@ -87,20 +87,20 @@ public:
     void evaluateBatch(const double x[], int num_x, double y[]) const;
 
     void evaluateFastCPUblas(const double x[], double y[]) const;
-    void evaluateFastGPUcublas(const double x[], double y[], std::ostream *os) const;
-    void evaluateFastGPUcuda(const double x[], double y[], std::ostream *os) const;
-    void evaluateFastGPUmagma(int gpuID, const double x[], double y[], std::ostream *os) const;
+    void evaluateFastGPUcublas(const double x[], double y[]) const;
+    void evaluateFastGPUcuda(const double x[], double y[]) const;
+    void evaluateFastGPUmagma(int gpuID, const double x[], double y[]) const;
 
     void evaluateBatchCPUblas(const double x[], int num_x, double y[]) const;
-    void evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream *os) const;
-    void evaluateBatchGPUcuda(const double x[], int num_x, double y[], std::ostream *os) const;
-    void evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[], std::ostream *os) const;
+    void evaluateBatchGPUcublas(const double x[], int num_x, double y[]) const;
+    void evaluateBatchGPUcuda(const double x[], int num_x, double y[]) const;
+    void evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[]) const;
 
     void integrate(double q[], double *conformal_correction) const;
 
     void evaluateHierarchicalFunctions(const double x[], int num_x, double y[]) const;
     void evaluateHierarchicalFunctionsInternal(const double x[], int num_x, double M_real[], double M_imag[]) const;
-    void setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream *os);
+    void setHierarchicalCoefficients(const double c[], TypeAcceleration acc);
 
     void clearAccelerationData();
     void clearRefinement();

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -646,7 +646,7 @@ void GridGlobal::evaluateFastCPUblas(const double[], double[]) const{}
 
 #ifdef Tasmanian_ENABLE_CUDA
 void GridGlobal::evaluateFastGPUcublas(const double x[], double y[], std::ostream *os) const{
-    makeCheckAccelerationData(accel_gpu_cublas, os);
+    makeCheckAccelerationData(accel_gpu_cublas);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
     double *weights = new double[points->getNumIndexes()];
@@ -665,7 +665,7 @@ void GridGlobal::evaluateFastGPUcuda(const double x[], double y[], std::ostream 
 
 #ifdef Tasmanian_ENABLE_MAGMA
 void GridGlobal::evaluateFastGPUmagma(int gpuID, const double x[], double y[], std::ostream *os) const{
-    makeCheckAccelerationData(accel_gpu_magma, os);
+    makeCheckAccelerationData(accel_gpu_magma);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
     double *weights = new double[points->getNumIndexes()];
@@ -706,7 +706,7 @@ void GridGlobal::evaluateBatchCPUblas(const double[], int, double[]) const{}
 #ifdef Tasmanian_ENABLE_CUDA
 void GridGlobal::evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream *os) const{
     int num_points = points->getNumIndexes();
-    makeCheckAccelerationData(accel_gpu_cublas, os);
+    makeCheckAccelerationData(accel_gpu_cublas);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
     double *weights = new double[((size_t) num_points) * ((size_t) num_x)];
@@ -726,7 +726,7 @@ void GridGlobal::evaluateBatchGPUcuda(const double x[], int num_x, double y[], s
 #ifdef Tasmanian_ENABLE_MAGMA
 void GridGlobal::evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[], std::ostream *os) const{
     int num_points = points->getNumIndexes();
-    makeCheckAccelerationData(accel_gpu_magma, os);
+    makeCheckAccelerationData(accel_gpu_magma);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
     double *weights = new double[((size_t) num_points) * ((size_t) num_x)];
@@ -741,7 +741,7 @@ void GridGlobal::evaluateBatchGPUmagma(int, const double[], int, double[], std::
 #endif // Tasmanian_ENABLE_MAGMA
 
 #ifdef Tasmanian_ENABLE_CUDA
-void GridGlobal::makeCheckAccelerationData(TypeAcceleration acc, std::ostream *os) const{
+void GridGlobal::makeCheckAccelerationData(TypeAcceleration acc) const{
     if (AccelerationMeta::isAccTypeFullMemoryGPU(acc)){
         if ((accel != 0) && (!accel->isCompatible(acc))){
             delete accel;
@@ -749,13 +749,12 @@ void GridGlobal::makeCheckAccelerationData(TypeAcceleration acc, std::ostream *o
         }
         if (accel == 0){ accel = (BaseAccelerationData*) (new AccelerationDataGPUFull()); }
         AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
-        gpu->setLogStream(os);
         double *gpu_values = gpu->getGPUValues();
         if (gpu_values == 0) gpu->loadGPUValues(((size_t) points->getNumIndexes()) * ((size_t) values->getNumOutputs()), values->getValues(0));
     }
 }
 #else
-void GridGlobal::makeCheckAccelerationData(TypeAcceleration, std::ostream *) const{}
+void GridGlobal::makeCheckAccelerationData(TypeAcceleration) const{}
 #endif // Tasmanian_ENABLE_CUDA
 
 void GridGlobal::integrate(double q[], double *conformal_correction) const{

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -645,7 +645,7 @@ void GridGlobal::evaluateFastCPUblas(const double[], double[]) const{}
 #endif // Tasmanian_ENABLE_BLAS
 
 #ifdef Tasmanian_ENABLE_CUDA
-void GridGlobal::evaluateFastGPUcublas(const double x[], double y[], std::ostream *os) const{
+void GridGlobal::evaluateFastGPUcublas(const double x[], double y[]) const{
     makeCheckAccelerationData(accel_gpu_cublas);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
@@ -657,14 +657,14 @@ void GridGlobal::evaluateFastGPUcublas(const double x[], double y[], std::ostrea
     delete[] weights;
 }
 #else
-void GridGlobal::evaluateFastGPUcublas(const double[], double[], std::ostream *) const{}
+void GridGlobal::evaluateFastGPUcublas(const double[], double[]) const{}
 #endif // Tasmanian_ENABLE_CUDA
-void GridGlobal::evaluateFastGPUcuda(const double x[], double y[], std::ostream *os) const{
-    evaluateFastGPUcublas(x, y, os);
+void GridGlobal::evaluateFastGPUcuda(const double x[], double y[]) const{
+    evaluateFastGPUcublas(x, y);
 }
 
 #ifdef Tasmanian_ENABLE_MAGMA
-void GridGlobal::evaluateFastGPUmagma(int gpuID, const double x[], double y[], std::ostream *os) const{
+void GridGlobal::evaluateFastGPUmagma(int gpuID, const double x[], double y[]) const{
     makeCheckAccelerationData(accel_gpu_magma);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
@@ -676,7 +676,7 @@ void GridGlobal::evaluateFastGPUmagma(int gpuID, const double x[], double y[], s
     delete[] weights;
 }
 #else
-void GridGlobal::evaluateFastGPUmagma(int, const double[], double[], std::ostream *) const{}
+void GridGlobal::evaluateFastGPUmagma(int, const double[], double[]) const{}
 #endif // Tasmanian_ENABLE_MAGMA
 
 void GridGlobal::evaluateBatch(const double x[], int num_x, double y[]) const{
@@ -704,7 +704,7 @@ void GridGlobal::evaluateBatchCPUblas(const double[], int, double[]) const{}
 #endif // Tasmanian_ENABLE_BLAS
 
 #ifdef Tasmanian_ENABLE_CUDA
-void GridGlobal::evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream *os) const{
+void GridGlobal::evaluateBatchGPUcublas(const double x[], int num_x, double y[]) const{
     int num_points = points->getNumIndexes();
     makeCheckAccelerationData(accel_gpu_cublas);
 
@@ -717,14 +717,14 @@ void GridGlobal::evaluateBatchGPUcublas(const double x[], int num_x, double y[],
     delete[] weights;
 }
 #else
-void GridGlobal::evaluateBatchGPUcublas(const double[], int, double[], std::ostream *) const{}
+void GridGlobal::evaluateBatchGPUcublas(const double[], int, double[]) const{}
 #endif // Tasmanian_ENABLE_CUDA
-void GridGlobal::evaluateBatchGPUcuda(const double x[], int num_x, double y[], std::ostream *os) const{
-    evaluateBatchGPUcublas(x, num_x, y, os);
+void GridGlobal::evaluateBatchGPUcuda(const double x[], int num_x, double y[]) const{
+    evaluateBatchGPUcublas(x, num_x, y);
 }
 
 #ifdef Tasmanian_ENABLE_MAGMA
-void GridGlobal::evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[], std::ostream *os) const{
+void GridGlobal::evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[]) const{
     int num_points = points->getNumIndexes();
     makeCheckAccelerationData(accel_gpu_magma);
 
@@ -737,7 +737,7 @@ void GridGlobal::evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, d
     delete[] weights;
 }
 #else
-void GridGlobal::evaluateBatchGPUmagma(int, const double[], int, double[], std::ostream *) const{}
+void GridGlobal::evaluateBatchGPUmagma(int, const double[], int, double[]) const{}
 #endif // Tasmanian_ENABLE_MAGMA
 
 #ifdef Tasmanian_ENABLE_CUDA
@@ -1113,7 +1113,7 @@ void GridGlobal::setSurplusRefinement(double tolerance, int output, const int *l
     delete[] flagged;
     delete[] surp;
 }
-void GridGlobal::setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream*){
+void GridGlobal::setHierarchicalCoefficients(const double c[], TypeAcceleration acc){
     if (accel != 0) accel->resetGPULoadedData();
     if (points != 0) clearRefinement();
     loadNeededPoints(c, acc);

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -91,15 +91,15 @@ public:
     void integrate(double q[], double *conformal_correction) const;
 
     void evaluateFastCPUblas(const double x[], double y[]) const;
-    void evaluateFastGPUcublas(const double x[], double y[], std::ostream *os) const;
-    void evaluateFastGPUcuda(const double x[], double y[], std::ostream *os) const;
-    void evaluateFastGPUmagma(int gpuID, const double x[], double y[], std::ostream *os) const;
+    void evaluateFastGPUcublas(const double x[], double y[]) const;
+    void evaluateFastGPUcuda(const double x[], double y[]) const;
+    void evaluateFastGPUmagma(int gpuID, const double x[], double y[]) const;
 
     void evaluateBatch(const double x[], int num_x, double y[]) const;
     void evaluateBatchCPUblas(const double x[], int num_x, double y[]) const;
-    void evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream *os) const;
-    void evaluateBatchGPUcuda(const double x[], int num_x, double y[], std::ostream *os) const;
-    void evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[], std::ostream *os) const;
+    void evaluateBatchGPUcublas(const double x[], int num_x, double y[]) const;
+    void evaluateBatchGPUcuda(const double x[], int num_x, double y[]) const;
+    void evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[]) const;
 
     int* estimateAnisotropicCoefficients(TypeDepth type, int output) const;
 
@@ -109,7 +109,7 @@ public:
     void mergeRefinement();
 
     void evaluateHierarchicalFunctions(const double x[], int num_x, double y[]) const;
-    void setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream *os);
+    void setHierarchicalCoefficients(const double c[], TypeAcceleration acc);
 
     void clearAccelerationData();
 

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -124,7 +124,7 @@ protected:
 
     static double legendre(int n, double x);
 
-    void makeCheckAccelerationData(TypeAcceleration acc, std::ostream *os) const;
+    void makeCheckAccelerationData(TypeAcceleration acc) const;
 
 private:
     int num_dimensions, num_outputs;

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -433,7 +433,7 @@ void GridLocalPolynomial::evaluateFastCPUblas(const double x[], double y[]) cons
 #ifdef Tasmanian_ENABLE_CUDA
 void GridLocalPolynomial::evaluateFastGPUcublas(const double x[], double y[], std::ostream *os) const{
     int num_points = points->getNumIndexes();
-    makeCheckAccelerationData(accel_gpu_cublas, os);
+    makeCheckAccelerationData(accel_gpu_cublas);
     checkAccelerationGPUValues();
     AccelerationDataGPUFull *gpu_acc = (AccelerationDataGPUFull*) accel;
 
@@ -512,7 +512,7 @@ void GridLocalPolynomial::evaluateBatchCPUblas(const double x[], int num_x, doub
 #ifdef Tasmanian_ENABLE_CUDA
 void GridLocalPolynomial::evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream *os) const{
     int num_points = points->getNumIndexes();
-    makeCheckAccelerationData(accel_gpu_cublas, os);
+    makeCheckAccelerationData(accel_gpu_cublas);
     checkAccelerationGPUValues();
     AccelerationDataGPUFull *gpu_acc = (AccelerationDataGPUFull*) accel;
 
@@ -532,7 +532,7 @@ void GridLocalPolynomial::evaluateBatchGPUcuda(const double x[], int num_x, doub
         return;
     }
     int num_points = points->getNumIndexes();
-    makeCheckAccelerationData(accel_gpu_cuda, os);
+    makeCheckAccelerationData(accel_gpu_cuda);
     checkAccelerationGPUValues();
     checkAccelerationGPUNodes();
     AccelerationDataGPUFull *gpu_acc = (AccelerationDataGPUFull*) accel;
@@ -1100,14 +1100,14 @@ void GridLocalPolynomial::buildSparseMatrixBlockForm(const double x[], int num_x
 #ifdef Tasmanian_ENABLE_CUDA
 void GridLocalPolynomial::buildDenseBasisMatrixGPU(const double gpu_x[], int cpu_num_x, double gpu_y[], std::ostream *os) const{
     int num_points = getNumPoints();
-    makeCheckAccelerationData(accel_gpu_cuda, os);
+    makeCheckAccelerationData(accel_gpu_cuda);
     checkAccelerationGPUNodes();
     AccelerationDataGPUFull *gpu_acc = (AccelerationDataGPUFull*) accel;
     TasCUDA::devalpwpoly(order, rule->getType(), num_dimensions, cpu_num_x, num_points, gpu_x, gpu_acc->getGPUNodes(), gpu_acc->getGPUSupport(), gpu_y);
 }
 void GridLocalPolynomial::buildSparseBasisMatrixGPU(const double gpu_x[], int cpu_num_x, int* &gpu_spntr, int* &gpu_sindx, double* &gpu_svals, int &num_nz, std::ostream *os) const{
     int num_points = getNumPoints();
-    makeCheckAccelerationData(accel_gpu_cuda, os);
+    makeCheckAccelerationData(accel_gpu_cuda);
     checkAccelerationGPUNodes();
     checkAccelerationGPUHierarchy();
     AccelerationDataGPUFull *gpu_acc = (AccelerationDataGPUFull*) accel;
@@ -1702,14 +1702,13 @@ void GridLocalPolynomial::setHierarchicalCoefficients(const double c[], TypeAcce
 }
 
 #ifdef Tasmanian_ENABLE_CUDA
-void GridLocalPolynomial::makeCheckAccelerationData(TypeAcceleration acc, std::ostream *os) const{
+void GridLocalPolynomial::makeCheckAccelerationData(TypeAcceleration acc) const{
     if (AccelerationMeta::isAccTypeFullMemoryGPU(acc)){
         if ((accel != 0) && (!accel->isCompatible(acc))){
             delete accel;
             accel = 0;
         }
         if (accel == 0){ accel = (BaseAccelerationData*) (new AccelerationDataGPUFull()); }
-        ((AccelerationDataGPUFull*) accel)->setLogStream(os);
     }
 }
 void GridLocalPolynomial::checkAccelerationGPUValues() const{
@@ -1758,7 +1757,7 @@ void GridLocalPolynomial::checkAccelerationGPUHierarchy() const{
     gpu->loadGPUHierarchy(num_points, pntr.data(), indx.data(), (int) roots.size(), roots.data());
 }
 #else
-void GridLocalPolynomial::makeCheckAccelerationData(TypeAcceleration, std::ostream *) const{}
+void GridLocalPolynomial::makeCheckAccelerationData(TypeAcceleration) const{}
 void GridLocalPolynomial::checkAccelerationGPUValues() const{}
 void GridLocalPolynomial::checkAccelerationGPUNodes() const{}
 void GridLocalPolynomial::checkAccelerationGPUHierarchy() const{}

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -78,15 +78,15 @@ public:
     void integrate(double q[], double *conformal_correction) const;
 
     void evaluateFastCPUblas(const double x[], double y[]) const;
-    void evaluateFastGPUcublas(const double x[], double y[], std::ostream *os) const;
-    void evaluateFastGPUcuda(const double x[], double y[], std::ostream *os) const;
-    void evaluateFastGPUmagma(int gpuID, const double x[], double y[], std::ostream *os) const;
+    void evaluateFastGPUcublas(const double x[], double y[]) const;
+    void evaluateFastGPUcuda(const double x[], double y[]) const;
+    void evaluateFastGPUmagma(int gpuID, const double x[], double y[]) const;
 
     void evaluateBatch(const double x[], int num_x, double y[]) const;
     void evaluateBatchCPUblas(const double x[], int num_x, double y[]) const;
-    void evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream *os) const;
-    void evaluateBatchGPUcuda(const double x[], int num_x, double y[], std::ostream *os) const;
-    void evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[], std::ostream *os) const;
+    void evaluateBatchGPUcublas(const double x[], int num_x, double y[]) const;
+    void evaluateBatchGPUcuda(const double x[], int num_x, double y[]) const;
+    void evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[]) const;
 
     void setSurplusRefinement(double tolerance, TypeRefinement criteria, int output, const int *level_limits, const double *scale_correction);
     void clearRefinement();
@@ -94,7 +94,7 @@ public:
     int removePointsByHierarchicalCoefficient(double tolerance, int output, const double *scale_correction); // returns the number of points kept
 
     void evaluateHierarchicalFunctions(const double x[], int num_x, double y[]) const;
-    void setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream *os);
+    void setHierarchicalCoefficients(const double c[], TypeAcceleration acc);
 
     void clearAccelerationData();
     void setFavorSparse(bool favor);
@@ -108,8 +108,8 @@ public:
     int getSpareBasisMatrixNZ(const double x[], int num_x, int num_chunk) const;
 
     // EXPERIMENTAL: GPU evaluateHierarchicalFunctionsGPU()
-    void buildDenseBasisMatrixGPU(const double gpu_x[], int cpu_num_x, double gpu_y[], std::ostream *os) const;
-    void buildSparseBasisMatrixGPU(const double gpu_x[], int cpu_num_x, int* &gpu_spntr, int* &gpu_sindx, double* &gpu_svals, int &num_nz, std::ostream *os) const;
+    void buildDenseBasisMatrixGPU(const double gpu_x[], int cpu_num_x, double gpu_y[]) const;
+    void buildSparseBasisMatrixGPU(const double gpu_x[], int cpu_num_x, int* &gpu_spntr, int* &gpu_sindx, double* &gpu_svals, int &num_nz) const;
 
 protected:
     void reset(bool clear_rule = true);

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -253,7 +253,7 @@ protected:
     void addChild(const int point[], int direction, GranulatedIndexSet *destination, IndexSet *exclude) const;
     void addChildLimited(const int point[], int direction, GranulatedIndexSet *destination, IndexSet *exclude, const int *level_limits) const;
 
-    void makeCheckAccelerationData(TypeAcceleration acc, std::ostream *os) const;
+    void makeCheckAccelerationData(TypeAcceleration acc) const;
     void checkAccelerationGPUValues() const;
     void checkAccelerationGPUNodes() const;
     void checkAccelerationGPUHierarchy() const;

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -421,7 +421,7 @@ void GridSequence::evaluateFastCPUblas(const double[], double[]) const{}
 #endif // Tasmanian_ENABLE_BLAS
 
 #ifdef Tasmanian_ENABLE_CUDA
-void GridSequence::evaluateFastGPUcublas(const double x[], double y[], std::ostream *os) const{
+void GridSequence::evaluateFastGPUcublas(const double x[], double y[]) const{
     makeCheckAccelerationData(accel_gpu_cublas);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
@@ -432,14 +432,14 @@ void GridSequence::evaluateFastGPUcublas(const double x[], double y[], std::ostr
     delete[] fvalues;
 }
 #else
-void GridSequence::evaluateFastGPUcublas(const double[], double[], std::ostream *) const{}
+void GridSequence::evaluateFastGPUcublas(const double[], double[]) const{}
 #endif // Tasmanian_ENABLE_CUDA
-void GridSequence::evaluateFastGPUcuda(const double x[], double y[], std::ostream *os) const{
-    evaluateFastGPUcublas(x, y, os);
+void GridSequence::evaluateFastGPUcuda(const double x[], double y[]) const{
+    evaluateFastGPUcublas(x, y);
 }
 
 #ifdef Tasmanian_ENABLE_MAGMA
-void GridSequence::evaluateFastGPUmagma(int gpuID, const double x[], double y[], std::ostream *os) const{
+void GridSequence::evaluateFastGPUmagma(int gpuID, const double x[], double y[]) const{
     makeCheckAccelerationData(accel_gpu_magma);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
@@ -450,7 +450,7 @@ void GridSequence::evaluateFastGPUmagma(int gpuID, const double x[], double y[],
     delete[] fvalues;
 }
 #else
-void GridSequence::evaluateFastGPUmagma(int, const double[], double[], std::ostream *) const{}
+void GridSequence::evaluateFastGPUmagma(int, const double[], double[]) const{}
 #endif
 
 void GridSequence::evaluateBatch(const double x[], int num_x, double y[]) const{
@@ -478,7 +478,7 @@ void GridSequence::evaluateBatchCPUblas(const double[], int, double[]) const{}
 #endif // Tasmanian_ENABLE_BLAS
 
 #ifdef Tasmanian_ENABLE_CUDA
-void GridSequence::evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream *os) const{
+void GridSequence::evaluateBatchGPUcublas(const double x[], int num_x, double y[]) const{
     int num_points = points->getNumIndexes();
     makeCheckAccelerationData(accel_gpu_cublas);
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
@@ -490,7 +490,7 @@ void GridSequence::evaluateBatchGPUcublas(const double x[], int num_x, double y[
 
     delete[] fvalues;
 }
-void GridSequence::evaluateBatchGPUcuda(const double x[], int num_x, double y[], std::ostream *os) const{
+void GridSequence::evaluateBatchGPUcuda(const double x[], int num_x, double y[]) const{
     int num_points = points->getNumIndexes();
     makeCheckAccelerationData(accel_gpu_cublas);
     AccelerationDataGPUFull *gpu_acc = (AccelerationDataGPUFull*) accel;
@@ -512,12 +512,12 @@ void GridSequence::evaluateBatchGPUcuda(const double x[], int num_x, double y[],
     delete[] fvalues;
 }
 #else
-void GridSequence::evaluateBatchGPUcublas(const double[], int, double[], std::ostream *) const{}
-void GridSequence::evaluateBatchGPUcuda(const double[], int, double[], std::ostream *) const{}
+void GridSequence::evaluateBatchGPUcublas(const double[], int, double[]) const{}
+void GridSequence::evaluateBatchGPUcuda(const double[], int, double[]) const{}
 #endif // Tasmanian_ENABLE_CUDA
 
 #ifdef Tasmanian_ENABLE_MAGMA
-void GridSequence::evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[], std::ostream *os) const{
+void GridSequence::evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[]) const{
     int num_points = points->getNumIndexes();
     makeCheckAccelerationData(accel_gpu_magma);
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
@@ -530,7 +530,7 @@ void GridSequence::evaluateBatchGPUmagma(int gpuID, const double x[], int num_x,
     delete[] fvalues;
 }
 #else
-void GridSequence::evaluateBatchGPUmagma(int, const double[], int, double[], std::ostream *) const{}
+void GridSequence::evaluateBatchGPUmagma(int, const double[], int, double[]) const{}
 #endif // Tasmanian_ENABLE_MAGMA
 
 #ifdef Tasmanian_ENABLE_CUDA
@@ -630,7 +630,7 @@ void GridSequence::evalHierarchicalFunctions(const double x[], double fvalues[])
     for(int j=0; j<num_dimensions; j++) delete[] cache[j];
     delete[] cache;
 }
-void GridSequence::setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream *os){
+void GridSequence::setHierarchicalCoefficients(const double c[], TypeAcceleration acc){
     if (accel != 0) accel->resetGPULoadedData();
     std::vector<double> *vals = 0;
     size_t num_ponits = (size_t) getNumPoints();
@@ -651,9 +651,9 @@ void GridSequence::setHierarchicalCoefficients(const double c[], TypeAcceleratio
     if (acc == accel_cpu_blas){
         evaluateBatchCPUblas(x.data(), points->getNumIndexes(), vals->data());
     }else if (acc == accel_gpu_cublas){
-        evaluateBatchGPUcublas(x.data(), points->getNumIndexes(), vals->data(), os);
+        evaluateBatchGPUcublas(x.data(), points->getNumIndexes(), vals->data());
     }else if (acc == accel_gpu_cuda){
-        evaluateBatchGPUcuda(x.data(), points->getNumIndexes(), vals->data(), os);
+        evaluateBatchGPUcuda(x.data(), points->getNumIndexes(), vals->data());
     }else{
         evaluateBatch(x.data(), points->getNumIndexes(), vals->data());
     }

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -498,16 +498,16 @@ void GridSequence::evaluateBatchGPUcuda(const double x[], int num_x, double y[],
     double *fvalues = new double[((size_t) num_points) * ((size_t) num_x)];
     evaluateHierarchicalFunctions(x, num_x, fvalues); // this will be replaced by GPU eval function
 
-    double *gpu_weights = TasCUDA::cudaSend<double>(((size_t) num_points) * ((size_t) num_x), fvalues, os);
-    double *gpu_result = TasCUDA::cudaNew<double>(((size_t) num_outputs) * ((size_t) num_x), os);
+    double *gpu_weights = TasCUDA::cudaSend<double>(((size_t) num_points) * ((size_t) num_x), fvalues);
+    double *gpu_result = TasCUDA::cudaNew<double>(((size_t) num_outputs) * ((size_t) num_x));
 
     gpu_acc->cublasDGEMM(false, num_outputs, num_x, num_points, gpu_weights, gpu_result);
     //TasCUDA::cudaDgemm(num_outputs, num_x, num_points, gpu_acc->getGPUValues(), gpu_weights, gpu_result);
 
-    TasCUDA::cudaRecv<double>(((size_t) num_outputs) * ((size_t) num_x), gpu_result, y, os);
+    TasCUDA::cudaRecv<double>(((size_t) num_outputs) * ((size_t) num_x), gpu_result, y);
 
-    TasCUDA::cudaDel<double>(gpu_result, os);
-    TasCUDA::cudaDel<double>(gpu_weights, os);
+    TasCUDA::cudaDel<double>(gpu_result);
+    TasCUDA::cudaDel<double>(gpu_weights);
 
     delete[] fvalues;
 }

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -422,7 +422,7 @@ void GridSequence::evaluateFastCPUblas(const double[], double[]) const{}
 
 #ifdef Tasmanian_ENABLE_CUDA
 void GridSequence::evaluateFastGPUcublas(const double x[], double y[], std::ostream *os) const{
-    makeCheckAccelerationData(accel_gpu_cublas, os);
+    makeCheckAccelerationData(accel_gpu_cublas);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
     double *fvalues = evalHierarchicalFunctions(x);
@@ -440,7 +440,7 @@ void GridSequence::evaluateFastGPUcuda(const double x[], double y[], std::ostrea
 
 #ifdef Tasmanian_ENABLE_MAGMA
 void GridSequence::evaluateFastGPUmagma(int gpuID, const double x[], double y[], std::ostream *os) const{
-    makeCheckAccelerationData(accel_gpu_magma, os);
+    makeCheckAccelerationData(accel_gpu_magma);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
     double *fvalues = evalHierarchicalFunctions(x);
@@ -480,7 +480,7 @@ void GridSequence::evaluateBatchCPUblas(const double[], int, double[]) const{}
 #ifdef Tasmanian_ENABLE_CUDA
 void GridSequence::evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream *os) const{
     int num_points = points->getNumIndexes();
-    makeCheckAccelerationData(accel_gpu_cublas, os);
+    makeCheckAccelerationData(accel_gpu_cublas);
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
 
     double *fvalues = new double[((size_t) num_points) * ((size_t) num_x)];
@@ -492,7 +492,7 @@ void GridSequence::evaluateBatchGPUcublas(const double x[], int num_x, double y[
 }
 void GridSequence::evaluateBatchGPUcuda(const double x[], int num_x, double y[], std::ostream *os) const{
     int num_points = points->getNumIndexes();
-    makeCheckAccelerationData(accel_gpu_cublas, os);
+    makeCheckAccelerationData(accel_gpu_cublas);
     AccelerationDataGPUFull *gpu_acc = (AccelerationDataGPUFull*) accel;
 
     double *fvalues = new double[((size_t) num_points) * ((size_t) num_x)];
@@ -519,7 +519,7 @@ void GridSequence::evaluateBatchGPUcuda(const double[], int, double[], std::ostr
 #ifdef Tasmanian_ENABLE_MAGMA
 void GridSequence::evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[], std::ostream *os) const{
     int num_points = points->getNumIndexes();
-    makeCheckAccelerationData(accel_gpu_magma, os);
+    makeCheckAccelerationData(accel_gpu_magma);
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
 
     double *fvalues = new double[((size_t) num_points) * ((size_t) num_x)];
@@ -534,7 +534,7 @@ void GridSequence::evaluateBatchGPUmagma(int, const double[], int, double[], std
 #endif // Tasmanian_ENABLE_MAGMA
 
 #ifdef Tasmanian_ENABLE_CUDA
-void GridSequence::makeCheckAccelerationData(TypeAcceleration acc, std::ostream *os) const{
+void GridSequence::makeCheckAccelerationData(TypeAcceleration acc) const{
     if (AccelerationMeta::isAccTypeFullMemoryGPU(acc)){
         if ((accel != 0) && (!accel->isCompatible(acc))){
             delete accel;
@@ -542,13 +542,12 @@ void GridSequence::makeCheckAccelerationData(TypeAcceleration acc, std::ostream 
         }
         if (accel == 0){ accel = (BaseAccelerationData*) (new AccelerationDataGPUFull()); }
         AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
-        gpu->setLogStream(os);
         double *gpu_values = gpu->getGPUValues();
         if (gpu_values == 0) gpu->loadGPUValues(((size_t) points->getNumIndexes()) * ((size_t) values->getNumOutputs()), surpluses);
     }
 }
 #else
-void GridSequence::makeCheckAccelerationData(TypeAcceleration, std::ostream *) const{}
+void GridSequence::makeCheckAccelerationData(TypeAcceleration) const{}
 #endif // Tasmanian_ENABLE_CUDA
 
 void GridSequence::integrate(double q[], double *conformal_correction) const{

--- a/SparseGrids/tsgGridSequence.hpp
+++ b/SparseGrids/tsgGridSequence.hpp
@@ -86,15 +86,15 @@ public:
     void integrate(double q[], double *conformal_correction) const;
 
     void evaluateFastCPUblas(const double x[], double y[]) const;
-    void evaluateFastGPUcublas(const double x[], double y[], std::ostream *os) const;
-    void evaluateFastGPUcuda(const double x[], double y[], std::ostream *os) const;
-    void evaluateFastGPUmagma(int gpuID, const double x[], double y[], std::ostream *os) const;
+    void evaluateFastGPUcublas(const double x[], double y[]) const;
+    void evaluateFastGPUcuda(const double x[], double y[]) const;
+    void evaluateFastGPUmagma(int gpuID, const double x[], double y[]) const;
 
     void evaluateBatch(const double x[], int num_x, double y[]) const;
     void evaluateBatchCPUblas(const double x[], int num_x, double y[]) const;
-    void evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream *os) const;
-    void evaluateBatchGPUcuda(const double x[], int num_x, double y[], std::ostream *os) const;
-    void evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[], std::ostream *os) const;
+    void evaluateBatchGPUcublas(const double x[], int num_x, double y[]) const;
+    void evaluateBatchGPUcuda(const double x[], int num_x, double y[]) const;
+    void evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[]) const;
 
     void evaluateHierarchicalFunctions(const double x[], int num_x, double y[]) const;
 
@@ -104,7 +104,7 @@ public:
     void clearRefinement();
     void mergeRefinement();
 
-    void setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream *os);
+    void setHierarchicalCoefficients(const double c[], TypeAcceleration acc);
 
     void getPolynomialSpace(bool interpolation, int &n, int* &poly) const;
 

--- a/SparseGrids/tsgGridSequence.hpp
+++ b/SparseGrids/tsgGridSequence.hpp
@@ -143,7 +143,7 @@ protected:
 
     double evalBasis(const int f[], const int p[]) const; // evaluate function corresponding to f at p
 
-    void makeCheckAccelerationData(TypeAcceleration acc, std::ostream *os) const;
+    void makeCheckAccelerationData(TypeAcceleration acc) const;
 
 private:
     int num_dimensions, num_outputs;

--- a/SparseGrids/tsgGridWavelet.cpp
+++ b/SparseGrids/tsgGridWavelet.cpp
@@ -335,9 +335,9 @@ void GridWavelet::evaluate(const double x[], double y[]) const{
 }
 
 void GridWavelet::evaluateFastCPUblas(const double x[], double y[]) const{ evaluate(x, y); }
-void GridWavelet::evaluateFastGPUcublas(const double x[], double y[], std::ostream*) const{ evaluate(x, y); }
-void GridWavelet::evaluateFastGPUcuda(const double x[], double y[], std::ostream*) const{ evaluate(x, y); }
-void GridWavelet::evaluateFastGPUmagma(int, const double x[], double y[], std::ostream*) const{ evaluate(x, y); }
+void GridWavelet::evaluateFastGPUcublas(const double x[], double y[]) const{ evaluate(x, y); }
+void GridWavelet::evaluateFastGPUcuda(const double x[], double y[]) const{ evaluate(x, y); }
+void GridWavelet::evaluateFastGPUmagma(int, const double x[], double y[]) const{ evaluate(x, y); }
 
 void GridWavelet::evaluateBatch(const double x[], int num_x, double y[]) const{
     #pragma omp parallel for
@@ -348,13 +348,13 @@ void GridWavelet::evaluateBatch(const double x[], int num_x, double y[]) const{
 void GridWavelet::evaluateBatchCPUblas(const double x[], int num_x, double y[]) const{
     evaluateBatch(x, num_x, y);
 }
-void GridWavelet::evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream*) const{
+void GridWavelet::evaluateBatchGPUcublas(const double x[], int num_x, double y[]) const{
     evaluateBatch(x, num_x, y);
 }
-void GridWavelet::evaluateBatchGPUcuda(const double x[], int num_x, double y[], std::ostream*) const{
+void GridWavelet::evaluateBatchGPUcuda(const double x[], int num_x, double y[]) const{
     evaluateBatch(x, num_x, y);
 }
-void GridWavelet::evaluateBatchGPUmagma(int, const double x[], int num_x, double y[], std::ostream*) const{
+void GridWavelet::evaluateBatchGPUmagma(int, const double x[], int num_x, double y[]) const{
     evaluateBatch(x, num_x, y);
 }
 
@@ -706,7 +706,7 @@ void GridWavelet::evaluateHierarchicalFunctions(const double x[], int num_x, dou
     }
 }
 
-void GridWavelet::setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream *os){
+void GridWavelet::setHierarchicalCoefficients(const double c[], TypeAcceleration acc){
     std::vector<double> *vals = 0;
     size_t num_ponits = (size_t) getNumPoints();
     size_t size_coeff = num_ponits * ((size_t) num_outputs);
@@ -726,9 +726,9 @@ void GridWavelet::setHierarchicalCoefficients(const double c[], TypeAcceleration
     if (acc == accel_cpu_blas){
         evaluateBatchCPUblas(x.data(), points->getNumIndexes(), vals->data());
     }else if (acc == accel_gpu_cublas){
-        evaluateBatchGPUcublas(x.data(), points->getNumIndexes(), vals->data(), os);
+        evaluateBatchGPUcublas(x.data(), points->getNumIndexes(), vals->data());
     }else if (acc == accel_gpu_cuda){
-        evaluateBatchGPUcuda(x.data(), points->getNumIndexes(), vals->data(), os);
+        evaluateBatchGPUcuda(x.data(), points->getNumIndexes(), vals->data());
     }else{
         evaluateBatch(x.data(), points->getNumIndexes(), vals->data());
     }

--- a/SparseGrids/tsgGridWavelet.hpp
+++ b/SparseGrids/tsgGridWavelet.hpp
@@ -78,15 +78,15 @@ public:
     void integrate(double q[], double *conformal_correction) const;
 
     void evaluateFastCPUblas(const double x[], double y[]) const;
-    void evaluateFastGPUcublas(const double x[], double y[], std::ostream *os) const;
-    void evaluateFastGPUcuda(const double x[], double y[], std::ostream *os) const;
-    void evaluateFastGPUmagma(int gpuID, const double x[], double y[], std::ostream *os) const;
+    void evaluateFastGPUcublas(const double x[], double y[]) const;
+    void evaluateFastGPUcuda(const double x[], double y[]) const;
+    void evaluateFastGPUmagma(int gpuID, const double x[], double y[]) const;
 
     void evaluateBatch(const double x[], int num_x, double y[]) const;
     void evaluateBatchCPUblas(const double x[], int num_x, double y[]) const;
-    void evaluateBatchGPUcublas(const double x[], int num_x, double y[], std::ostream *os) const;
-    void evaluateBatchGPUcuda(const double x[], int num_x, double y[], std::ostream *os) const;
-    void evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[], std::ostream *os) const;
+    void evaluateBatchGPUcublas(const double x[], int num_x, double y[]) const;
+    void evaluateBatchGPUcuda(const double x[], int num_x, double y[]) const;
+    void evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, double y[]) const;
 
     void setSurplusRefinement(double tolerance, TypeRefinement criteria, int output = -1, const int *level_limits = 0);
     void clearRefinement();
@@ -94,7 +94,7 @@ public:
 
     void evaluateHierarchicalFunctions(const double x[], int num_x, double y[]) const;
 
-    void setHierarchicalCoefficients(const double c[], TypeAcceleration acc, std::ostream *os);
+    void setHierarchicalCoefficients(const double c[], TypeAcceleration acc);
 
     const double* getSurpluses() const;
     const int* getPointIndexes() const;


### PR DESCRIPTION
* cuda errors now generate exceptions with meaningful messages
* old behaviour was using `logstream` or `os` streams to output messages in case of an error
* the streams are not needed any more and have been removed