### PR TITLE
Upgrade CMake in Docker image with CUDA

### DIFF
--- a/docker/Dockerfile_nvidia-cuda9.0-ubuntu16.04
+++ b/docker/Dockerfile_nvidia-cuda9.0-ubuntu16.04
@@ -4,9 +4,19 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         libopenblas-dev \
         python \
         python-numpy \
-        cmake \
         gfortran \
         git \
+        wget \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+RUN export CMAKE_VERSION=3.10.3 && \
+    export CMAKE_VERSION_SHORT=3.10 && \
+    export CMAKE_URL=https://cmake.org/files/v${CMAKE_VERSION_SHORT}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \
+    export CMAKE_SCRIPT=cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \
+    export CMAKE_PREFIX=/usr/local && \
+    wget --quiet ${CMAKE_URL} --output-document=${CMAKE_SCRIPT} && \
+    mkdir -p ${CMAKE_PREFIX} && \
+    sh ${CMAKE_SCRIPT} --skip-license --prefix=${CMAKE_PREFIX} && \
+    rm ${CMAKE_SCRIPT}


### PR DESCRIPTION
Image with NVIDIA CUDA derives from Ubuntu 16.04 that comes with CMake 3.5 when
installing with the system package manager.  Instead here we now download binaries for CMake 3.10.

Note: I built and pushed to docker hub a `dalg24/tasmanian_stack:nvidia-cuda9.0-ubuntu16.04-18.10.0` image.  I already went ahead and tagged it as `dalg24/tasmanian_stack:nvidia-cuda9.0` so this is ready to merge after the CI checks pass.