### PR TITLE
Overflow in global

### DIFF
--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -747,8 +747,8 @@ void GridGlobal::makeCheckAccelerationData(TypeAcceleration) const{}
 #endif // Tasmanian_ENABLE_CUDA
 
 void GridGlobal::integrate(double q[], double *conformal_correction) const{
-    double *w = new double[getNumPoints()];
-    getQuadratureWeights(w);
+    std::vector<double> w(getNumPoints());
+    getQuadratureWeights(w.data());
     if (conformal_correction != 0) for(int i=0; i<points->getNumIndexes(); i++) w[i] *= conformal_correction[i];
     std::fill(q, q+num_outputs, 0.0);
     #pragma omp parallel for schedule(static)
@@ -758,7 +758,6 @@ void GridGlobal::integrate(double q[], double *conformal_correction) const{
             q[k] += w[i] * v[k];
         }
     }
-    delete[] w;
 }
 
 void GridGlobal::evaluateHierarchicalFunctions(const double x[], int num_x, double y[]) const{

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -459,21 +459,27 @@ int GridGlobal::getNumPoints() const{ return ((points == 0) ? getNumNeeded() : p
 
 void GridGlobal::getLoadedPoints(double *x) const{
     int num_points = points->getNumIndexes();
+    Data2D<double> split;
+    split.load(num_dimensions, num_points, x);
     #pragma omp parallel for schedule(static)
     for(int i=0; i<num_points; i++){
         const int *p = points->getIndex(i);
+        double *xx = split.getStrip(i);
         for(int j=0; j<num_dimensions; j++){
-            x[i*num_dimensions + j] = wrapper->getNode(p[j]);
+            xx[j] = wrapper->getNode(p[j]);
         }
     }
 }
 void GridGlobal::getNeededPoints(double *x) const{
     int num_points = needed->getNumIndexes();
+    Data2D<double> split;
+    split.load(num_dimensions, num_points, x);
     #pragma omp parallel for schedule(static)
     for(int i=0; i<num_points; i++){
         const int *p = needed->getIndex(i);
+        double *xx = split.getStrip(i);
         for(int j=0; j<num_dimensions; j++){
-            x[i*num_dimensions + j] = wrapper->getNode(p[j]);
+            xx[j] = wrapper->getNode(p[j]);
         }
     }
 }

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -636,10 +636,9 @@ void GridGlobal::evaluate(const double x[], double y[]) const{
 
 #ifdef Tasmanian_ENABLE_BLAS
 void GridGlobal::evaluateFastCPUblas(const double x[], double y[]) const{
-    double *w = new double[points->getNumIndexes()];
-    getInterpolationWeights(x, w);
-    TasBLAS::dgemv(num_outputs, points->getNumIndexes(), values->getValues(0), w, y);
-    delete[] w;
+    std::vector<double> w(points->getNumIndexes());
+    getInterpolationWeights(x, w.data());
+    TasBLAS::dgemv(num_outputs, points->getNumIndexes(), values->getValues(0), w.data(), y);
 }
 #else
 void GridGlobal::evaluateFastCPUblas(const double[], double[]) const{}
@@ -650,12 +649,10 @@ void GridGlobal::evaluateFastGPUcublas(const double x[], double y[]) const{
     makeCheckAccelerationData(accel_gpu_cublas);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
-    double *weights = new double[points->getNumIndexes()];
-    getInterpolationWeights(x, weights);
+    std::vector<double> weights(points->getNumIndexes());
+    getInterpolationWeights(x, weights.data());
 
-    gpu->cublasDGEMM(true, num_outputs, 1, points->getNumIndexes(), weights, y);
-
-    delete[] weights;
+    gpu->cublasDGEMM(true, num_outputs, 1, points->getNumIndexes(), weights.data(), y);
 }
 #else
 void GridGlobal::evaluateFastGPUcublas(const double[], double[]) const{}
@@ -669,12 +666,10 @@ void GridGlobal::evaluateFastGPUmagma(int gpuID, const double x[], double y[]) c
     makeCheckAccelerationData(accel_gpu_magma);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
-    double *weights = new double[points->getNumIndexes()];
-    getInterpolationWeights(x, weights);
+    std::vector<double> weights(points->getNumIndexes());
+    getInterpolationWeights(x, weights.data());
 
-    gpu->magmaCudaDGEMM(true, gpuID, num_outputs, 1, points->getNumIndexes(), weights, y);
-
-    delete[] weights;
+    gpu->magmaCudaDGEMM(true, gpuID, num_outputs, 1, points->getNumIndexes(), weights.data(), y);
 }
 #else
 void GridGlobal::evaluateFastGPUmagma(int, const double[], double[]) const{}

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -178,7 +178,7 @@ void GridGlobal::read(std::ifstream &ifs){
             oned_max_level = IM.getMaxLevel(updated_tensors);
         }else{
             oned_max_level = max_levels[0];
-            for(int j=1; j<num_dimensions; j++) if (oned_max_level < max_levels[j]) oned_max_level = max_levels[j];
+            for(auto l: max_levels) if (oned_max_level < l) oned_max_level = l;
         }
         OneDimensionalMeta meta(custom);
         wrapper = new OneDimensionalWrapper(&meta, oned_max_level, rule, alpha, beta);
@@ -245,7 +245,7 @@ void GridGlobal::readBinary(std::ifstream &ifs){
             oned_max_level = IM.getMaxLevel(updated_tensors);
         }else{
             oned_max_level = max_levels[0];
-            for(int j=1; j<num_dimensions; j++) if (oned_max_level < max_levels[j]) oned_max_level = max_levels[j];
+            for(auto l: max_levels) if (oned_max_level < l) oned_max_level = l;
         }
         OneDimensionalMeta meta(custom);
         wrapper = new OneDimensionalWrapper(&meta, oned_max_level, rule, alpha, beta);

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -702,12 +702,10 @@ void GridGlobal::evaluateBatchGPUcublas(const double x[], int num_x, double y[])
     makeCheckAccelerationData(accel_gpu_cublas);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
-    double *weights = new double[((size_t) num_points) * ((size_t) num_x)];
-    evaluateHierarchicalFunctions(x, num_x, weights);
+    Data2D<double> weights; weights.resize(num_points, num_x);
+    evaluateHierarchicalFunctions(x, num_x, weights.getStrip(0));
 
-    gpu->cublasDGEMM(true, num_outputs, num_x, num_points, weights, y);
-
-    delete[] weights;
+    gpu->cublasDGEMM(true, num_outputs, num_x, num_points, weights.getStrip(0), y);
 }
 #else
 void GridGlobal::evaluateBatchGPUcublas(const double[], int, double[]) const{}
@@ -722,12 +720,10 @@ void GridGlobal::evaluateBatchGPUmagma(int gpuID, const double x[], int num_x, d
     makeCheckAccelerationData(accel_gpu_magma);
 
     AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
-    double *weights = new double[((size_t) num_points) * ((size_t) num_x)];
-    evaluateHierarchicalFunctions(x, num_x, weights);
+    Data2D<double> weights; weights.resize(num_points, num_x);
+    evaluateHierarchicalFunctions(x, num_x, weights.getStrip(0));
 
-    gpu->magmaCudaDGEMM(true, gpuID, num_outputs, num_x, num_points, weights, y);
-
-    delete[] weights;
+    gpu->magmaCudaDGEMM(true, gpuID, num_outputs, num_x, num_points, weights.getStrip(0), y);
 }
 #else
 void GridGlobal::evaluateBatchGPUmagma(int, const double[], int, double[]) const{}

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -492,7 +492,7 @@ void GridGlobal::getQuadratureWeights(double weights[]) const{
     int num_points = work->getNumIndexes();
     std::fill(weights, weights + num_points, 0.0);
 
-    int *num_oned_points = new int[num_dimensions];
+    std::vector<int> num_oned_points(num_dimensions);
     for(int n=0; n<active_tensors->getNumIndexes(); n++){
         const int* levels = active_tensors->getIndex(n);
         num_oned_points[0] = wrapper->getNumPoints(levels[0]);
@@ -514,19 +514,17 @@ void GridGlobal::getQuadratureWeights(double weights[]) const{
             weights[tensor_refs[n][i]] += tensor_weight * w;
         }
     }
-    delete[] num_oned_points;
-    work = 0;
 }
 
 void GridGlobal::getInterpolationWeights(const double x[], double weights[]) const{
     IndexSet *work = (points == 0) ? needed : points;
 
-    CacheLagrange<double> *lcache = new CacheLagrange<double>(num_dimensions, max_levels.data(), wrapper, x);
+    CacheLagrange<double> lcache(num_dimensions, max_levels.data(), wrapper, x);
 
     int num_points = work->getNumIndexes();
     std::fill(weights, weights + num_points, 0.0);
 
-    int *num_oned_points = new int[num_dimensions];
+    std::vector<int> num_oned_points(num_dimensions);
     for(int n=0; n<active_tensors->getNumIndexes(); n++){
         const int* levels = active_tensors->getIndex(n);
         num_oned_points[0] = wrapper->getNumPoints(levels[0]);
@@ -540,16 +538,12 @@ void GridGlobal::getInterpolationWeights(const double x[], double weights[]) con
             int t = i;
             double w = 1.0;
             for(int j=num_dimensions-1; j>=0; j--){
-                w *= lcache->getLagrange(j, levels[j], t % num_oned_points[j]);
+                w *= lcache.getLagrange(j, levels[j], t % num_oned_points[j]);
                 t /= num_oned_points[j];
             }
             weights[tensor_refs[n][i]] += tensor_weight * w;
         }
     }
-    delete[] num_oned_points;
-    work = 0;
-
-    delete lcache;
 }
 
 void GridGlobal::loadNeededPoints(const double *vals, TypeAcceleration){

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -623,8 +623,8 @@ const double* GridGlobal::getLoadedValues() const{
 }
 
 void GridGlobal::evaluate(const double x[], double y[]) const{
-    double *w = new double[points->getNumIndexes()];
-    getInterpolationWeights(x, w);
+    std::vector<double> w(points->getNumIndexes());
+    getInterpolationWeights(x, w.data());
     TasBLAS::setzero(num_outputs, y);
     for(int k=0; k<num_outputs; k++){
         for(int i=0; i<points->getNumIndexes(); i++){
@@ -632,7 +632,6 @@ void GridGlobal::evaluate(const double x[], double y[]) const{
             y[k] += w[i] * v[k];
         }
     }
-    delete[] w;
 }
 
 #ifdef Tasmanian_ENABLE_BLAS

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -771,9 +771,11 @@ void GridGlobal::integrate(double q[], double *conformal_correction) const{
 
 void GridGlobal::evaluateHierarchicalFunctions(const double x[], int num_x, double y[]) const{
     int num_points = (points == 0) ? needed->getNumIndexes() : points->getNumIndexes();
+    Data2D<double> yy; yy.load(num_points, num_x, y);
+    Data2D<double> xx; xx.cload(num_dimensions, num_x, x);
     #pragma omp parallel for
     for(int i=0; i<num_x; i++){
-        getInterpolationWeights(&(x[((size_t) i) * ((size_t) num_dimensions)]), &(y[((size_t) i) * ((size_t) num_points)]));
+        getInterpolationWeights(xx.getCStrip(i), yy.getStrip(i));
     }
 }
 

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -685,15 +685,16 @@ void GridGlobal::evaluateBatch(const double x[], int num_x, double y[]) const{
 #ifdef Tasmanian_ENABLE_BLAS
 void GridGlobal::evaluateBatchCPUblas(const double x[], int num_x, double y[]) const{
     int num_points = points->getNumIndexes();
-    double *weights = new double[num_points * num_x];
+    Data2D<double> weights;
+    weights.resize(num_points, num_x);
+    Data2D<double> xx;
+    xx.cload(num_dimensions, num_x, x);
     #pragma omp parallel for
     for(int i=0; i<num_x; i++){
-        getInterpolationWeights(&(x[((size_t) i) * ((size_t) num_dimensions)]), &(weights[((size_t) i) * ((size_t) num_points)]));
+        getInterpolationWeights(xx.getCStrip(i), weights.getStrip(i));
     }
 
-    TasBLAS::dgemm(num_outputs, num_x, num_points, 1.0, values->getValues(0), weights, 0.0, y);
-
-    delete[] weights;
+    TasBLAS::dgemm(num_outputs, num_x, num_points, 1.0, values->getValues(0), weights.getStrip(0), 0.0, y);
 }
 #else
 void GridGlobal::evaluateBatchCPUblas(const double[], int, double[]) const{}

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -93,7 +93,7 @@ void GridLocalPolynomial::write(std::ofstream &ofs) const{
         }else{
             ofs << "1";
             size_t n = parents.getTotalEntries();
-            const int *p = parents.getStrip(0);
+            const int *p = parents.getCStrip(0);
             for(size_t i=0; i<n; i++){ ofs << " " << p[i]; } ofs << endl;
         }
         int num_points = (points == 0) ? needed->getNumIndexes() : points->getNumIndexes();
@@ -137,7 +137,7 @@ void GridLocalPolynomial::writeBinary(std::ofstream &ofs) const{
             flag = 'n'; ofs.write(&flag, sizeof(char));
         }else{
             flag = 'y'; ofs.write(&flag, sizeof(char));
-            ofs.write((char*) parents.getStrip(0), parents.getTotalEntries() * sizeof(int));
+            ofs.write((char*) parents.getCStrip(0), parents.getTotalEntries() * sizeof(int));
         }
 
         int num_points = (points == 0) ? needed->getNumIndexes() : points->getNumIndexes();
@@ -711,7 +711,7 @@ void GridLocalPolynomial::getInterpolationWeights(const double x[], double *weig
 
                 while(monkey_count[0] < max_parents){
                     if (monkey_count[current] < max_parents){
-                        int branch = dagUp->getStrip(monkey_tail[current])[monkey_count[current]];
+                        int branch = dagUp->getCStrip(monkey_tail[current])[monkey_count[current]];
                         if ((branch == -1) || used[branch]){
                             monkey_count[current]++;
                         }else{
@@ -1298,7 +1298,7 @@ void GridLocalPolynomial::getQuadratureWeights(double *weights) const{
 
                 while(monkey_count[0] < max_parents){
                     if (monkey_count[current] < max_parents){
-                        int branch = dagUp->getStrip(monkey_tail[current])[monkey_count[current]];
+                        int branch = dagUp->getCStrip(monkey_tail[current])[monkey_count[current]];
                         if ((branch == -1) || used[branch]){
                             monkey_count[current]++;
                         }else{

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -149,22 +149,32 @@ public:
         num_strips = (size_t) new_num_strips;
         vec.resize(stride * num_strips);
         data = vec.data();
+        cdata = vec.data();
     }
     void resize(int new_stride, int new_num_strips, T val){
         stride = (size_t) new_stride;
         num_strips = (size_t) new_num_strips;
         vec.resize(stride * num_strips, val);
         data = vec.data();
+        cdata = vec.data();
     }
     void load(int new_stride, int new_num_strips, T* new_data){
         stride = (size_t) new_stride;
         num_strips = (size_t) new_num_strips;
         data = new_data;
+        cdata = data;
+        vec.resize(0);
+    }
+    void cload(int new_stride, int new_num_strips, const T* new_data){
+        stride = (size_t) new_stride;
+        num_strips = (size_t) new_num_strips;
+        cdata = new_data;
+        data = 0;
         vec.resize(0);
     }
 
     T* getStrip(int i){ return &(data[i*stride]); }
-    const T* getStrip(int i) const{ return &(data[i*stride]); }
+    const T* getCStrip(int i) const{ return &(cdata[i*stride]); }
     int getStride() const{ return (int) stride; }
     int getNumStrips() const{ return (int) num_strips; }
     size_t getTotalEntries() const{ return stride * num_strips; }
@@ -172,6 +182,7 @@ public:
 private:
     size_t stride, num_strips;
     T* data;
+    const T* cdata;
     std::vector<T> vec;
 };
 


### PR DESCRIPTION
* removed the `[i * stride + j]` indexing in global grid get points and evaluate (no potential for overflow)