### PR TITLE
Vector and exceptions in make grids

### DIFF
--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -147,13 +147,37 @@ void TasmanianSparseGrid::read(std::ifstream &ifs, bool binary){
 }
 
 void TasmanianSparseGrid::makeGlobalGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const int *anisotropic_weights, double alpha, double beta, const char* custom_filename, const int *level_limits){
+    std::vector<int> aw, ll;
+    if (anisotropic_weights != 0){
+        int sizeaw = (OneDimensionalMeta::isTypeCurved(type)) ? 2*dimensions : dimensions;
+        aw.resize(sizeaw);
+        std::copy(anisotropic_weights, anisotropic_weights + sizeaw, aw.data());
+    }
+    if (level_limits != 0){
+        ll.resize(dimensions);
+        std::copy(level_limits, level_limits + dimensions, ll.data());
+    }
+    makeGlobalGrid(dimensions, outputs, depth, type, rule, aw, alpha, beta, custom_filename, ll);
+}
+void TasmanianSparseGrid::makeGlobalGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const std::vector<int> &anisotropic_weights, double alpha, double beta, const char* custom_filename, const std::vector<int> &level_limits){
+    if (dimensions < 1) throw std::invalid_argument("ERROR: makeGlobalGrid() requires positive dimensions");
+    if (outputs < 0) throw std::invalid_argument("ERROR: makeGlobalGrid() requires non-negative outputs");
+    if (depth < 0) throw std::invalid_argument("ERROR: makeGlobalGrid() requires non-negative depth");
+    if (!OneDimensionalMeta::isGlobal(rule)) throw std::invalid_argument("ERROR: makeGlobalGrid() requires a global rule");
+    if ((rule == rule_customtabulated) && (custom_filename == 0)) throw std::invalid_argument("ERROR: makeGlobalGrid() with custom tabulated rule requires a filename");
+    size_t expected_aw_size = (OneDimensionalMeta::isTypeCurved(type)) ? 2*dimensions : dimensions;
+    if ((!anisotropic_weights.empty()) && (anisotropic_weights.size() != expected_aw_size)) throw std::invalid_argument("ERROR: makeGlobalGrid() requires anisotropic_weights with either 0 or dimenions entries");
+    if ((!level_limits.empty()) && (level_limits.size() != (size_t) dimensions)) throw std::invalid_argument("ERROR: makeGlobalGrid() requires level_limits with either 0 or dimenions entries");
     clear();
     global = new GridGlobal();
-    global->makeGrid(dimensions, outputs, depth, type, rule, anisotropic_weights, alpha, beta, custom_filename, level_limits);
+    const int *ll = 0, *aw = 0;
+    if (!anisotropic_weights.empty()) aw = anisotropic_weights.data();
+    if (!level_limits.empty()) ll = level_limits.data();
+    global->makeGrid(dimensions, outputs, depth, type, rule, aw, alpha, beta, custom_filename, ll);
     base = global;
-    if (level_limits != 0){
+    if (!level_limits.empty()){
         llimits = new int[dimensions];
-        std::copy(level_limits, level_limits + dimensions, llimits);
+        std::copy(level_limits.begin(), level_limits.end(), llimits);
     }
 }
 void TasmanianSparseGrid::makeSequenceGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const int *anisotropic_weights, const int *level_limits){

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -277,13 +277,35 @@ void TasmanianSparseGrid::makeWaveletGrid(int dimensions, int outputs, int depth
     }
 }
 void TasmanianSparseGrid::makeFourierGrid(int dimensions, int outputs, int depth, TypeDepth type, const int* anisotropic_weights, const int* level_limits){
+    std::vector<int> aw, ll;
+    if (anisotropic_weights != 0){
+        int sizeaw = (OneDimensionalMeta::isTypeCurved(type)) ? 2*dimensions : dimensions;
+        aw.resize(sizeaw);
+        std::copy(anisotropic_weights, anisotropic_weights + sizeaw, aw.data());
+    }
+    if (level_limits != 0){
+        ll.resize(dimensions);
+        std::copy(level_limits, level_limits + dimensions, ll.data());
+    }
+    makeFourierGrid(dimensions, outputs, depth, type, aw, ll);
+}
+void TasmanianSparseGrid::makeFourierGrid(int dimensions, int outputs, int depth, TypeDepth type, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits){
+    if (dimensions < 1) throw std::invalid_argument("ERROR: makeFourierGrid() requires positive dimensions");
+    if (outputs < 0) throw std::invalid_argument("ERROR: makeFourierGrid() requires non-negative outputs");
+    if (depth < 0) throw std::invalid_argument("ERROR: makeFourierGrid() requires non-negative depth");
+    size_t expected_aw_size = (OneDimensionalMeta::isTypeCurved(type)) ? 2*dimensions : dimensions;
+    if ((!anisotropic_weights.empty()) && (anisotropic_weights.size() != expected_aw_size)) throw std::invalid_argument("ERROR: makeFourierGrid() requires anisotropic_weights with either 0 or dimenions entries");
+    if ((!level_limits.empty()) && (level_limits.size() != (size_t) dimensions)) throw std::invalid_argument("ERROR: makeFourierGrid() requires level_limits with either 0 or dimenions entries");
     clear();
     fourier = new GridFourier();
-    fourier->makeGrid(dimensions, outputs, depth, type, anisotropic_weights, level_limits);
+    const int *ll = 0, *aw = 0;
+    if (!anisotropic_weights.empty()) aw = anisotropic_weights.data();
+    if (!level_limits.empty()) ll = level_limits.data();
+    fourier->makeGrid(dimensions, outputs, depth, type, aw, ll);
     base = fourier;
-    if (level_limits != 0){
+    if (!level_limits.empty()){
         llimits = new int[dimensions];
-        std::copy(level_limits, level_limits + dimensions, llimits);
+        std::copy(level_limits.begin(), level_limits.end(), llimits);
     }
 }
 

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -249,17 +249,31 @@ void TasmanianSparseGrid::makeLocalPolynomialGrid(int dimensions, int outputs, i
     }
 }
 void TasmanianSparseGrid::makeWaveletGrid(int dimensions, int outputs, int depth, int order, const int *level_limits){
+    std::vector<int> ll;
+    if (level_limits != 0){
+        ll.resize(dimensions);
+        std::copy(level_limits, level_limits + dimensions, ll.data());
+    }
+    makeWaveletGrid(dimensions, outputs, depth, order, ll);
+}
+void TasmanianSparseGrid::makeWaveletGrid(int dimensions, int outputs, int depth, int order, const std::vector<int> &level_limits){
+    if (dimensions < 1) throw std::invalid_argument("ERROR: makeWaveletGrid() requires positive dimensions");
+    if (outputs < 0) throw std::invalid_argument("ERROR: makeWaveletGrid() requires non-negative outputs");
+    if (depth < 0) throw std::invalid_argument("ERROR: makeWaveletGrid() requires non-negative depth");
     if ((order != 1) && (order != 3)){
         std::string message = "ERROR: makeWaveletGrid is called with order: " + std::to_string(order) + "but wavelets are implemented only for orders 1 and 3.";
         throw std::invalid_argument(message);
     }
+    if ((!level_limits.empty()) && (level_limits.size() != (size_t) dimensions)) throw std::invalid_argument("ERROR: makeWaveletGrid() requires level_limits with either 0 or dimenions entries");
     clear();
+    const int *ll = 0;
+    if (!level_limits.empty()) ll = level_limits.data();
     wavelet = new GridWavelet();
-    wavelet->makeGrid(dimensions, outputs, depth, order, level_limits);
+    wavelet->makeGrid(dimensions, outputs, depth, order, ll);
     base = wavelet;
-    if (level_limits != 0){
+    if (!level_limits.empty()){
         llimits = new int[dimensions];
-        std::copy(level_limits, level_limits + dimensions, llimits);
+        std::copy(level_limits.begin(), level_limits.end(), llimits);
     }
 }
 void TasmanianSparseGrid::makeFourierGrid(int dimensions, int outputs, int depth, TypeDepth type, const int* anisotropic_weights, const int* level_limits){

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -217,21 +217,35 @@ void TasmanianSparseGrid::makeSequenceGrid(int dimensions, int outputs, int dept
     }
 }
 void TasmanianSparseGrid::makeLocalPolynomialGrid(int dimensions, int outputs, int depth, int order, TypeOneDRule rule, const int *level_limits){
-    if (!OneDimensionalMeta::isLocalPolynomial(rule)){
-        std::string message = "ERROR: makeLocalPolynomialGrid is called with rule: " + std::string(OneDimensionalMeta::getIORuleString(rule)) + ", which is not a local polynomial rule";
-        throw std::invalid_argument(message);
+    std::vector<int> ll;
+    if (level_limits != 0){
+        ll.resize(dimensions);
+        std::copy(level_limits, level_limits + dimensions, ll.data());
     }
+    makeLocalPolynomialGrid(dimensions, outputs, depth, order, rule, ll);
+}
+void TasmanianSparseGrid::makeLocalPolynomialGrid(int dimensions, int outputs, int depth, int order, TypeOneDRule rule, const std::vector<int> &level_limits){
+    if (dimensions < 1) throw std::invalid_argument("ERROR: makeLocalPolynomialGrid() requires positive dimensions");
+    if (outputs < 0) throw std::invalid_argument("ERROR: makeLocalPolynomialGrid() requires non-negative outputs");
+    if (depth < 0) throw std::invalid_argument("ERROR: makeLocalPolynomialGrid() requires non-negative depth");
     if (order < -1){
         std::string message = "ERROR: makeLocalPolynomialGrid is called with order: " + std::to_string(order) + ", but the order cannot be less than -1.";
         throw std::invalid_argument(message);
     }
+    if (!OneDimensionalMeta::isLocalPolynomial(rule)){
+        std::string message = "ERROR: makeLocalPolynomialGrid is called with rule: " + std::string(OneDimensionalMeta::getIORuleString(rule)) + ", which is not a local polynomial rule";
+        throw std::invalid_argument(message);
+    }
+    if ((!level_limits.empty()) && (level_limits.size() != (size_t) dimensions)) throw std::invalid_argument("ERROR: makeLocalPolynomialGrid() requires level_limits with either 0 or dimenions entries");
     clear();
+    const int *ll = 0;
+    if (!level_limits.empty()) ll = level_limits.data();
     pwpoly = new GridLocalPolynomial();
-    pwpoly->makeGrid(dimensions, outputs, depth, order, rule, level_limits);
+    pwpoly->makeGrid(dimensions, outputs, depth, order, rule, ll);
     base = pwpoly;
-    if (level_limits != 0){
+    if (!level_limits.empty()){
         llimits = new int[dimensions];
-        std::copy(level_limits, level_limits + dimensions, llimits);
+        std::copy(level_limits.begin(), level_limits.end(), llimits);
     }
 }
 void TasmanianSparseGrid::makeWaveletGrid(int dimensions, int outputs, int depth, int order, const int *level_limits){

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -68,6 +68,7 @@ public:
     void makeGlobalGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const int *anisotropic_weights = 0, double alpha = 0.0, double beta = 0.0, const char* custom_filename = 0, const int *level_limits = 0);
     void makeGlobalGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const std::vector<int> &anisotropic_weights, double alpha = 0.0, double beta = 0.0, const char* custom_filename = 0, const std::vector<int> &level_limits = std::vector<int>());
     void makeSequenceGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const int *anisotropic_weights = 0, const int *level_limits = 0);
+    void makeSequenceGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits = std::vector<int>());
     void makeLocalPolynomialGrid(int dimensions, int outputs, int depth, int order = 1, TypeOneDRule rule = rule_localp, const int *level_limits = 0);
     void makeWaveletGrid(int dimensions, int outputs, int depth, int order = 1, const int *level_limits = 0);
     void makeFourierGrid(int dimensions, int outputs, int depth, TypeDepth type, const int* anisotropic_weights = 0, const int* level_limits = 0);

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -72,6 +72,7 @@ public:
     void makeLocalPolynomialGrid(int dimensions, int outputs, int depth, int order = 1, TypeOneDRule rule = rule_localp, const int *level_limits = 0);
     void makeLocalPolynomialGrid(int dimensions, int outputs, int depth, int order, TypeOneDRule rule, const std::vector<int> &level_limits);
     void makeWaveletGrid(int dimensions, int outputs, int depth, int order = 1, const int *level_limits = 0);
