### PR TITLE
Loop order

### DIFF
--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -626,11 +626,10 @@ void GridGlobal::evaluate(const double x[], double y[]) const{
     std::vector<double> w(points->getNumIndexes());
     getInterpolationWeights(x, w.data());
     TasBLAS::setzero(num_outputs, y);
-    for(int k=0; k<num_outputs; k++){
-        for(int i=0; i<points->getNumIndexes(); i++){
-            const double *v = values->getValues(i);
-            y[k] += w[i] * v[k];
-        }
+    for(int i=0; i<points->getNumIndexes(); i++){
+        const double *v = values->getValues(i);
+        double wi = w[i];
+        for(int k=0; k<num_outputs; k++) y[k] += wi * v[k];
     }
 }
 

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -397,12 +397,15 @@ void GridLocalPolynomial::evaluate(const double x[], double y[]) const{
 
     std::fill(y, y + num_outputs, 0.0);
 
+    Data2D<double> surps;
+    surps.cload(num_outputs, points->getNumIndexes(), surpluses);
+
     for(auto const &r : roots){
         double basis_value = evalBasisSupported(points->getIndex(r), x, isSupported);
 
         if (isSupported){
-            offset = r * num_outputs;
-            for(int k=0; k<num_outputs; k++) y[k] += basis_value * surpluses[offset + k];
+            const double *s = surps.getCStrip(r);
+            for(int k=0; k<num_outputs; k++) y[k] += basis_value * s[k];
 
             int current = 0;
             monkey_tail[0] = r;
@@ -413,9 +416,8 @@ void GridLocalPolynomial::evaluate(const double x[], double y[]) const{
                     offset = indx[monkey_count[current]];
                     basis_value = evalBasisSupported(points->getIndex(offset), x, isSupported);
                     if (isSupported){
-                        offset *= num_outputs;
-                        for(int k=0; k<num_outputs; k++) y[k] += basis_value * surpluses[offset + k];
-                        offset /= num_outputs;
+                        s = surps.getCStrip(offset);
+                        for(int k=0; k<num_outputs; k++) y[k] += basis_value * s[k];
 
                         monkey_tail[++current] = offset;
                         monkey_count[current] = pntr[offset];

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -408,8 +408,8 @@ void GridSequence::evaluate(const double x[], double y[]) const{
 
     for(int i=0; i<num_points; i++){
         const int* p = points->getIndex(i);
-        double basis_value = cache[0][p[0]];
         const double *s = surps.getCStrip(i);
+        double basis_value = cache[0][p[0]];
         for(int j=1; j<num_dimensions; j++){
             basis_value *= cache[j][p[j]];
         }


### PR DESCRIPTION
* reorder the for-loops for Global Grids, boosts performance when dealing with many outputs (and no blas or cuda)
* minor performance boost in evaluate local, removed overflow potential