### PR TITLE
intel compiler has a strange bug, probably due to optimization

### DIFF
--- a/SparseGrids/tsgCoreOneDimensional.cpp
+++ b/SparseGrids/tsgCoreOneDimensional.cpp
@@ -293,7 +293,7 @@ int OneDimensionalMeta::getIExact(int level, TypeOneDRule rule) const{
         case rule_gausspatterson:
         case rule_fejer2:             return ((1 << (level+1)) - 2);
 
-        case rule_clenshawcurtis:     return ((level == 0) ? 0 : (1 << level));
+        case rule_clenshawcurtis:     return (level > 0) ? (1 << level) : 0;
         case rule_clenshawcurtis0:    return ((1 << (level+1)) +1);
         case rule_rlejadouble2:       return getNumPoints(level,rule_rlejadouble2)-1;
         case rule_rlejadouble4:       return getNumPoints(level,rule_rlejadouble4)-1;


### PR DESCRIPTION
* on Intel 18 compiler `((level == 0) ? 0 : (1 << level));` return 1 when `level == 0`
* same compiler `(level > 0) ? (1 << level) : 0;` returns the correct value