### PR TITLE
fixed a clang bug with indexing

### DIFF
--- a/SparseGrids/tsgIndexSets.cpp
+++ b/SparseGrids/tsgIndexSets.cpp
@@ -66,7 +66,7 @@ void UnsortedIndexSet::getIndexesSorted(std::vector<int> &sorted) const{
     while(warp < num_indexes){
         size_t full_warps = 2*warp * ((num_indexes) / (2*warp));
         #pragma omp parallel for
-        for(long long i=0; (size_t) i<full_warps; i+=2*warp){
+        for(int i=0; i<(int) full_warps; i+=(int) (2*warp)){
             mergeLists(&(list_source[i]), warp, &(list_source[i+warp]), warp, &(list_destination[i]));
         }
 


### PR DESCRIPTION
* MSVC++ requires that OpenMP loop indexing is signed
* clang restricts the for-loop test condition to simple comparison, no typecasting