### PR TITLE
Adjust flags for OSX compatibility

### DIFF
--- a/Config/AltBuildSystems/Makefile.in
+++ b/Config/AltBuildSystems/Makefile.in
@@ -13,7 +13,7 @@ NVCC_OPT =
 
 # Default C++ compiler
 CC = g++
-OPTC = -O3 -ffast-math -mtune=native $(COMPILE_OPTIONS) -fPIC -Wstrict-aliasing
+OPTC = -O3 -std=c++11 $(COMPILE_OPTIONS) -fPIC -Wstrict-aliasing
 OPTL = $(OPTC)
 
 # Default Fortran compiler


### PR DESCRIPTION
* OSX g++ command links to clang which requires explicit c++11 flag
* fast-math flags make some tests fail due to rounding