### PR TITLE
New tester executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ HEADERS = $(patsubst ./DREAM/%,./include/%,$(filter-out $(CMAKE_IN_HEADERS),$(wi
           ./include/TasmanianConfig.hpp
 
 ALL_TARGETS = GaussPattersonRule.table TasmanianSG.py example_sparse_grids.py testTSG.py sandbox.py example_sparse_grids.cpp example_dream.cpp \
-              libtasmaniansparsegrid.so libtasmaniansparsegrid.a libtasmaniandream.so libtasmaniandream.a tasgrid tasdream $(HEADERS)
+              libtasmaniansparsegrid.so libtasmaniansparsegrid.a libtasmaniandream.so libtasmaniandream.a tasgrid tasdream gridtest $(HEADERS)
 
 CONFIGURED_HEADERS = ./SparseGrids/TasmanianConfig.hpp
 
@@ -66,6 +66,12 @@ tasgrid: libtasmaniansparsegrid.a libtasmaniansparsegrid.so ./SparseGrids/tasgri
 	cp ./SparseGrids/tasgrid .
 
 SparseGrids/tasgrid: ./SparseGrids/libtasmaniansparsegrid.so $(TSG_SOURCE) $(CONFIGURED_HEADERS)
+	cd SparseGrids; make
+
+gridtest: libtasmaniansparsegrid.a libtasmaniansparsegrid.so ./SparseGrids/gridtest
+	cp ./SparseGrids/gridtest .
+
+SparseGrids/gridtest: ./SparseGrids/libtasmaniansparsegrid.so $(TSG_SOURCE) $(CONFIGURED_HEADERS)
 	cd SparseGrids; make
 
 # DREAM
@@ -196,7 +202,7 @@ InterfaceFortran/libtasmanianfortran90.a:
 # Testing and examples
 .PHONY: test
 test: $(ALL_TARGETS)
-	./tasgrid -test
+	./gridtest
 	./tasdream -test
 	./testTSG.py && { echo "SUCCESS: Test completed successfully"; }
 
@@ -219,6 +225,7 @@ clean:
 	rm -fr tasmaniansg.mod
 	rm -fr fortester*
 	rm -fr tasgrid
+	rm -fr gridtest
 	rm -fr tasdream
 	rm -fr TasmanianSG.py
 	rm -fr example_sparse_grids.py

--- a/SparseGrids/CMakeLists.txt
+++ b/SparseGrids/CMakeLists.txt
@@ -134,15 +134,6 @@ set(Tasmanian_source_libsparsegrid_cuda
        tsgCudaBasisEvaluations.hpp
        tsgCudaLinearAlgebra.hpp)
 
-set(Tasmanian_source_tasgrid
-        tasgrid_main.cpp
-        TasmanianSparseGrid.hpp
-        tasgridExternalTests.hpp
-        tasgridExternalTests.cpp
-        tasgridTestFunctions.hpp
-        tasgridTestFunctions.cpp
-        tasgridWrapper.hpp
-        tasgridWrapper.cpp)
 
 ########################################################################
 # add the tasgrid and examples executables
@@ -155,12 +146,20 @@ add_executable(Tasmanian_tasgrid tasgrid_main.cpp
                                  tasgridTestFunctions.cpp
                                  tasgridWrapper.hpp
                                  tasgridWrapper.cpp)
+add_executable(Tasmanian_gridtest gridtest_main.cpp
+                                  TasmanianSparseGrid.hpp
+                                  tasgridExternalTests.hpp
+                                  tasgridExternalTests.cpp
+                                  tasgridTestFunctions.hpp
+                                  tasgridTestFunctions.cpp)
 add_executable(Tasmanian_example_sparse_grids Examples/example_sparse_grids.cpp)
 
 set_property(TARGET Tasmanian_tasgrid              PROPERTY CXX_STANDARD 11)
+set_property(TARGET Tasmanian_gridtest             PROPERTY CXX_STANDARD 11)
 set_property(TARGET Tasmanian_example_sparse_grids PROPERTY CXX_STANDARD 11)
 
 set_target_properties(Tasmanian_tasgrid PROPERTIES OUTPUT_NAME "tasgrid")
+set_target_properties(Tasmanian_gridtest PROPERTIES OUTPUT_NAME "gridtest")
 set_target_properties(Tasmanian_example_sparse_grids PROPERTIES OUTPUT_NAME "example_sparse_grids")
 
 if (Tasmanian_ENABLE_OPENMP AND OpenMP_CXX_LIBRARIES)
@@ -168,6 +167,8 @@ if (Tasmanian_ENABLE_OPENMP AND OpenMP_CXX_LIBRARIES)
     # also the libs are redundant here, as those will be added by libsparsegrid
     target_link_libraries(Tasmanian_tasgrid ${OpenMP_CXX_LIBRARIES})
     target_compile_options(Tasmanian_tasgrid PRIVATE ${OpenMP_CXX_FLAGS})
+    target_link_libraries(Tasmanian_gridtest ${OpenMP_CXX_LIBRARIES})
+    target_compile_options(Tasmanian_gridtest PRIVATE ${OpenMP_CXX_FLAGS})
 endif()
 
 
@@ -183,9 +184,11 @@ if (NOT "${Tasmanian_libs_type}" STREQUAL "SHARED_ONLY")
 
     # if static libraries are available, executables link statically
     target_link_libraries(Tasmanian_tasgrid              Tasmanian_libsparsegrid_static)
+    target_link_libraries(Tasmanian_gridtest             Tasmanian_libsparsegrid_static)
     target_link_libraries(Tasmanian_example_sparse_grids Tasmanian_libsparsegrid_static)
 else() # if there are not static libs, use shared libs for the executables
     target_link_libraries(Tasmanian_tasgrid              Tasmanian_libsparsegrid_shared)
+    target_link_libraries(Tasmanian_gridtest             Tasmanian_libsparsegrid_shared)
     target_link_libraries(Tasmanian_example_sparse_grids Tasmanian_libsparsegrid_shared)
 endif()
 
@@ -222,6 +225,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
         Tasmanian_macro_sparsegrids_windows_defines(Tasmanian_libsparsegrid_shared)
     else()
         target_compile_definitions(Tasmanian_tasgrid PUBLIC -DTSG_DYNAMIC)
+        target_compile_definitions(Tasmanian_gridtest PUBLIC -DTSG_DYNAMIC)
     endif()
 
     if (NOT "${Tasmanian_libs_type}" STREQUAL "SHARED_ONLY")
@@ -233,19 +237,20 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     endif()
 
     Tasmanian_macro_sparsegrids_windows_defines(Tasmanian_tasgrid)
+    Tasmanian_macro_sparsegrids_windows_defines(Tasmanian_gridtest)
 endif()
 
 
 ########################################################################
 # Testing
 ########################################################################
-add_test(SparseGridsAcceleration tasgrid -test acceleration -gpuid ${Tasmanian_TESTS_GPU_ID})
-add_test(SparseGridsDomain       tasgrid -test domain)
-add_test(SparseGridsRefinement   tasgrid -test refinement)
-add_test(SparseGridsGlobal       tasgrid -test global)
-add_test(SparseGridsLocal        tasgrid -test local)
-add_test(SparseGridsWavelet      tasgrid -test wavelet)
-add_test(SparseGridsFourier      tasgrid -test fourier)
+add_test(SparseGridsAcceleration gridtest acceleration -gpuid ${Tasmanian_TESTS_GPU_ID})
+add_test(SparseGridsDomain       gridtest domain)
+add_test(SparseGridsRefinement   gridtest refinement)
+add_test(SparseGridsGlobal       gridtest global)
+add_test(SparseGridsLocal        gridtest local)
+add_test(SparseGridsWavelet      gridtest wavelet)
+add_test(SparseGridsFourier      gridtest fourier)
 if (Tasmanian_TESTS_OMP_NUM_THREADS GREATER 0)
     set_tests_properties(SparseGridsAcceleration SparseGridsDomain SparseGridsRefinement SparseGridsGlobal SparseGridsLocal SparseGridsWavelet
         PROPERTIES

--- a/SparseGrids/CMakeLists.txt
+++ b/SparseGrids/CMakeLists.txt
@@ -151,7 +151,9 @@ add_executable(Tasmanian_gridtest gridtest_main.cpp
                                   tasgridExternalTests.hpp
                                   tasgridExternalTests.cpp
                                   tasgridTestFunctions.hpp
-                                  tasgridTestFunctions.cpp)
+                                  tasgridTestFunctions.cpp
+                                  tasgridUnitTests.hpp
+                                  tasgridUnitTests.cpp)
 add_executable(Tasmanian_example_sparse_grids Examples/example_sparse_grids.cpp)
 
 set_property(TARGET Tasmanian_tasgrid              PROPERTY CXX_STANDARD 11)
@@ -251,6 +253,7 @@ add_test(SparseGridsGlobal       gridtest global)
 add_test(SparseGridsLocal        gridtest local)
 add_test(SparseGridsWavelet      gridtest wavelet)
 add_test(SparseGridsFourier      gridtest fourier)
+add_test(SparseGridsExceptions   gridtest errors)
 if (Tasmanian_TESTS_OMP_NUM_THREADS GREATER 0)
     set_tests_properties(SparseGridsAcceleration SparseGridsDomain SparseGridsRefinement SparseGridsGlobal SparseGridsLocal SparseGridsWavelet
         PROPERTIES

--- a/SparseGrids/Makefile
+++ b/SparseGrids/Makefile
@@ -22,10 +22,14 @@ LIBOBJ = tsgIndexSets.o tsgCoreOneDimensional.o tsgIndexManipulator.o tsgGridGlo
 
 WROBJ = tasgrid_main.o tasgridTestFunctions.o tasgridExternalTests.o tasgridWrapper.o
 
+GTONJ = gridtest_main.o tasgridTestFunctions.o tasgridExternalTests.o
+
 LIBNAME = libtasmaniansparsegrid.a
 SHAREDNAME = libtasmaniansparsegrid.so
 
 EXECNAME = tasgrid
+
+TESTNAME = gridtest
 
 %.cu.o: %.cu $(LHEADERS)
 	$(NVCC) $(NVCC_OPT) -c $< -o $@
@@ -33,7 +37,7 @@ EXECNAME = tasgrid
 %.o: %.cpp $(LHEADERS)
 	$(CC) $(OPTC) $(IADD) -c $< -o $@
 
-all: $(LIBNAME) $(EXECNAME) $(SHAREDNAME)
+all: $(LIBNAME) $(EXECNAME) $(TESTNAME) $(SHAREDNAME)
 
 $(SHAREDNAME): $(LIBOBJ)
 	$(CC) $(OPTL) $(LIBOBJ) -shared -o $(SHAREDNAME) $(LIBS)
@@ -44,9 +48,12 @@ $(LIBNAME): $(LIBOBJ)
 $(EXECNAME):  $(LIBNAME) $(WROBJ)
 	$(CC) $(OPTL) $(LADD) -L. $(WROBJ) -o $(EXECNAME) $(LIBNAME) $(LIBS)
 
+$(TESTNAME):  $(LIBNAME) $(GTONJ)
+	$(CC) $(OPTL) $(LADD) -L. $(GTONJ) -o $(TESTNAME) $(LIBNAME) $(LIBS)
 
 clean:
 	rm -fr *.o
 	rm -fr $(LIBNAME)
 	rm -fr $(EXECNAME)
+	rm -fr $(TESTNAME)
 	rm -fr $(SHAREDNAME)

--- a/SparseGrids/Makefile
+++ b/SparseGrids/Makefile
@@ -11,7 +11,7 @@ LHEADERS = tsgIndexSets.hpp tsgCoreOneDimensional.hpp tsgIndexManipulator.hpp ts
            tsgRuleLocalPolynomial.hpp tsgHardCodedTabulatedRules.hpp tsgGridLocalPolynomial.hpp tsgGridFourier.hpp \
            tsgRuleWavelet.hpp tsgCudaMacros.hpp tsgGridWavelet.hpp \
            tsgCudaLinearAlgebra.hpp tsgCudaBasisEvaluations.hpp tsgAcceleratedDataStructures.hpp \
-           tasgridTestFunctions.hpp tasgridExternalTests.hpp tasgridWrapper.hpp \
+           tasgridTestFunctions.hpp tasgridExternalTests.hpp tasgridWrapper.hpp tasgridUnitTests.hpp \
            TasmanianSparseGrid.hpp
 
 LIBOBJ = tsgIndexSets.o tsgCoreOneDimensional.o tsgIndexManipulator.o tsgGridGlobal.o tsgSequenceOptimizer.o tsgOneDimensionalWrapper.o \
@@ -22,7 +22,7 @@ LIBOBJ = tsgIndexSets.o tsgCoreOneDimensional.o tsgIndexManipulator.o tsgGridGlo
 
 WROBJ = tasgrid_main.o tasgridTestFunctions.o tasgridExternalTests.o tasgridWrapper.o
 
-GTONJ = gridtest_main.o tasgridTestFunctions.o tasgridExternalTests.o
+GTONJ = gridtest_main.o tasgridTestFunctions.o tasgridExternalTests.o tasgridUnitTests.o
 
 LIBNAME = libtasmaniansparsegrid.a
 SHAREDNAME = libtasmaniansparsegrid.so

--- a/SparseGrids/gridtest_main.cpp
+++ b/SparseGrids/gridtest_main.cpp
@@ -39,7 +39,7 @@
 
 #include "TasmanianSparseGrid.hpp"
 #include "tasgridExternalTests.hpp"
-#include "tasgridWrapper.hpp"
+#include "tasgridUnitTests.hpp"
 
 using namespace std;
 using namespace TasGrid;
@@ -63,6 +63,7 @@ int main(int argc, const char ** argv){
     bool seed_reset = false;
 
     TestList test = test_all;
+    UnitTests utest = unit_none;
 
     int gpuid = -1;
     int k = 1;
@@ -81,6 +82,7 @@ int main(int argc, const char ** argv){
         if ((strcmp(argv[k],"local") == 0)) test = test_local;
         if ((strcmp(argv[k],"wavelet") == 0)) test = test_wavelet;
         if ((strcmp(argv[k],"fourier") == 0)) test = test_fourier;
+        if ((strcmp(argv[k],"errors") == 0)) utest = unit_except;
         if ((strcmp(argv[k],"-gpuid") == 0)){
             if (k+1 >= argc){
                 cerr << "ERROR: -gpuid requires a valid number!" << endl;
@@ -98,6 +100,7 @@ int main(int argc, const char ** argv){
     }
 
     ExternalTester tester(1000);
+    GridUnitTester utester;
     tester.setGPUID(gpuid);
     bool pass = true;
     if (debug){
@@ -106,9 +109,16 @@ int main(int argc, const char ** argv){
         tester.debugTestII();
     }else{
         if (verbose) tester.setVerbose(true);
+        if (verbose) utester.setVerbose(true);
+
         if (seed_reset) tester.resetRandomSeed();
-        pass = tester.Test(test);
+
+        if (utest == unit_none){
+            if (test == test_all) pass = pass && utester.Test(unit_all);
+            pass = pass && tester.Test(test);
+        }else{
+            pass = pass && utester.Test(unit_all);
+        }
     }
     return (pass) ? 0 : 1;
-
 }

--- a/SparseGrids/gridtest_main.cpp
+++ b/SparseGrids/gridtest_main.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2017, Miroslav Stoyanov
+ *
+ * This file is part of
+ * Toolkit for Adaptive Stochastic Modeling And Non-Intrusive ApproximatioN: TASMANIAN
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * UT-BATTELLE, LLC AND THE UNITED STATES GOVERNMENT MAKE NO REPRESENTATIONS AND DISCLAIM ALL WARRANTIES, BOTH EXPRESSED AND IMPLIED.
+ * THERE ARE NO EXPRESS OR IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE SOFTWARE WILL NOT INFRINGE ANY PATENT,
+ * COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS, OR THAT THE SOFTWARE WILL ACCOMPLISH THE INTENDED RESULTS OR THAT THE SOFTWARE OR ITS USE WILL NOT RESULT IN INJURY OR DAMAGE.
+ * THE USER ASSUMES RESPONSIBILITY FOR ALL LIABILITIES, PENALTIES, FINES, CLAIMS, CAUSES OF ACTION, AND COSTS AND EXPENSES, CAUSED BY, RESULTING FROM OR ARISING OUT OF,
+ * IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
+ */
+
+#include <cstdlib>
+#include <cstdio>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <iomanip>
+#include <string.h>
+#include <math.h>
+
+#include "TasmanianSparseGrid.hpp"
+#include "tasgridExternalTests.hpp"
+#include "tasgridWrapper.hpp"
+
+using namespace std;
+using namespace TasGrid;
+
+int main(int argc, const char ** argv){
+
+    //cout << " Phruuuuphrrr " << endl; // this is the sound that the Tasmanian devil makes
+
+    // tests for speed
+    if ((argc > 1) && ((strcmp(argv[1],"-benchmark") == 0) || (strcmp(argv[1],"-bench") == 0))){
+        ExternalTester tester(1);
+        tester.resetRandomSeed();
+        tester.benchmark(argc, argv);
+        return 0;
+    }
+
+    // testing
+    bool debug = false;
+    bool debugII = false;
+    bool verbose = false;
+    bool seed_reset = false;
+
+    TestList test = test_all;
+
+    int gpuid = -1;
+    int k = 1;
+    while (k < argc){
+        if ((strcmp(argv[k],"debug") == 0)) debug = true;
+        if ((strcmp(argv[k],"db") == 0)) debugII = true;
+        if ((strcmp(argv[k],"verbose") == 0)) verbose = true;
+        if ((strcmp(argv[k],"v") == 0)) verbose = true;
+        if ((strcmp(argv[k],"-v") == 0)) verbose = true;
+        if ((strcmp(argv[k],"-random") == 0)) seed_reset = true;
+        if ((strcmp(argv[k],"random") == 0)) seed_reset = true;
+        if ((strcmp(argv[k],"acceleration") == 0)) test = test_acceleration;
+        if ((strcmp(argv[k],"domain") == 0)) test = test_domain;
+        if ((strcmp(argv[k],"refinement") == 0)) test = test_refinement;
+        if ((strcmp(argv[k],"global") == 0)) test = test_global;
+        if ((strcmp(argv[k],"local") == 0)) test = test_local;
+        if ((strcmp(argv[k],"wavelet") == 0)) test = test_wavelet;
+        if ((strcmp(argv[k],"fourier") == 0)) test = test_fourier;
+        if ((strcmp(argv[k],"-gpuid") == 0)){
+            if (k+1 >= argc){
+                cerr << "ERROR: -gpuid requires a valid number!" << endl;
+                return 1;
+            }
+            gpuid = atoi(argv[k+1]);
+            k++;
+            if ((gpuid < -1) || (gpuid >= TasmanianSparseGrid::getNumGPUs())){
+                cerr << "ERROR: -gpuid " << gpuid << " is not a valid gpuid!" << endl;
+                cerr << "      see ./tasgrid -v for a list of detected GPUs." << endl;
+                return 1;
+            }
+        }
+        k++;
+    }
+
+    ExternalTester tester(1000);
+    tester.setGPUID(gpuid);
+    bool pass = true;
+    if (debug){
+        tester.debugTest();
+    }else if (debugII){
+        tester.debugTestII();
+    }else{
+        if (verbose) tester.setVerbose(true);
+        if (seed_reset) tester.resetRandomSeed();
+        pass = tester.Test(test);
+    }
+    return (pass) ? 0 : 1;
+
+}

--- a/SparseGrids/tasgridUnitTests.cpp
+++ b/SparseGrids/tasgridUnitTests.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2017, Miroslav Stoyanov
+ *
+ * This file is part of
+ * Toolkit for Adaptive Stochastic Modeling And Non-Intrusive ApproximatioN: TASMANIAN
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * UT-BATTELLE, LLC AND THE UNITED STATES GOVERNMENT MAKE NO REPRESENTATIONS AND DISCLAIM ALL WARRANTIES, BOTH EXPRESSED AND IMPLIED.
+ * THERE ARE NO EXPRESS OR IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE SOFTWARE WILL NOT INFRINGE ANY PATENT,
+ * COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS, OR THAT THE SOFTWARE WILL ACCOMPLISH THE INTENDED RESULTS OR THAT THE SOFTWARE OR ITS USE WILL NOT RESULT IN INJURY OR DAMAGE.
+ * THE USER ASSUMES RESPONSIBILITY FOR ALL LIABILITIES, PENALTIES, FINES, CLAIMS, CAUSES OF ACTION, AND COSTS AND EXPENSES, CAUSED BY, RESULTING FROM OR ARISING OUT OF,
+ * IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
+ */
+
+#ifndef __TASGRID_UNIT_TESTS_CPP
+#define __TASGRID_UNIT_TESTS_CPP
+
+#include "tasgridUnitTests.hpp"
+
+GridUnitTester::GridUnitTester() : verbose(false){}
+GridUnitTester::~GridUnitTester(){}
+
+void GridUnitTester::setVerbose(bool new_verbose){ verbose = new_verbose; }
+
+bool GridUnitTester::Test(UnitTests test){
+    cout << endl << endl;
+    cout << "---------------------------------------------------------------------" << endl;
+    cout << "       Tasmanian Sparse Grids Module: Unit Tests" << endl;
+    cout << "---------------------------------------------------------------------" << endl << endl;
+
+    bool testExceptions = true;
+
+    if ((test == unit_all) || (test == unit_except)) testExceptions = testAllException();
+
+    bool pass = testExceptions;
+    //bool pass = true;
+
+    cout << endl;
+    if (pass){
+        cout << "---------------------------------------------------------------------" << endl;
+        cout << "           All Unit Tests Completed Successfully" << endl;
+        cout << "---------------------------------------------------------------------" << endl << endl;
+    }else{
+        cout << "FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL" << endl;
+        cout << "         Some Unit Tests Have Failed" << endl;
+        cout << "FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL" << endl << endl;
+    }
+    return pass;
+}
+
+bool GridUnitTester::testAllException(){
+    bool pass = true;
+    bool passAll = true;
+    int wfirst = 15, wsecond = 30, wthird = 15;
+
+    // perform std::invalid_argument tests
+    for(int i=0; i<3; i++){
+        try{
+            invalidArgumentCall(i);
+            cout << "Missed arg exception i = " << i << " see GridUnitTester::invalidArgumentCall()" << endl;
+            pass = false;
+            break;
+        }catch(std::invalid_argument &e){
+            //cout << "Got arg exception i = " << i << endl;
+        }
+    }
+
+    if (verbose){
+        cout << setw(wfirst) << "Exception" << setw(wsecond) << "std::invalid_argument" << setw(wthird) << ((pass) ? "Pass" : "FAIL") << endl;
+    }
+
+    passAll = passAll && pass;
+    pass = true;
+
+    // perform std::runtime_error tests
+    for(int i=0; i<2; i++){
+        try{
+            runtimeErrorCall(i);
+            cout << "Missed run exception i = " << i << " see GridUnitTester::runtimeErrorCall()" << endl;
+            pass = false;
+            break;
+        }catch(std::runtime_error &e){
+            //cout << "Got arg exception i = " << i << endl;
+        }
+    }
+
+    if (verbose){
+        cout << setw(wfirst) << "Exception" << setw(wsecond) << "std::runtime_error" << setw(wthird) << ((pass) ? "Pass" : "FAIL") << endl;
+    }
+    passAll = passAll && pass;
+
+    cout << setw(wfirst+1) << "Exceptions" << setw(wsecond-1) << "" << setw(wthird) << ((passAll) ? "Pass" : "FAIL") << endl;
+
+    return pass;
+}
+
+void GridUnitTester::invalidArgumentCall(int i){
+    TasmanianSparseGrid grid;
+    switch(i){
+    case 0: grid.makeSequenceGrid(2, 1, 3, type_level, rule_localp); break; // localp is not a sequence rule
+    case 1: grid.makeLocalPolynomialGrid(2, 1, 3, -2, rule_localp); break; // -2 is not a valid order
+    case 2: grid.makeWaveletGrid(2, 1, 3, 2, 0); break; // 2 is not a valid order (for wavelets)
+    default: break;
+    }
+}
+
+void GridUnitTester::runtimeErrorCall(int i){
+    TasmanianSparseGrid grid;
+    switch(i){
+    case 0: grid.updateGlobalGrid(2, type_level); break; // grid not initialized
+    case 1: grid.updateSequenceGrid(2, type_level); break; // grid not initialized
+    default: break;
+    }
+}
+
+#endif

--- a/SparseGrids/tasgridUnitTests.hpp
+++ b/SparseGrids/tasgridUnitTests.hpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2017, Miroslav Stoyanov
+ *
+ * This file is part of
+ * Toolkit for Adaptive Stochastic Modeling And Non-Intrusive ApproximatioN: TASMANIAN
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * UT-BATTELLE, LLC AND THE UNITED STATES GOVERNMENT MAKE NO REPRESENTATIONS AND DISCLAIM ALL WARRANTIES, BOTH EXPRESSED AND IMPLIED.
+ * THERE ARE NO EXPRESS OR IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE SOFTWARE WILL NOT INFRINGE ANY PATENT,
+ * COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS, OR THAT THE SOFTWARE WILL ACCOMPLISH THE INTENDED RESULTS OR THAT THE SOFTWARE OR ITS USE WILL NOT RESULT IN INJURY OR DAMAGE.
+ * THE USER ASSUMES RESPONSIBILITY FOR ALL LIABILITIES, PENALTIES, FINES, CLAIMS, CAUSES OF ACTION, AND COSTS AND EXPENSES, CAUSED BY, RESULTING FROM OR ARISING OUT OF,
+ * IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
+ */
+
+#ifndef __TASGRID_UNIT_TESTS_HPP
+#define __TASGRID_UNIT_TESTS_HPP
+
+#include <cstdlib>
+#include <cstdio>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <iomanip>
+#include <string.h>
+#include <math.h>
+
+#include "TasmanianSparseGrid.hpp"
+
+#include "tasgridTestFunctions.hpp"
+
+using std::cout;
+using std::endl;
+using std::setw;
+
+using namespace TasGrid;
+
+enum UnitTests{
+    unit_none, unit_all, unit_except
+};
+
+class GridUnitTester{
+public:
+    GridUnitTester();
+    ~GridUnitTester();
+
+    void setVerbose(bool new_verbose);
+
+    bool Test(UnitTests test);
+
+    bool testAllException();
+
+protected:
+    void invalidArgumentCall(int i);
+    void runtimeErrorCall(int i);
+
+private:
+    bool verbose;
+};
+
+#endif

--- a/Testing/multiBuildTest.sh
+++ b/Testing/multiBuildTest.sh
@@ -182,7 +182,7 @@ if (( $bGCC == 1 )); then
     cp -r $sTempSource $sTempBuild/Tasmanian || { exit 1; }
     cd $sTempBuild/Tasmanian || { exit 1; }
     make -j || { echo "Legacy build failed!"; exit 1; }
-    ./tasgrid -test || { echo "Legacy tasgrid failed!"; exit 1; }
+    ./gridtest || { echo "Legacy tasgrid failed!"; exit 1; }
     ./tasdream -test || { echo "Legacy tasdream failed!"; exit 1; }
     ./testTSG.py || { echo "Legacy python test failed!"; exit 1; }
     make examples || { echo "Legacy build examples failed!"; exit 1; }


### PR DESCRIPTION
* until now `tasgrid` was used for both testing and the CLI interface
* separate the tests into a second executable
    * second executable runs in known location (cmake build folders), important for I/O tests
    * reduces the size of the CLI interface executable
* right now, only one new test is included in very preliminary stage, more tests will come as this module grows