+    void makeWaveletGrid(int dimensions, int outputs, int depth, int order, const std::vector<int> &level_limits);
     void makeFourierGrid(int dimensions, int outputs, int depth, TypeDepth type, const int* anisotropic_weights = 0, const int* level_limits = 0);
     void copyGrid(const TasmanianSparseGrid *source);
 

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -74,6 +74,7 @@ public:
     void makeWaveletGrid(int dimensions, int outputs, int depth, int order = 1, const int *level_limits = 0);
     void makeWaveletGrid(int dimensions, int outputs, int depth, int order, const std::vector<int> &level_limits);
     void makeFourierGrid(int dimensions, int outputs, int depth, TypeDepth type, const int* anisotropic_weights = 0, const int* level_limits = 0);
+    void makeFourierGrid(int dimensions, int outputs, int depth, TypeDepth type, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits = std::vector<int>());
     void copyGrid(const TasmanianSparseGrid *source);
 
     void updateGlobalGrid(int depth, TypeDepth type, const int *anisotropic_weights = 0, const int *level_limits = 0);

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -70,6 +70,7 @@ public:
     void makeSequenceGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const int *anisotropic_weights = 0, const int *level_limits = 0);
     void makeSequenceGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits = std::vector<int>());
     void makeLocalPolynomialGrid(int dimensions, int outputs, int depth, int order = 1, TypeOneDRule rule = rule_localp, const int *level_limits = 0);
