### PR TITLE
Exceptions in file I/O

### DIFF
--- a/InterfacePython/testTSG.in.py
+++ b/InterfacePython/testTSG.in.py
@@ -194,9 +194,8 @@ class TestTasmanian(unittest.TestCase):
 
         # test an error message from wrong read
         print("Attempting a bogus read to see if error would be properly registered")
-        gridB.disableLog()
         self.assertFalse(gridB.read("testSaveBlah"), "Failed to flag a fake read")
-        gridB.setErrorLogCerr()
+        print("GOOD: error was registered")
 
         # custom rule test
         grid.makeGlobalGrid(2, 0, 4, 'level', 'custom-tabulated', [], 0.0, 0.0, "GaussPattersonRule.table")

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -31,6 +31,9 @@
 #ifndef __TASMANIAN_SPARSE_GRID_CPP
 #define __TASMANIAN_SPARSE_GRID_CPP
 
+#include <stdexcept>
+#include <string>
+
 #include "TasmanianSparseGrid.hpp"
 
 #include "tsgCudaMacros.hpp"
@@ -271,7 +274,7 @@ void TasmanianSparseGrid::updateGlobalGrid(int depth, TypeDepth type, const int 
             std::copy(level_limits, level_limits + global->getNumDimensions(), llimits);
         }
     }else{
-        if (logstream != 0){ (*logstream) << "ERROR: updateGlobalGrid called, but the grid is not global" << endl; }
+        throw std::runtime_error("ERROR: updateGlobalGrid called, but the grid is not global");
     }
 }
 void TasmanianSparseGrid::updateSequenceGrid(int depth, TypeDepth type, const int *anisotropic_weights, const int *level_limits){
@@ -282,7 +285,7 @@ void TasmanianSparseGrid::updateSequenceGrid(int depth, TypeDepth type, const in
             std::copy(level_limits, level_limits + sequence->getNumDimensions(), llimits);
         }
     }else{
-        if (logstream != 0){ (*logstream) << "ERROR: updateSequenceGrid called, but the grid is not sequence" << endl; }
+        throw std::runtime_error("ERROR: updateSequenceGrid called, but the grid is not sequence");
     }
 }
 

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -534,6 +534,10 @@ void TasmanianSparseGrid::getDomainTransform(double a[], double b[]) const{
     std::copy(domain_transform_b.begin(), domain_transform_b.end(), b);
 }
 void TasmanianSparseGrid::setDomainTransform(const std::vector<double> a, const std::vector<double> b){
+    if ((base == 0) || (base->getNumDimensions() == 0)){
+        throw std::runtime_error("ERROR: cannot call setDomainTransform on uninitialized grid!");
+    }
+    if (acc_domain != 0){ delete acc_domain; acc_domain = 0; }
     domain_transform_a = a; // copy assignment
     domain_transform_b = b;
 }

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -1090,8 +1090,8 @@ void TasmanianSparseGrid::getGlobalPolynomialSpace(bool interpolation, int &num_
     }else if (sequence != 0){
         sequence->getPolynomialSpace(interpolation, num_indexes, poly);
     }else{
-        if (logstream != 0){ (*logstream) << "ERROR: getGlobalPolynomialSpace() called for a grid that is neither Global nor Sequence." << endl; }
         num_indexes = 0;
+        throw std::runtime_error("ERROR: getGlobalPolynomialSpace() called for a grid that is neither Global nor Sequence");
     }
 }
 const double* TasmanianSparseGrid::getHierarchicalCoefficients() const{
@@ -1119,16 +1119,14 @@ const int* TasmanianSparseGrid::getPointsIndexes() const{
     }else if (sequence != 0){
         return sequence->getPointIndexes();
     }else{
-        if (logstream != 0){ (*logstream) << "ERROR: getPointIndexes() called for a grid that is neither local polynomial nor wavelet nor sequence." << endl; }
-        return 0;
+        throw std::runtime_error("ERROR: getPointIndexes() called for a grid that is neither Local Polynomial, nor Wavelet, nor Sequence");
     }
 }
 const int* TasmanianSparseGrid::getNeededIndexes() const{
     if (pwpoly != 0){
         return pwpoly->getNeededIndexes();
     }else{
-        if (logstream != 0){ (*logstream) << "ERROR: getPointIndexes() called for a grid that is not local polynomial." << endl; }
-        return 0;
+        throw std::runtime_error("ERROR: getPointIndexes() called for a grid that is not Local Polynomial");
     }
 }
 

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -172,10 +172,6 @@ void TasmanianSparseGrid::makeGlobalGrid(int dimensions, int outputs, int depth,
     }
 }
 void TasmanianSparseGrid::makeSequenceGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const int *anisotropic_weights, const int *level_limits){
-    if (outputs < 1){
-        if (logstream != 0){ (*logstream) << "ERROR: makeSequenceGrid is called with zero outputs, for zero outputs use makeGlobalGrid instead" << endl; }
-        return;
-    }
     if (OneDimensionalMeta::isSequence(rule)){
         clear();
         sequence = new GridSequence();
@@ -186,21 +182,18 @@ void TasmanianSparseGrid::makeSequenceGrid(int dimensions, int outputs, int dept
             std::copy(level_limits, level_limits + dimensions, llimits);
         }
     }else{
-        if (logstream != 0){ (*logstream) << "ERROR: makeSequenceGrid is called with rule " << OneDimensionalMeta::getIORuleString(rule) << " which is not a sequence rule" << endl; }
+        std::string message = "ERROR: makeSequenceGrid is called with rule: " + std::string(OneDimensionalMeta::getIORuleString(rule)) + ", which is not a sequence rule";
+        throw std::invalid_argument(message);
     }
 }
 void TasmanianSparseGrid::makeLocalPolynomialGrid(int dimensions, int outputs, int depth, int order, TypeOneDRule rule, const int *level_limits){
     if (!OneDimensionalMeta::isLocalPolynomial(rule)){
-        if (logstream != 0){
-            (*logstream) << "ERROR: makeLocalPolynomialGrid is called with rule " << OneDimensionalMeta::getIORuleString(rule) << " which is not a local polynomial rule" << endl;
-            (*logstream) << "       use either " << OneDimensionalMeta::getIORuleString(rule_localp) << " or " << OneDimensionalMeta::getIORuleString(rule_semilocalp)
-                         << " or " << OneDimensionalMeta::getIORuleString(rule_localp0)  << endl;
-        }
-        return;
+        std::string message = "ERROR: makeLocalPolynomialGrid is called with rule: " + std::string(OneDimensionalMeta::getIORuleString(rule)) + ", which is not a local polynomial rule";
+        throw std::invalid_argument(message);
     }
     if (order < -1){
-        if (logstream != 0){ (*logstream) << "ERROR: makeLocalPolynomialGrid is called with order " << order << ", but the order cannot be less than -1." << endl; }
-        return;
+        std::string message = "ERROR: makeLocalPolynomialGrid is called with order: " + std::to_string(order) + ", but the order cannot be less than -1.";
+        throw std::invalid_argument(message);
     }
     clear();
     pwpoly = new GridLocalPolynomial();
@@ -213,8 +206,8 @@ void TasmanianSparseGrid::makeLocalPolynomialGrid(int dimensions, int outputs, i
 }
 void TasmanianSparseGrid::makeWaveletGrid(int dimensions, int outputs, int depth, int order, const int *level_limits){
     if ((order != 1) && (order != 3)){
-        if (logstream != 0){ (*logstream) << "ERROR: makeWaveletGrid is called with order " << order << ", but wavelets are implemented only for orders 1 and 3." << endl; }
-        return;
+        std::string message = "ERROR: makeWaveletGrid is called with order: " + std::to_string(order) + "but wavelets are implemented only for orders 1 and 3.";
+        throw std::invalid_argument(message);
     }
     clear();
     wavelet = new GridWavelet();

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -979,10 +979,10 @@ void TasmanianSparseGrid::evaluateSparseHierarchicalFunctionsGPU(const double gp
 }
 #else
 void TasmanianSparseGrid::evaluateHierarchicalFunctionsGPU(const double*, int, double*) const{
-    if (logstream != 0) (*logstream) << "ERROR: evaluateHierarchicalFunctionsGPU() called, but the library wasn't compiled with Tasmanian_ENABLE_CUDA=ON!" << endl;
+    throw std::runtime_error("ERROR: evaluateHierarchicalFunctionsGPU() called, but the library was not compiled with Tasmanian_ENABLE_CUDA=ON");
 }
 void TasmanianSparseGrid::evaluateSparseHierarchicalFunctionsGPU(const double*, int, int*&, int*&, double*&, int&) const{
-    if (logstream != 0) (*logstream) << "ERROR: evaluateSparseHierarchicalFunctionsGPU() called, but the library wasn't compiled with Tasmanian_ENABLE_CUDA=ON!" << endl;
+    throw std::runtime_error("ERROR: evaluateSparseHierarchicalFunctionsGPU() called, but the library was not compiled with Tasmanian_ENABLE_CUDA=ON");
 }
 #endif
 

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -512,8 +512,7 @@ bool TasmanianSparseGrid::isFourier() const{
 
 void TasmanianSparseGrid::setDomainTransform(const double a[], const double b[]){
     if ((base == 0) || (base->getNumDimensions() == 0)){
-        if (logstream != 0){ (*logstream) << "ERROR: cannot call setDomainTransform on uninitialized grid!" << endl; }
-        return;
+        throw std::runtime_error("ERROR: cannot call setDomainTransform on uninitialized grid!");
     }
     if (acc_domain != 0){ delete acc_domain; acc_domain = 0; }
     int num_dimensions = base->getNumDimensions();
@@ -529,8 +528,7 @@ void TasmanianSparseGrid::clearDomainTransform(){
 }
 void TasmanianSparseGrid::getDomainTransform(double a[], double b[]) const{
     if ((base == 0) || (base->getNumDimensions() == 0) || (domain_transform_a.size() == 0)){
-        if (logstream != 0){ (*logstream) << "ERROR: cannot call getDomainTransform on uninitialized grid or if no transform has been set!" << endl; }
-        return;
+        throw std::runtime_error("ERROR: cannot call getDomainTransform on uninitialized grid or if no transform has been set!");
     }
     std::copy(domain_transform_a.begin(), domain_transform_a.end(), a);
     std::copy(domain_transform_b.begin(), domain_transform_b.end(), b);
@@ -650,8 +648,7 @@ double TasmanianSparseGrid::getQuadratureScale(int num_dimensions, TypeOneDRule 
 
 void TasmanianSparseGrid::setConformalTransformASIN(const int truncation[]){
     if ((base == 0) || (base->getNumDimensions() == 0)){
-        if (logstream != 0){ (*logstream) << "ERROR: cannot call setConformalTransformASIN on uninitialized grid!" << endl; }
-        return;
+        throw std::runtime_error("ERROR: cannot call setConformalTransformASIN on uninitialized grid!");
     }
     clearConformalTransform();
     int num_dimensions = base->getNumDimensions();
@@ -663,8 +660,7 @@ void TasmanianSparseGrid::clearConformalTransform(){
 }
 void TasmanianSparseGrid::getConformalTransformASIN(int truncation[]) const{
     if ((base == 0) || (base->getNumDimensions() == 0) || (conformal_asin_power == 0)){
-        if (logstream != 0){ (*logstream) << "ERROR: cannot call getDomainTransform on uninitialized grid or if no transform has been set!" << endl; }
-        return;
+        throw std::runtime_error("ERROR: cannot call getDomainTransform on uninitialized grid or if no transform has been set!");
     }
     int num_dimensions = base->getNumDimensions();
     std::copy(conformal_asin_power, conformal_asin_power + num_dimensions, truncation);

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -883,12 +883,12 @@ void TasmanianSparseGrid::setAnisotropicRefinement(TypeDepth type, int min_growt
         sequence->setAnisotropicRefinement(type, min_growth, output, llimits);
     }else if (global != 0){
         if (OneDimensionalMeta::isNonNested(global->getRule())){
-            if (logstream != 0){ (*logstream) << "ERROR: setAnisotropicRefinement called for a global grid with non-nested rule" << endl; }
+            throw std::runtime_error("ERROR: setAnisotropicRefinement called for a global grid with non-nested rule");
         }else{
             global->setAnisotropicRefinement(type, min_growth, output, llimits);
         }
     }else{
-        if (logstream != 0){ (*logstream) << "ERROR: setAnisotropicRefinement called for grid that is neither sequence nor Global with sequence rule" << endl; }
+        throw std::runtime_error("ERROR: setAnisotropicRefinement called for a grid that is neither Sequence nor Global with a sequence rule");
     }
 }
 int* TasmanianSparseGrid::estimateAnisotropicCoefficients(TypeDepth type, int output){
@@ -896,12 +896,12 @@ int* TasmanianSparseGrid::estimateAnisotropicCoefficients(TypeDepth type, int ou
         return sequence->estimateAnisotropicCoefficients(type, output);
     }else if (global != 0){
         if (OneDimensionalMeta::isNonNested(global->getRule())){
-            if (logstream != 0){ (*logstream) << "ERROR: estimateAnisotropicCoefficients called for a global grid with non-nested rule" << endl; }
+            throw std::runtime_error("ERROR: estimateAnisotropicCoefficients called for a Global grid with non-nested rule");
         }else{
             return global->estimateAnisotropicCoefficients(type, output);
         }
     }else{
-        if (logstream != 0){ (*logstream) << "ERROR: estimateAnisotropicCoefficients called for grid that is neither sequence nor Global with sequence rule" << endl; }
+        throw std::runtime_error("ERROR: estimateAnisotropicCoefficients called for a grid that is neither Sequence nor Global with a sequence rule");
     }
     return 0;
 }
@@ -916,10 +916,10 @@ void TasmanianSparseGrid::setSurplusRefinement(double tolerance, int output, con
         if (OneDimensionalMeta::isSequence(global->getRule())){
             global->setSurplusRefinement(tolerance, output, llimits);
         }else{
-            if (logstream != 0){ (*logstream) << "ERROR: setSurplusRefinement called for a global grid with non-sequence rule" << endl; }
+            throw std::runtime_error("ERROR: setSurplusRefinement called for a Global grid with non-sequence rule");
         }
     }else{
-        if (logstream != 0){ (*logstream) << "ERROR: setSurplusRefinement(double, int) called for grid that is neither sequence nor Global with sequence rule" << endl; }
+        throw std::runtime_error("ERROR: setSurplusRefinement(double, int) called for a grid that is neither Sequence nor Global with a sequence rule");
     }
 }
 void TasmanianSparseGrid::setSurplusRefinement(double tolerance, TypeRefinement criteria, int output, const int *level_limits, const double *scale_correction){
@@ -932,7 +932,7 @@ void TasmanianSparseGrid::setSurplusRefinement(double tolerance, TypeRefinement 
     }else if (wavelet != 0){
         wavelet->setSurplusRefinement(tolerance, criteria, output, llimits);
     }else{
-        if (logstream != 0){ (*logstream) << "ERROR: setSurplusRefinement(double, TypeRefinement) called for grid that is neither local polynomial nor wavelet" << endl; }
+        throw std::runtime_error("ERROR: setSurplusRefinement(double, TypeRefinement) called for a grid that is neither Local Polynomial nor Wavelet");
     }
 }
 void TasmanianSparseGrid::clearRefinement(){
@@ -943,8 +943,7 @@ void TasmanianSparseGrid::mergeRefinement(){
 }
 void TasmanianSparseGrid::removePointsByHierarchicalCoefficient(double tolerance, int output, const double *scale_correction){
     if (pwpoly == 0){
-        if (logstream != 0){ (*logstream) << "ERROR: removePointsBySurplus() called for a grid that is not local polynomial." << endl; }
-        return;
+        throw std::runtime_error("ERROR: removePointsBySurplus() called for a grid that is not Local Polynomial.");
     }else{
         if (pwpoly->removePointsByHierarchicalCoefficient(tolerance, output, scale_correction) == 0){
             clear();

--- a/SparseGrids/tsgCoreOneDimensional.hpp
+++ b/SparseGrids/tsgCoreOneDimensional.hpp
@@ -41,16 +41,16 @@ namespace TasGrid{
 
 class CustomTabulated{
 public:
-    CustomTabulated(std::ostream *os = 0);
-    CustomTabulated(const char* filename, std::ostream *os = 0);
-    CustomTabulated(const CustomTabulated &custom, std::ostream *os = 0);
+    CustomTabulated();
+    CustomTabulated(const char* filename);
+    CustomTabulated(const CustomTabulated &custom);
     ~CustomTabulated();
 
     // I/O subroutines
     void write(std::ofstream &ofs) const;
-    bool read(std::ifstream &ifs);
+    void read(std::ifstream &ifs);
     void writeBinary(std::ofstream &ofs) const;
-    bool readBinary(std::ifstream &ifs);
+    void readBinary(std::ifstream &ifs);
     void copyRule(const CustomTabulated *custom);
 
     int getNumLevels() const;
@@ -72,7 +72,6 @@ private:
     double *nodes;
     double *weights;
     std::string *description;
-    std::ostream *logstream;
 };
 
 class OneDimensionalMeta{

--- a/SparseGrids/tsgGridFourier.cpp
+++ b/SparseGrids/tsgGridFourier.cpp
@@ -139,7 +139,7 @@ void GridFourier::read(std::ifstream &ifs, std::ostream *logstream){
         for(int j=1; j<num_dimensions; j++){ if (oned_max_level < max_levels[j]) oned_max_level = max_levels[j]; }
 
         OneDimensionalMeta meta(0);
-        wrapper = new OneDimensionalWrapper(&meta, oned_max_level, rule_fourier, 0.0, 0.0, logstream);
+        wrapper = new OneDimensionalWrapper(&meta, oned_max_level, rule_fourier, 0.0, 0.0);
 
         UnsortedIndexSet *exponents_unsorted = new UnsortedIndexSet(num_dimensions, work->getNumIndexes());
         int *exponent = new int[num_dimensions];
@@ -253,7 +253,7 @@ void GridFourier::readBinary(std::ifstream &ifs, std::ostream *logstream){
         for(int j=1; j<num_dimensions; j++) if (oned_max_level < max_levels[j]) oned_max_level = max_levels[j];
 
         OneDimensionalMeta meta(0);
-        wrapper = new OneDimensionalWrapper(&meta, oned_max_level, rule_fourier, 0.0, 0.0, logstream);
+        wrapper = new OneDimensionalWrapper(&meta, oned_max_level, rule_fourier, 0.0, 0.0);
 
         UnsortedIndexSet* exponents_unsorted = new UnsortedIndexSet(num_dimensions, work->getNumIndexes());
         int *exponent = new int[num_dimensions];

--- a/SparseGrids/tsgGridFourier.cpp
+++ b/SparseGrids/tsgGridFourier.cpp
@@ -105,7 +105,7 @@ void GridFourier::write(std::ofstream &ofs) const{
     }
 }
 
-void GridFourier::read(std::ifstream &ifs, std::ostream *logstream){
+void GridFourier::read(std::ifstream &ifs){
     reset();
     ifs >> num_dimensions >> num_outputs;
     if (num_dimensions > 0){
@@ -213,7 +213,7 @@ void GridFourier::writeBinary(std::ofstream &ofs) const{
     }
 }
 
-void GridFourier::readBinary(std::ifstream &ifs, std::ostream *logstream){
+void GridFourier::readBinary(std::ifstream &ifs){
     reset();
     int num_dim_out[2];
     ifs.read((char*) num_dim_out, 2*sizeof(int));

--- a/SparseGrids/tsgGridFourier.hpp
+++ b/SparseGrids/tsgGridFourier.hpp
@@ -54,10 +54,10 @@ public:
     ~GridFourier();
 
     void write(std::ofstream &ofs) const;
-    void read(std::ifstream &ifs, std::ostream *logstream = 0);
+    void read(std::ifstream &ifs);
 
     void writeBinary(std::ofstream &ofs) const;
-    void readBinary(std::ifstream &ifs, std::ostream *logstream = 0);
+    void readBinary(std::ifstream &ifs);
 
     void makeGrid(int cnum_dimensions, int cnum_outputs, int depth, TypeDepth type, const int* anisotropic_weights = 0, const int* level_limits = 0);
     void copyGrid(const GridFourier *fourier);

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -147,7 +147,7 @@ void GridGlobal::writeBinary(std::ofstream &ofs) const{
         }
     }
 }
-void GridGlobal::read(std::ifstream &ifs, std::ostream *logstream){
+void GridGlobal::read(std::ifstream &ifs){
     reset(true); // true deletes any custom rule
     ifs >> num_dimensions >> num_outputs >> alpha >> beta;
     if (num_dimensions > 0){
@@ -200,7 +200,7 @@ void GridGlobal::read(std::ifstream &ifs, std::ostream *logstream){
     }
 }
 
-void GridGlobal::readBinary(std::ifstream &ifs, std::ostream *logstream){
+void GridGlobal::readBinary(std::ifstream &ifs){
     reset(true); // true deletes any custom rule
     int num_dim_out[2];
     ifs.read((char*) num_dim_out, 2*sizeof(int));

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -156,7 +156,7 @@ void GridGlobal::read(std::ifstream &ifs, std::ostream *logstream){
         ifs >> T;
         rule = OneDimensionalMeta::getIORuleString(T.c_str());
         if (rule == rule_customtabulated){
-            custom = new CustomTabulated(logstream);
+            custom = new CustomTabulated();
             custom->read(ifs);
         }
         tensors = new IndexSet(num_dimensions);  tensors->read(ifs);
@@ -214,7 +214,7 @@ void GridGlobal::readBinary(std::ifstream &ifs, std::ostream *logstream){
         ifs.read((char*) num_dim_out, sizeof(int));
         rule = OneDimensionalMeta::getIORuleInt(num_dim_out[0]);
         if (rule == rule_customtabulated){
-            custom = new CustomTabulated(logstream);
+            custom = new CustomTabulated();
             custom->readBinary(ifs);
         }
 

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -179,7 +179,7 @@ void GridGlobal::read(std::ifstream &ifs, std::ostream *logstream){
             for(int j=1; j<num_dimensions; j++) if (oned_max_level < max_levels[j]) oned_max_level = max_levels[j];
         }
         OneDimensionalMeta meta(custom);
-        wrapper = new OneDimensionalWrapper(&meta, oned_max_level, rule, alpha, beta, logstream);
+        wrapper = new OneDimensionalWrapper(&meta, oned_max_level, rule, alpha, beta);
 
         int nz_weights = active_tensors->getNumIndexes();
         IndexSet *work = (points != 0) ? points : needed;
@@ -246,7 +246,7 @@ void GridGlobal::readBinary(std::ifstream &ifs, std::ostream *logstream){
             for(int j=1; j<num_dimensions; j++) if (oned_max_level < max_levels[j]) oned_max_level = max_levels[j];
         }
         OneDimensionalMeta meta(custom);
-        wrapper = new OneDimensionalWrapper(&meta, oned_max_level, rule, alpha, beta, logstream);
+        wrapper = new OneDimensionalWrapper(&meta, oned_max_level, rule, alpha, beta);
 
         int nz_weights = active_tensors->getNumIndexes();
         IndexSet *work = (points != 0) ? points : needed;

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -53,10 +53,10 @@ public:
     ~GridGlobal();
 
     void write(std::ofstream &ofs) const;
-    void read(std::ifstream &ifs, std::ostream *logstream = 0);
+    void read(std::ifstream &ifs);
 
     void writeBinary(std::ofstream &ofs) const;
-    void readBinary(std::ifstream &ifs, std::ostream *logstream = 0);
+    void readBinary(std::ifstream &ifs);
 
     void makeGrid(int cnum_dimensions, int cnum_outputs, int depth, TypeDepth type, TypeOneDRule crule, const int *anisotropic_weights = 0, double calpha = 0.0, double cbeta = 0.0, const char* custom_filename = 0, const int *level_limits = 0);
     void copyGrid(const GridGlobal *global);

--- a/SparseGrids/tsgOneDimensionalWrapper.cpp
+++ b/SparseGrids/tsgOneDimensionalWrapper.cpp
@@ -31,11 +31,14 @@
 #ifndef __TSG_ONE_DIMENSIONAL_WRAPPER_CPP
 #define __TSG_ONE_DIMENSIONAL_WRAPPER_CPP
 
+#include <stdexcept>
+#include <string>
+
 #include "tsgOneDimensionalWrapper.hpp"
 
 namespace TasGrid{
 
-OneDimensionalWrapper::OneDimensionalWrapper(const OneDimensionalMeta *meta, int max_level, TypeOneDRule crule, double alpha, double beta, std::ostream *logstream) :
+OneDimensionalWrapper::OneDimensionalWrapper(const OneDimensionalMeta *meta, int max_level, TypeOneDRule crule, double alpha, double beta) :
     num_levels(max_level+1), rule(crule), indx(0), nodes(0)
 {
     // find the points per level and the cumulative pointers
@@ -62,13 +65,12 @@ OneDimensionalWrapper::OneDimensionalWrapper(const OneDimensionalMeta *meta, int
 
         if (rule == rule_customtabulated){
             if (num_levels > meta->getCustom()->getNumLevels()){
-                if (logstream != 0){ (*logstream) << "ERROR: custom-tabulated rule needed with levels " << num_levels << ", but only " << meta->getCustom()->getNumLevels() << " are provided." << endl; }
-                #ifndef USE_XSDK_DEFAULTS
-                exit(1); // disabled by USE_XSDK_DEFAULTS
-                #else
-                max_level = meta->getCustom()->getNumLevels();
-                num_levels = max_level;
-                #endif // USE_XSDK_DEFAULTS
+                std::string message = "ERROR: custom-tabulated rule needed with levels ";
+                message += std::to_string(num_levels);
+                message += ", but only ";
+                message += std::to_string(meta->getCustom()->getNumLevels());
+                message += " are provided.";
+                throw std::runtime_error(message);
             }
         }
 
@@ -148,13 +150,12 @@ OneDimensionalWrapper::OneDimensionalWrapper(const OneDimensionalMeta *meta, int
         }else if (rule == rule_gausspatterson){
             gp = new TableGaussPatterson();
             if (num_levels > gp->getNumLevels()){
-                if (logstream != 0){ (*logstream) << "ERROR: gauss-patterson rule needed with level " << max_level << ", but only " << gp->getNumLevels() << " are hardcoded." << endl; }
-                #ifndef USE_XSDK_DEFAULTS
-                exit(1); // disabled by USE_XSDK_DEFAULTS
-                #else
-                max_level = gp->getNumLevels()-1;
-                num_levels = max_level+1;
-                #endif // USE_XSDK_DEFAULTS
+                std::string message = "ERROR: gauss-patterson rule needed with level ";
+                message += std::to_string(max_level);
+                message += ", but only ";
+                message += std::to_string(gp->getNumLevels());
+                message += " are hardcoded.";
+                throw std::runtime_error(message);
             }
             unique = gp->getNodes(max_level);
 

--- a/SparseGrids/tsgOneDimensionalWrapper.hpp
+++ b/SparseGrids/tsgOneDimensionalWrapper.hpp
@@ -40,7 +40,7 @@ namespace TasGrid{
 
 class OneDimensionalWrapper{
 public:
-    OneDimensionalWrapper(const OneDimensionalMeta *meta, int max_level, TypeOneDRule crule, double alpha = 0.0, double beta = 0.0, std::ostream *logstream = 0);
+    OneDimensionalWrapper(const OneDimensionalMeta *meta, int max_level, TypeOneDRule crule, double alpha = 0.0, double beta = 0.0);
     ~OneDimensionalWrapper();
 
     int getNumPoints(int level) const;


### PR DESCRIPTION
* replaced error messages in incorrect input with exception `std::invalid_argument(message)`
* replaced error messages in file I/O with exception `std::runtime_error(message)`
* respect backwards compatibility with file formats newer than version 3.0 (from 2015)
* cannot set domain transform for an empty grid
* it is now possible to create sequence grids with zero outputs (bad for performance, but mathematically valid)