### PR TITLE
Overflow sequence grids

### DIFF
--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -223,6 +223,7 @@ void GridSequence::copyGrid(const GridSequence *seq){
 
         needed = new IndexSet(seq->needed);
     }
+    surpluses = seq->surpluses;
 }
 
 void GridSequence::setPoints(IndexSet* &pset, int cnum_outputs, TypeOneDRule crule){

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -995,7 +995,7 @@ void GridSequence::recomputeSurpluses(){
 
 void GridSequence::applyTransformationTransposed(double weights[]) const{
     IndexSet *work = (points == 0) ? needed : points;
-    int n = work->getNumIndexes();
+    int num_points = work->getNumIndexes();
 
     IndexManipulator IM(num_dimensions);
     std::vector<int> level;
@@ -1004,21 +1004,22 @@ void GridSequence::applyTransformationTransposed(double weights[]) const{
     Data2D<int> parents;
     IM.computeDAGup(work, parents);
 
-    int top_level = level[0];  for(int i=1; i<n; i++){  if (top_level < level[i]) top_level = level[i];  }
+    int top_level = level[0];
+    for(auto l: level) if (top_level < l) top_level = l;
 
-    int *monkey_count = new int[top_level + 1];
-    int *monkey_tail = new int[top_level + 1];
-    bool *used = new bool[n];
+    std::vector<int> monkey_count(top_level + 1);
+    std::vector<int> monkey_tail(top_level + 1);
+    std::vector<bool> used(num_points);
 
     for(int l=top_level; l>0; l--){
-        for(int i=0; i<n; i++){
+        for(int i=0; i<num_points; i++){
             if (level[i] == l){
                 const int* p = work->getIndex(i);
                 int current = 0;
 
                 monkey_count[0] = 0;
                 monkey_tail[0] = i;
-                std::fill(used, used + n, false);
+                std::fill(used.begin(), used.end(), false);
 
                 while(monkey_count[0] < num_dimensions){
                     if (monkey_count[current] < num_dimensions){
@@ -1039,10 +1040,6 @@ void GridSequence::applyTransformationTransposed(double weights[]) const{
             }
         }
     }
-
-    delete[] used;
-    delete[] monkey_tail;
-    delete[] monkey_count;
 }
 
 void GridSequence::clearAccelerationData(){

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -545,7 +545,7 @@ void GridSequence::makeCheckAccelerationData(TypeAcceleration acc) const{
         if (accel == 0){ accel = (BaseAccelerationData*) (new AccelerationDataGPUFull()); }
         AccelerationDataGPUFull *gpu = (AccelerationDataGPUFull*) accel;
         double *gpu_values = gpu->getGPUValues();
-        if (gpu_values == 0) gpu->loadGPUValues(((size_t) points->getNumIndexes()) * ((size_t) values->getNumOutputs()), surpluses.data());
+        if (gpu_values == 0) gpu->loadGPUValues(surpluses.size(), surpluses.data());
     }
 }
 #else

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -401,18 +401,21 @@ void GridSequence::evaluate(const double x[], double y[]) const{
 
     std::fill(y, y + num_outputs, 0.0);
 
-    int n = points->getNumIndexes();
+    int num_points = points->getNumIndexes();
 
-    for(int i=0; i<n; i++){
+    Data2D<double> surps;
+    surps.cload(num_outputs, num_points, surpluses.data());
+
+    for(int i=0; i<num_points; i++){
         const int* p = points->getIndex(i);
         double basis_value = cache[0][p[0]];
-        const double *surp = &(surpluses[((size_t) i) * ((size_t) num_outputs)]);
+        const double *s = surps.getCStrip(i);
         for(int j=1; j<num_dimensions; j++){
             basis_value *= cache[j][p[j]];
         }
 
         for(int k=0; k<num_outputs; k++){
-            y[k] += basis_value * surp[k];
+            y[k] += basis_value * s[k];
         }
     }
 

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -848,23 +848,25 @@ void GridSequence::getPolynomialSpace(bool interpolation, int &n, int* &poly) co
     IndexSet *work = (points == 0) ? needed : points;
     if (interpolation){
         n = work->getNumIndexes();
+        size_t entries = ((size_t) n) * ((size_t) num_dimensions);
 
-        poly = new int[n * num_dimensions];
+        poly = new int[entries];
         const int* p = work->getIndex(0);
 
-        std::copy(p, p + n * num_dimensions, poly);
+        std::copy(p, p + entries, poly);
     }else{
         IndexManipulator IM(num_dimensions);
-        IndexSet* set = IM.getPolynomialSpace(work, rule, interpolation);
+        IndexSet* pset = IM.getPolynomialSpace(work, rule, interpolation);
 
-        n = set->getNumIndexes();
+        n = pset->getNumIndexes();
+        size_t entries = ((size_t) n) * ((size_t) num_dimensions);
 
-        poly = new int[n * num_dimensions];
-        const int* p = set->getIndex(0);
+        poly = new int[entries];
+        const int* p = pset->getIndex(0);
 
-        std::copy(p, p + n * num_dimensions, poly);
+        std::copy(p, p + entries, poly);
 
-        delete set;
+        delete pset;
     }
 }
 const double* GridSequence::getSurpluses() const{

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -590,11 +590,12 @@ void GridSequence::integrate(double q[], double *conformal_correction) const{
 }
 
 void GridSequence::evaluateHierarchicalFunctions(const double x[], int num_x, double y[]) const{
-    IndexSet *work = (points == 0) ? needed : points;
-    int num_points = work->getNumIndexes();
+    int num_points = (points == 0) ? needed->getNumIndexes() : points->getNumIndexes();
+    Data2D<double> yy; yy.load(num_points, num_x, y);
+    Data2D<double> xx; xx.cload(num_dimensions, num_x, x);
     #pragma omp parallel for
     for(int i=0; i<num_x; i++){
-        evalHierarchicalFunctions(&(x[((size_t) i) * ((size_t) num_dimensions)]), &(y[((size_t) i) * ((size_t) num_points)]));
+        evalHierarchicalFunctions(xx.getCStrip(i), yy.getStrip(i));
     }
 }
 void GridSequence::evalHierarchicalFunctions(const double x[], double fvalues[]) const{

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -297,21 +297,27 @@ int GridSequence::getNumPoints() const{ return ((points == 0) ? getNumNeeded() :
 
 void GridSequence::getLoadedPoints(double *x) const{
     int num_points = points->getNumIndexes();
-    #pragma omp parallel for
+    Data2D<double> split;
+    split.load(num_dimensions, num_points, x);
+    #pragma omp parallel for schedule(static)
     for(int i=0; i<num_points; i++){
         const int *p = points->getIndex(i);
+        double *xx = split.getStrip(i);
         for(int j=0; j<num_dimensions; j++){
-            x[i*num_dimensions + j] = nodes[p[j]];
+            xx[j] = nodes[p[j]];
         }
     }
 }
 void GridSequence::getNeededPoints(double *x) const{
     int num_points = needed->getNumIndexes();
-    #pragma omp parallel for
+    Data2D<double> split;
+    split.load(num_dimensions, num_points, x);
+    #pragma omp parallel for schedule(static)
     for(int i=0; i<num_points; i++){
         const int *p = needed->getIndex(i);
+        double *xx = split.getStrip(i);
         for(int j=0; j<num_dimensions; j++){
-            x[i*num_dimensions + j] = nodes[p[j]];
+            xx[j] = nodes[p[j]];
         }
     }
 }

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -556,6 +556,9 @@ void GridSequence::integrate(double q[], double *conformal_correction) const{
     int num_points = points->getNumIndexes();
     std::fill(q, q + num_outputs, 0.0);
 
+    Data2D<double> surp;
+    surp.cload(num_outputs, num_points, surpluses.data());
+
     // for sequence grids, quadrature weights are expensive,
     // if using simple integration use the basis integral + surpluses, which is fast
     // if using conformal map, then we have to compute the expensive weights
@@ -565,12 +568,12 @@ void GridSequence::integrate(double q[], double *conformal_correction) const{
         for(int i=0; i<num_points; i++){
             const int* p = points->getIndex(i);
             double w = integ[p[0]];
-            const double *surp = &(surpluses[((size_t) i) * ((size_t) num_outputs)]);
+            const double *s = surp.getCStrip(i);
             for(int j=1; j<num_dimensions; j++){
                 w *= integ[p[j]];
             }
             for(int k=0; k<num_outputs; k++){
-                q[k] += w * surp[k];
+                q[k] += w * s[k];
             }
         }
     }else{

--- a/SparseGrids/tsgGridSequence.hpp
+++ b/SparseGrids/tsgGridSequence.hpp
@@ -120,7 +120,7 @@ protected:
     void evalHierarchicalFunctions(const double x[], double fvalues[]) const;
 
     void prepareSequence(int n);
-    double* cacheBasisIntegrals() const;
+    void cacheBasisIntegrals(std::vector<double> &integ) const;
 
     template<typename T>
     T** cacheBasisValues(const T x[]) const{

--- a/SparseGrids/tsgGridSequence.hpp
+++ b/SparseGrids/tsgGridSequence.hpp
@@ -153,7 +153,7 @@ private:
     IndexSet *needed;
     //int *parents; // NOTE: this is needed only for computing surpluses, maybe there is no need to store it
 
-    double *surpluses;
+    std::vector<double> surpluses;
     double *nodes;
     double *coeff;
 

--- a/SparseGrids/tsgGridSequence.hpp
+++ b/SparseGrids/tsgGridSequence.hpp
@@ -116,7 +116,6 @@ public:
 protected:
     void reset();
 
-    double* evalHierarchicalFunctions(const double x[]) const;
     void evalHierarchicalFunctions(const double x[], double fvalues[]) const;
 
     void prepareSequence(int n);


### PR DESCRIPTION
Remove the possibility for integer overflow in sequence grids (so long as number of points, outputs, dimensions, and x remain within `int`, the product will not overflow)