+    void makeLocalPolynomialGrid(int dimensions, int outputs, int depth, int order, TypeOneDRule rule, const std::vector<int> &level_limits);
     void makeWaveletGrid(int dimensions, int outputs, int depth, int order = 1, const int *level_limits = 0);
     void makeFourierGrid(int dimensions, int outputs, int depth, TypeDepth type, const int* anisotropic_weights = 0, const int* level_limits = 0);
     void copyGrid(const TasmanianSparseGrid *source);

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -66,6 +66,7 @@ public:
     void read(std::ifstream &ifs, bool binary = false);
 
     void makeGlobalGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const int *anisotropic_weights = 0, double alpha = 0.0, double beta = 0.0, const char* custom_filename = 0, const int *level_limits = 0);
+    void makeGlobalGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const std::vector<int> &anisotropic_weights, double alpha = 0.0, double beta = 0.0, const char* custom_filename = 0, const std::vector<int> &level_limits = std::vector<int>());
     void makeSequenceGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const int *anisotropic_weights = 0, const int *level_limits = 0);
     void makeLocalPolynomialGrid(int dimensions, int outputs, int depth, int order = 1, TypeOneDRule rule = rule_localp, const int *level_limits = 0);
     void makeWaveletGrid(int dimensions, int outputs, int depth, int order = 1, const int *level_limits = 0);

--- a/SparseGrids/tasgridUnitTests.cpp
+++ b/SparseGrids/tasgridUnitTests.cpp
@@ -70,7 +70,7 @@ bool GridUnitTester::testAllException(){
     int wfirst = 15, wsecond = 30, wthird = 15;
 
     // perform std::invalid_argument tests
-    for(int i=0; i<20; i++){
+    for(int i=0; i<24; i++){
         try{
             invalidArgumentCall(i);
             cout << "Missed arg exception i = " << i << " see GridUnitTester::invalidArgumentCall()" << endl;
@@ -132,7 +132,12 @@ void GridUnitTester::invalidArgumentCall(int i){
     case 16: grid.makeLocalPolynomialGrid(2,  1,  3, -2, rule_localp); break; // -2 is not a valid order
     case 17: grid.makeLocalPolynomialGrid(2,  1,  3, -2, rule_mindelta); break; // mindelta is not a local rule
     case 18: grid.makeLocalPolynomialGrid(2,  1,  3,  1, rule_localp, std::vector<int>()={3}); break; // level limits is too short
-    case 19: grid.makeWaveletGrid(2, 1, 3, 2, 0); break; // 2 is not a valid order (for wavelets)
+    case 19: grid.makeWaveletGrid(0,  1,  3,  1,  0); break; // 0 is not a valid dimensions
+    case 20: grid.makeWaveletGrid(2, -1,  3,  1,  0); break; // -1 is not a valid outputs
+    case 21: grid.makeWaveletGrid(2,  1, -3,  1,  0); break; // -3 is not a valid depth
+    case 22: grid.makeWaveletGrid(2,  1,  3,  2,  0); break; // 2 is not a valid order (for wavelets)
+    case 23: grid.makeWaveletGrid(2,  1,  3,  2,  std::vector<int>()={3}); break; // level limits is too short
+
     default: break;
     }
 }

--- a/SparseGrids/tasgridUnitTests.cpp
+++ b/SparseGrids/tasgridUnitTests.cpp
@@ -70,7 +70,7 @@ bool GridUnitTester::testAllException(){
     int wfirst = 15, wsecond = 30, wthird = 15;
 
     // perform std::invalid_argument tests
-    for(int i=0; i<24; i++){
+    for(int i=0; i<29; i++){
         try{
             invalidArgumentCall(i);
             cout << "Missed arg exception i = " << i << " see GridUnitTester::invalidArgumentCall()" << endl;
@@ -137,6 +137,11 @@ void GridUnitTester::invalidArgumentCall(int i){
     case 21: grid.makeWaveletGrid(2,  1, -3,  1,  0); break; // -3 is not a valid depth
     case 22: grid.makeWaveletGrid(2,  1,  3,  2,  0); break; // 2 is not a valid order (for wavelets)
     case 23: grid.makeWaveletGrid(2,  1,  3,  2,  std::vector<int>()={3}); break; // level limits is too short
+    case 24: grid.makeFourierGrid(0, 1, 3, type_level); break; // dimension is 0
+    case 25: grid.makeFourierGrid(2, -1, 3, type_level); break; // output is -1
+    case 26: grid.makeFourierGrid(2, 2, -1, type_level); break; // depth is -1
+    case 27: grid.makeFourierGrid(2, 2, 2, type_level, std::vector<int>()={3}); break; // aw is too short
+    case 28: grid.makeFourierGrid(2, 2, 2, type_level, std::vector<int>(), std::vector<int>()={3}); break; // level limits is too short
 
     default: break;
     }

--- a/SparseGrids/tasgridUnitTests.cpp
+++ b/SparseGrids/tasgridUnitTests.cpp
@@ -70,7 +70,7 @@ bool GridUnitTester::testAllException(){
     int wfirst = 15, wsecond = 30, wthird = 15;
 
     // perform std::invalid_argument tests
-    for(int i=0; i<15; i++){
+    for(int i=0; i<20; i++){
         try{
             invalidArgumentCall(i);
             cout << "Missed arg exception i = " << i << " see GridUnitTester::invalidArgumentCall()" << endl;
@@ -126,8 +126,13 @@ void GridUnitTester::invalidArgumentCall(int i){
     case 10: grid.makeSequenceGrid(2, 1, 3, type_level, rule_localp); break; // localp is not a sequence rule
     case 11: grid.makeSequenceGrid(2, 2, 2, type_level, rule_rleja, std::vector<int>()={3}); break; // aw is too short
     case 12: grid.makeSequenceGrid(2, 2, 2, type_level, rule_chebyshev, std::vector<int>(), std::vector<int>()={3}); break; // level limits is too short
-    case 13: grid.makeLocalPolynomialGrid(2, 1, 3, -2, rule_localp); break; // -2 is not a valid order
-    case 14: grid.makeWaveletGrid(2, 1, 3, 2, 0); break; // 2 is not a valid order (for wavelets)
+    case 13: grid.makeLocalPolynomialGrid(0,  1,  3,  3, rule_localp); break; // 0 is not valid dimensions
+    case 14: grid.makeLocalPolynomialGrid(2, -1,  3,  2, rule_localp); break; // -1 is not valid outputs
+    case 15: grid.makeLocalPolynomialGrid(2,  1, -1,  2, rule_localp); break; // -1 is not valid depth
+    case 16: grid.makeLocalPolynomialGrid(2,  1,  3, -2, rule_localp); break; // -2 is not a valid order
+    case 17: grid.makeLocalPolynomialGrid(2,  1,  3, -2, rule_mindelta); break; // mindelta is not a local rule
+    case 18: grid.makeLocalPolynomialGrid(2,  1,  3,  1, rule_localp, std::vector<int>()={3}); break; // level limits is too short
+    case 19: grid.makeWaveletGrid(2, 1, 3, 2, 0); break; // 2 is not a valid order (for wavelets)
     default: break;
     }
 }

--- a/SparseGrids/tasgridUnitTests.cpp
+++ b/SparseGrids/tasgridUnitTests.cpp
@@ -70,7 +70,7 @@ bool GridUnitTester::testAllException(){
     int wfirst = 15, wsecond = 30, wthird = 15;
 
     // perform std::invalid_argument tests
-    for(int i=0; i<7; i++){
+    for(int i=0; i<15; i++){
         try{
             invalidArgumentCall(i);
             cout << "Missed arg exception i = " << i << " see GridUnitTester::invalidArgumentCall()" << endl;
@@ -113,13 +113,21 @@ bool GridUnitTester::testAllException(){
 void GridUnitTester::invalidArgumentCall(int i){
     TasmanianSparseGrid grid;
     switch(i){
-    case 0: grid.makeGlobalGrid(0, 1, 3, type_level, rule_gausslegendre); break; // dimension is 0
-    case 1: grid.makeGlobalGrid(2, -1, 3, type_level, rule_gausslegendre); break; // output is -1
-    case 2: grid.makeGlobalGrid(2, 2, -1, type_level, rule_rleja); break; // depth is -1
-    case 3: grid.makeGlobalGrid(2, 2, -1, type_level, rule_localp); break; // rule is localp
-    case 4: grid.makeSequenceGrid(2, 1, 3, type_level, rule_localp); break; // localp is not a sequence rule
-    case 5: grid.makeLocalPolynomialGrid(2, 1, 3, -2, rule_localp); break; // -2 is not a valid order
-    case 6: grid.makeWaveletGrid(2, 1, 3, 2, 0); break; // 2 is not a valid order (for wavelets)
+    case  0: grid.makeGlobalGrid(0, 1, 3, type_level, rule_gausslegendre); break; // dimension is 0
+    case  1: grid.makeGlobalGrid(2, -1, 3, type_level, rule_gausslegendre); break; // output is -1
+    case  2: grid.makeGlobalGrid(2, 2, -1, type_level, rule_rleja); break; // depth is -1
+    case  3: grid.makeGlobalGrid(2, 2, 1, type_level, rule_localp); break; // rule is localp
+    case  4: grid.makeGlobalGrid(2, 2, 2, type_level, rule_rleja, std::vector<int>()={3}); break; // aw is too short
+    case  5: grid.makeGlobalGrid(2, 2, 2, type_level, rule_customtabulated, std::vector<int>(), 0.0, 0.0, 0); break; // custom filename is empty
+    case  6: grid.makeGlobalGrid(2, 2, 2, type_level, rule_chebyshev, std::vector<int>(), 0.0, 0.0, 0, std::vector<int>()={3}); break; // level limits is too short
+    case  7: grid.makeSequenceGrid(0, 1, 3, type_level, rule_rleja); break; // dimension is 0
+    case  8: grid.makeSequenceGrid(2, -1, 3, type_level, rule_minlebesgue); break; // output is -1
+    case  9: grid.makeSequenceGrid(2, 2, -1, type_level, rule_rleja); break; // depth is -1
+    case 10: grid.makeSequenceGrid(2, 1, 3, type_level, rule_localp); break; // localp is not a sequence rule
+    case 11: grid.makeSequenceGrid(2, 2, 2, type_level, rule_rleja, std::vector<int>()={3}); break; // aw is too short
+    case 12: grid.makeSequenceGrid(2, 2, 2, type_level, rule_chebyshev, std::vector<int>(), std::vector<int>()={3}); break; // level limits is too short
+    case 13: grid.makeLocalPolynomialGrid(2, 1, 3, -2, rule_localp); break; // -2 is not a valid order
+    case 14: grid.makeWaveletGrid(2, 1, 3, 2, 0); break; // 2 is not a valid order (for wavelets)
     default: break;
     }
 }

--- a/SparseGrids/tasgridUnitTests.cpp
+++ b/SparseGrids/tasgridUnitTests.cpp
@@ -70,7 +70,7 @@ bool GridUnitTester::testAllException(){
     int wfirst = 15, wsecond = 30, wthird = 15;
 
     // perform std::invalid_argument tests
-    for(int i=0; i<3; i++){
+    for(int i=0; i<7; i++){
         try{
             invalidArgumentCall(i);
             cout << "Missed arg exception i = " << i << " see GridUnitTester::invalidArgumentCall()" << endl;
@@ -113,9 +113,13 @@ bool GridUnitTester::testAllException(){
 void GridUnitTester::invalidArgumentCall(int i){
     TasmanianSparseGrid grid;
     switch(i){
-    case 0: grid.makeSequenceGrid(2, 1, 3, type_level, rule_localp); break; // localp is not a sequence rule
-    case 1: grid.makeLocalPolynomialGrid(2, 1, 3, -2, rule_localp); break; // -2 is not a valid order
-    case 2: grid.makeWaveletGrid(2, 1, 3, 2, 0); break; // 2 is not a valid order (for wavelets)
+    case 0: grid.makeGlobalGrid(0, 1, 3, type_level, rule_gausslegendre); break; // dimension is 0
+    case 1: grid.makeGlobalGrid(2, -1, 3, type_level, rule_gausslegendre); break; // output is -1
+    case 2: grid.makeGlobalGrid(2, 2, -1, type_level, rule_rleja); break; // depth is -1
+    case 3: grid.makeGlobalGrid(2, 2, -1, type_level, rule_localp); break; // rule is localp
+    case 4: grid.makeSequenceGrid(2, 1, 3, type_level, rule_localp); break; // localp is not a sequence rule
+    case 5: grid.makeLocalPolynomialGrid(2, 1, 3, -2, rule_localp); break; // -2 is not a valid order
+    case 6: grid.makeWaveletGrid(2, 1, 3, 2, 0); break; // 2 is not a valid order (for wavelets)
     default: break;
     }
 }

--- a/SparseGrids/tsgCoreOneDimensional.cpp
+++ b/SparseGrids/tsgCoreOneDimensional.cpp
@@ -687,6 +687,10 @@ int OneDimensionalMeta::getIORuleInt(TypeOneDRule rule){
     }
 }
 
+bool OneDimensionalMeta::isTypeCurved(TypeDepth type){
+    return ((type == type_curved) || (type == type_ipcurved) || (type == type_qptotal));
+}
+
 TypeDepth OneDimensionalMeta::getIOTypeString(const char *name){
     if (strcmp(name, "level") == 0){
         return type_level;

--- a/SparseGrids/tsgCoreOneDimensional.hpp
+++ b/SparseGrids/tsgCoreOneDimensional.hpp
@@ -100,6 +100,8 @@ public:
     static TypeOneDRule getIORuleInt(int index);
     static int getIORuleInt(TypeOneDRule rule);
 
+    static bool isTypeCurved(TypeDepth type);
+
     static TypeDepth getIOTypeString(const char *name);
     static TypeDepth getIOTypeInt(int type);
 


### PR DESCRIPTION
* each `make<type>Grid()` function has an overload that accepts vectors for level limits and anisotropy
* basic sanity check is performed to ensure that dimensions are positive, outputs are non-negative, the correct rule is used for the grid type, etc.
* exceptions are checked in the unit-test module