### PR TITLE
More internal docs

### DIFF
--- a/Doxygen/CMakeLists.txt
+++ b/Doxygen/CMakeLists.txt
@@ -5,7 +5,6 @@ set(DOXYGEN_DISABLE_INDEX       "NO")
 set(DOXYGEN_GENERATE_TREEVIEW  "YES") # left-hand index
 set(DOXYGEN_SORT_GROUP_NAMES    "NO") # use the order in the source files (logical order)
 set(DOXYGEN_SORT_MEMBER_DOCS    "NO") # use the order in the source files (logical order)
-set(DOXYGEN_INTERNAL_DOCS      "YES") # silence eventually, especially for a release
 
 set(DOXYGEN_PREDEFINED "__TASMANIAN_DOXYGEN_SKIP") # indicate sections to skip from documentation
 
@@ -19,12 +18,11 @@ set(DOXYGEN_PROJECT_NUMBER "") # if project number if given, the rendered font i
 
 set(DOXYGEN_USE_MDFILE_AS_MAINPAGE "${CMAKE_CURRENT_SOURCE_DIR}/../README.md")
 
-doxygen_add_docs(Tasmanian_docs
+doxygen_add_docs(Tasmanian_doxygen
                  ${CMAKE_CURRENT_SOURCE_DIR}/../README.md
                  ${CMAKE_CURRENT_SOURCE_DIR}/Installation.md
                  ${CMAKE_CURRENT_SOURCE_DIR}/../SparseGrids/tsgIndexManipulator.hpp
                  ${CMAKE_CURRENT_SOURCE_DIR}/../SparseGrids/tsgIndexSets.hpp
+                 ${CMAKE_CURRENT_SOURCE_DIR}/../SparseGrids/tsgCoreOneDimensional.hpp
                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                  COMMENT "Tasmanian Doxygen documentation")
-
-add_custom_target(Tasmanian_doxygen_documentation ALL DEPENDS Tasmanian_docs)

--- a/Doxygen/CMakeLists.txt
+++ b/Doxygen/CMakeLists.txt
@@ -21,7 +21,7 @@ set(DOXYGEN_USE_MDFILE_AS_MAINPAGE "${CMAKE_CURRENT_SOURCE_DIR}/../README.md")
 if (NOT DOXYGEN_INTERNAL_DOCS)
 # the \internal command works for functions and namespaces, but not classes
 # have to exclude the classes manually
-    set(DOXYGEN_EXCLUDE_SYMBOLS TasGrid::Data2D TasGrid::MultiIndexSet TasGrid::StorageSet TasGrid::CustomTabulated)
+    set(DOXYGEN_EXCLUDE_SYMBOLS TasGrid::Data2D TasGrid::MultiIndexSet TasGrid::StorageSet TasGrid::CustomTabulated TasGrid::OneDimensionalWrapper)
 endif()
 
 doxygen_add_docs(Tasmanian_doxygen
@@ -30,5 +30,6 @@ doxygen_add_docs(Tasmanian_doxygen
                  ${CMAKE_CURRENT_SOURCE_DIR}/../SparseGrids/tsgIndexManipulator.hpp
                  ${CMAKE_CURRENT_SOURCE_DIR}/../SparseGrids/tsgIndexSets.hpp
                  ${CMAKE_CURRENT_SOURCE_DIR}/../SparseGrids/tsgCoreOneDimensional.hpp
+                 ${CMAKE_CURRENT_SOURCE_DIR}/../SparseGrids/tsgOneDimensionalWrapper.hpp
                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                  COMMENT "Tasmanian Doxygen documentation")

--- a/Doxygen/CMakeLists.txt
+++ b/Doxygen/CMakeLists.txt
@@ -21,7 +21,8 @@ set(DOXYGEN_USE_MDFILE_AS_MAINPAGE "${CMAKE_CURRENT_SOURCE_DIR}/../README.md")
 if (NOT DOXYGEN_INTERNAL_DOCS)
 # the \internal command works for functions and namespaces, but not classes
 # have to exclude the classes manually
-    set(DOXYGEN_EXCLUDE_SYMBOLS TasGrid::Data2D TasGrid::MultiIndexSet TasGrid::StorageSet TasGrid::CustomTabulated TasGrid::OneDimensionalWrapper)
+    set(DOXYGEN_EXCLUDE_SYMBOLS TasGrid::Data2D TasGrid::MultiIndexSet TasGrid::StorageSet TasGrid::CustomTabulated TasGrid::OneDimensionalWrapper
+        TasGrid::TasSparse::SparseMatrix)
 endif()
 
 doxygen_add_docs(Tasmanian_doxygen
@@ -31,5 +32,6 @@ doxygen_add_docs(Tasmanian_doxygen
                  ${CMAKE_CURRENT_SOURCE_DIR}/../SparseGrids/tsgIndexSets.hpp
                  ${CMAKE_CURRENT_SOURCE_DIR}/../SparseGrids/tsgCoreOneDimensional.hpp
                  ${CMAKE_CURRENT_SOURCE_DIR}/../SparseGrids/tsgOneDimensionalWrapper.hpp
+                 ${CMAKE_CURRENT_SOURCE_DIR}/../SparseGrids/tsgLinearSolvers.hpp
                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                  COMMENT "Tasmanian Doxygen documentation")

--- a/Doxygen/CMakeLists.txt
+++ b/Doxygen/CMakeLists.txt
@@ -18,6 +18,12 @@ set(DOXYGEN_PROJECT_NUMBER "") # if project number if given, the rendered font i
 
 set(DOXYGEN_USE_MDFILE_AS_MAINPAGE "${CMAKE_CURRENT_SOURCE_DIR}/../README.md")
 
+if (NOT DOXYGEN_INTERNAL_DOCS)
+# the \internal command works for functions and namespaces, but not classes
+# have to exclude the classes manually
+    set(DOXYGEN_EXCLUDE_SYMBOLS TasGrid::Data2D TasGrid::MultiIndexSet TasGrid::StorageSet TasGrid::CustomTabulated)
+endif()
+
 doxygen_add_docs(Tasmanian_doxygen
                  ${CMAKE_CURRENT_SOURCE_DIR}/../README.md
                  ${CMAKE_CURRENT_SOURCE_DIR}/Installation.md

--- a/SparseGrids/tsgCoreOneDimensional.hpp
+++ b/SparseGrids/tsgCoreOneDimensional.hpp
@@ -37,29 +37,61 @@
 #include <string>
 #include <math.h>
 
+//! \internal
+//! \file tsgCoreOneDimensional.hpp
+//! \brief Algorithms and meta-data for the Gauuss, Chebyshev and custom rules.
+//! \author Miroslav Stoyanov
+//! \ingroup TasmanianCoreOneDimensional
+//!
+//! Contains core information about one dimensional rules, custom tabulated,
+//! Chebyshev and Gaussian rules. Also, generic I/O data.
+
+//! \internal
+//! \defgroup TasmanianCoreOneDimensional Core data for Gauuss, Chebyshev and custom rules.
+//!
+//! \par Core One Dimensional Rules
+//! Contains core information about one dimensional rules, custom tabulated,
+//! Chebyshev and Gaussian rules. Also, generic I/O data.
+
 namespace TasGrid{
 
+//! \internal
+//! \brief Class providing manipulation of custom tabulated rules, file I/O and structured access to the points, weights, and meta-data.
+//! \ingroup TasmanianCoreOneDimensional
 class CustomTabulated{
 public:
+    //! \brief Default constructor, create an empty table, need to read from file before any other data can be accessed.
     CustomTabulated();
+    //! \brief Destructor, clear the rule.
     ~CustomTabulated();
 
-    // I/O subroutines
-    void write(std::ofstream &ofs) const;
+    //! \brief Read from a custom user provided ASCII file, see the file-format section.
     void read(const char* filename);
+    //! \brief Read from an already open ASCII file, used in conjunction with \b GlobalGrid::read()
     void read(std::ifstream &ifs);
-    void writeBinary(std::ofstream &ofs) const;
+    //! \brief Read from an already open binary file, used in conjunction with \b GlobalGrid::readBinary()
     void readBinary(std::ifstream &ifs);
+    //! \brief Write to an already open ASCII file, used in conjunction with \b GlobalGrid::write()
+    void write(std::ofstream &ofs) const;
+    //! \brief Write to an already open binary file, used in conjunction with \b GlobalGrid::writeBinary()
+    void writeBinary(std::ofstream &ofs) const;
 
+    //! \brief Returns the number of loaded levels.
     int getNumLevels() const;
+    //! \brief Returns the number of points associated with the selected \b level.
     int getNumPoints(int level) const;
+    //! \brief Return the exactness of the interpolation rule at \b level, usually one less than the number of points.
     int getIExact(int level) const;
+    //! \brief Return the exactness of the integration/quadrature rule at \b level, provided by the user in the custom file.
     int getQExact(int level) const;
 
+    //! \brief Get the points \b x and quadrature weights \b w associated with the rule at the \b level.
     void getWeightsNodes(int level, std::vector<double> &w, std::vector<double> &x) const;
+    //! \brief Returns the user provided human readable description string.
     const char* getDescription() const;
 
 protected:
+    //! \brief Clear the number of levels.
     void reset();
 
 private:
@@ -72,58 +104,101 @@ private:
     std::string description;
 };
 
+//! \internal
+//! \brief Metadata for one dimensional rules, number of points, exactness, I/O, etc.
+//! \ingroup TasmanianCoreOneDimensional
 namespace OneDimensionalMeta{
+    //! \brief Return the number of points for the \b rule at the \b level, includes all global rules.
     int getNumPoints(int level, TypeOneDRule rule);
+    //! \brief Return the exactness of the interpolation \b rule at the \b level, includes all global rules.
     int getIExact(int level, TypeOneDRule rule);
+    //! \brief Return the exactness of the integration/quadrature \b rule at the \b level, includes all global rules.
     int getQExact(int level, TypeOneDRule rule);
 
+    //! \brief Return \b True if the \b rule does not have nested nodes, e.g., gauss-legendre.
     bool isNonNested(TypeOneDRule rule);
+    //! \brief Return \b True if the \b rule is nested and has single-node growth, fit for \b GridSequence, e.g., leja.
     bool isSequence(TypeOneDRule rule);
+    //! \brief Return \b True if the \b rule has basis with Lagrange polynomials with global support, fit for \b GridGlobal, e.g., clenshaw-curtis.
     bool isGlobal(TypeOneDRule rule);
+    //! \brief Return \b True if the \b rule grows by one point per level.
     bool isSingleNodeGrowth(TypeOneDRule rule);
+    //! \brief Return \b True if the \b rule has polynomial basis with local support, fit for \b GridLocalPolynomial, e.g., localp.
     bool isLocalPolynomial(TypeOneDRule rule);
+    //! \brief Return \b True if the \b rule has wavelet basis with local support.
     bool isWavelet(TypeOneDRule rule);
+    //! \brief Return \b True if the \b rule has trigonometric basis.
     bool isFourier(TypeOneDRule rule);
 
+    //! \brief Map the string rule name to the enumerate, used in ASCII I/O, command line and Python.
     TypeOneDRule getIORuleString(const char *name);
+    //! \brief Map the enumerate to a string, used in ASCII I/O, command line and Python.
     const char* getIORuleString(TypeOneDRule rule);
+    //! \brief Map the enumerate to a human readable string, used in \b printStats().
     const char* getHumanString(TypeOneDRule rule);
+    //! \brief Map the integer to enumerate, used in binary I/O and Fortran (compiler and version independent).
     TypeOneDRule getIORuleInt(int index);
+    //! \brief Map the enumerate to an integer, used in binary I/O and Fortran (compiler and version independent).
     int getIORuleInt(TypeOneDRule rule);
 
+    //! \brief Return \b True if the multi-index selection type has log-correction term (need to use floating point indexing).
     bool isTypeCurved(TypeDepth type);
 
+    //! \brief Map the string to the enumerate multi-index selection strategy, used in command line and Python.
     TypeDepth getIOTypeString(const char *name);
+    //! \brief Map the integer to the enumerate multi-index selection strategy, used in Fortran.
     TypeDepth getIOTypeInt(int type);
 
+    //! \brief Map the string to the enumerate hierarchical refinement strategy, used in command line and Python.
     TypeRefinement getIOTypeRefinementString(const char *name);
+    //! \brief Map the integer to the enumerate hierarchical refinement strategy, used in Fortran.
     TypeRefinement getIOTypeRefinementInt(int ref);
 }
 
+//! \internal
+//! \brief Contains algorithms for generating Gauss,Chebyshev, and Fourier nodes and weights.
+//! \ingroup TasmanianCoreOneDimensional
 namespace OneDimensionalNodes{
     // non-nested rules
+    //! \brief Generate Gauss-Legendre weights \b w and points \b x for (input) number of points \b m.
     void getGaussLegendre(int m, std::vector<double> &w, std::vector<double> &x);
+    //! \brief Generate Chebyshev weights \b w and points \b x for (input) number of points \b m.
     void getChebyshev(int m, std::vector<double> &w, std::vector<double> &x);
+    //! \brief Generate Gauss-Chebyshev type 1 weights \b w and points \b x for (input) number of points \b m.
     void getGaussChebyshev1(int m, std::vector<double> &w, std::vector<double> &x);
+    //! \brief Generate Gauss-Chebyshev type 2 weights \b w and points \b x for (input) number of points \b m.
     void getGaussChebyshev2(int m, std::vector<double> &w, std::vector<double> &x);
+    //! \brief Generate Gauss-Jacobi weights \b w and points \b x for (input) number of points \b m, using parameters \b alpha and \b beta.
     void getGaussJacobi(int m, std::vector<double> &w, std::vector<double> &x, double alpha, double beta);
+    //! \brief Generate Gauss-Hermite weights \b w and points \b x for (input) number of points \b m, using parameters \b alpha
     void getGaussHermite(int m, std::vector<double> &w, std::vector<double> &x, double alpha);
+    //! \brief Generate Gauss-Laguerre weights \b w and points \b x for (input) number of points \b m, using parameters \b alpha
     void getGaussLaguerre(int m, std::vector<double> &w, std::vector<double> &x, double alpha);
 
     // nested rules
+    //! \brief Generate Clenshaw-Curtis \b nodes for the \b level.
     void getClenshawCurtisNodes(int level, std::vector<double> &nodes);
+    //! \brief Return the Clenshaw-Curtis weight for the \b level and node indexed by \b point.
     double getClenshawCurtisWeight(int level, int point);
 
+    //! \brief Generate Clenshaw-Curtis zero-boundary condition \b nodes for the \b level.
     void getClenshawCurtisNodesZero(int level, std::vector<double> &nodes); // assuming zero boundary
+    //! \brief Return the Clenshaw-Curtis zero-boundary condition weight for the \b level and node indexed by \b point.
     double getClenshawCurtisWeightZero(int level, int point); // assuming zero boundary
 
+    //! \brief Generate Fejer type 2 \b nodes for the \b level.
     void getFejer2Nodes(int level, std::vector<double> &nodes);
+    //! \brief Return the Fejer type 2 weight for the \b level and node indexed by \b point.
     double getFejer2Weight(int level, int point);
 
+    //! \brief Generate the first \b n R-Leja \b nodes, starting with 1, -1, 0, ...
     void getRLeja(int n, std::vector<double> &nodes);
+    //! \brief Generate the first \b n R-Leja \b nodes, starting with 0, 1, -1, ...
     void getRLejaCentered(int n, std::vector<double> &nodes);
+    //! \brief Generate the first \b n R-Leja \b nodes, starting with -0.5, 0.5, ...
     void getRLejaShifted(int n, std::vector<double> &nodes);
 
+    //! \brief Generate the Fourier \b nodes for the given \b level, uniformly distributed points with right-most point omitted due to periodicity.
     void getFourierNodes(int level, std::vector<double> &nodes);
 }
 

--- a/SparseGrids/tsgCoreOneDimensional.hpp
+++ b/SparseGrids/tsgCoreOneDimensional.hpp
@@ -55,7 +55,6 @@
 
 namespace TasGrid{
 
-//! \internal
 //! \brief Class providing manipulation of custom tabulated rules, file I/O and structured access to the points, weights, and meta-data.
 //! \ingroup TasmanianCoreOneDimensional
 class CustomTabulated{

--- a/SparseGrids/tsgIndexManipulator.hpp
+++ b/SparseGrids/tsgIndexManipulator.hpp
@@ -66,11 +66,11 @@ namespace TasGrid{
 
 namespace MultiIndexManipulations{
 
+//! \internal
+//! \brief Generate a full tensor multi-index set with **num_entries**  in each direction
+//! \ingroup TasmanianMultiIndexManipulations
 template<typename I>
 void generateFullTensorSet(const std::vector<I> &num_entries, MultiIndexSet &set){
-//! \internal
-//! \brief generate a full tensor multi-index set with **num_entries**  in each direction
-//! \ingroup TasmanianMultiIndexManipulations
     I num_total = 1;
     for(auto &l : num_entries) num_total *= l;
     size_t num_dimensions = num_entries.size();
@@ -89,11 +89,11 @@ void generateFullTensorSet(const std::vector<I> &num_entries, MultiIndexSet &set
     set.setIndexes(indexes);
 }
 
+//! \internal
+//! \brief Generate the multi-index with entries satisfying the **!outside()**, assumes that the **!outside()** defines a lower set
+//! \ingroup TasmanianMultiIndexManipulations
 template<typename I>
 void generateLowerMultiIndexSet(std::function<bool(const std::vector<I> &index)> outside, MultiIndexSet &set){
-//! \internal
-//! \brief generate the multi-index with entries satisfying the **!outside()**, assumes that the **!outside()** defines a lower set
-//! \ingroup TasmanianMultiIndexManipulations
     size_t num_dimensions = set.getNumDimensions();
     size_t c = num_dimensions -1;
     bool out = false;
@@ -114,17 +114,16 @@ void generateLowerMultiIndexSet(std::function<bool(const std::vector<I> &index)>
     set.setIndexes(indexes);
 }
 
+//! \internal
+//! \brief Take the last set of **level_sets** append a new set of the parents or children that satisfy **inside()**, repeat recursively until there are no more indexes to add
+//! \ingroup TasmanianMultiIndexManipulations
 template<typename I, bool completion>
 void recursiveLoadPoints(std::function<bool(const std::vector<I> &index)> inside, const MultiIndexSet &set, std::vector<MultiIndexSet> &level_sets){
-//! \internal
-//! \brief take the last set of **level_sets** append a new set of the parents or children that satisfy **inside()**, repeat recursively until there are no more indexes to add
-//! \ingroup TasmanianMultiIndexManipulations
-//!
-//! **level_sets** must contain at least one set, then this function considers all the children/parents of the entries of the last set (given by `level_sets.back()`)
-//! and then creates a new set with only the children/parents that satisfy the **inside()**. The new set is appended to the **level_sets**
-//! (similar to `push_back()`, but using `resize()`). The recursion terminates at the set where all children/parents fail the **inside()**.
-//! * **I** defines the Int type for the set (should be `int` right now)
-//! * **completion** equal `true` indicates the use of *parents* (i.e., do the lower completion), set to `false` indicates the use of *children*
+//! \b level_sets must contain at least one set, then this function considers all the children/parents of the entries of the last set (given by `level_sets.back()`)
+//! and then creates a new set with only the children that satisfy the \b inside() or the parents (regardless of \b inside()). The new set is appended to the \b level_sets
+//! (similar to `push_back()`, but using `resize()`). The recursion terminates at the set where all children fail the \b inside() or all parents are already included.
+//! - \b I defines the Int type for the set (should be `int` right now)
+//! - \b completion equal \b True indicates the use of *parents* (i.e., do the lower completion), set to \b False indicates the use of *children*
     size_t num_dimensions = level_sets.back().getNumDimensions();
     bool adding = true;
     while(adding){
@@ -160,11 +159,11 @@ void recursiveLoadPoints(std::function<bool(const std::vector<I> &index)> inside
     }
 }
 
+//! \internal
+//! \brief Take the union of all \b level_sets and either \b overwrite the \b set or if \b overwrite is \b False then add to the \b set
+//! \ingroup TasmanianMultiIndexManipulations
 template<bool overwrite>
 void unionSets(std::vector<MultiIndexSet> &level_sets, MultiIndexSet &set){
-//! \internal
-//! \brief **set** is combines with the union of the **level_sets**, if **overwrite** is **true** the content of **set** is discarded
-//! \ingroup TasmanianMultiIndexManipulations
     int num_levels = (int) level_sets.size();
     while(num_levels > 1){
         int stride = num_levels / 2 + (((num_levels % 2) > 0) ? 1 : 0);
@@ -180,11 +179,11 @@ void unionSets(std::vector<MultiIndexSet> &level_sets, MultiIndexSet &set){
     }
 }
 
+//! \internal
+//! \brief If **set** is a lower set, then do nothing, otherwise add the the multi-indexes needed to make **set** a lower-set
+//! \ingroup TasmanianMultiIndexManipulations
 template<typename I>
 void completeSetToLower(MultiIndexSet &set){
-//! \internal
-//! \brief if **set** is a lower set, then do nothing, otherwise add the the multi-indexes needed to make **set** a lower-set
-//! \ingroup TasmanianMultiIndexManipulations
     size_t num_dimensions = set.getNumDimensions();
     int num = set.getNumIndexes();
     Data2D<I> completion;
@@ -212,12 +211,11 @@ void completeSetToLower(MultiIndexSet &set){
     }
 }
 
-
+//! \internal
+//! \brief Generate the multi-index with entries satisfying the **criteria()**, the result is a lower set regardless of the **criteria()**
+//! \ingroup TasmanianMultiIndexManipulations
 template<typename I>
 void generateGeneralMultiIndexSet(std::function<bool(const std::vector<I> &index)> criteria, MultiIndexSet &set){
-//! \internal
-//! \brief generate the multi-index with entries satisfying the **criteria()**, the result is a lower set regardless of the **criteria()**
-//! \ingroup TasmanianMultiIndexManipulations
     size_t num_dimensions = set.getNumDimensions();
     std::vector<MultiIndexSet> level_sets(1);
     level_sets[0].setNumDimensions((int) num_dimensions);
@@ -231,13 +229,12 @@ void generateGeneralMultiIndexSet(std::function<bool(const std::vector<I> &index
     completeSetToLower<I>(set);
 }
 
+//! \internal
+//! \brief Set an empty vector **weights** to the canonical weights of the type (if **anisotropic_weights** is empty) or the actual weights with scaling adjustment
+//! \ingroup TasmanianMultiIndexManipulations
 template<typename I>
 void getProperWeights(size_t num_dimensions, I offset, TypeDepth type, const std::vector<I> &anisotropic_weights,
                       std::vector<I> &weights, I &normalized_offset, bool &known_lower){
-//! \internal
-//! \brief set an empty vector **weights** to the canonical weights of the type (if **anisotropic_weights** is empty) or the actual weights with scaling adjustment
-//! \ingroup TasmanianMultiIndexManipulations
-//!
 //! Based on the **anisotropic_weights** and selection parameters, create canonical/normalized weights and run basic analysis on the resulting multi-index set.
 //! * **num_dimensions** specifies the number of dimensions of the multi-index
 //! * **type** is the selection type, e.g., type_iptotal
@@ -274,12 +271,11 @@ void getProperWeights(size_t num_dimensions, I offset, TypeDepth type, const std
     }
 }
 
+//! \internal
+//! \brief Generates a multi-index set based on the combination of weights, rule_exactness, offset and type
+//! \ingroup TasmanianMultiIndexManipulations
 template<typename I, typename CacheType, TypeDepth TotalCurvedHyper>
 void generateWeightedTensorsCached(const std::vector<I> &weights, CacheType normalized_offset, std::function<long long(I i)> rule_exactness, MultiIndexSet &mset){
-//! \internal
-//! \brief generates a multi-index set based on the combination of weights, rule_exactness, offset and type
-//! \ingroup TasmanianMultiIndexManipulations
-//!
 //! Simplifies the calls to caching and generating multi-indexes
 //! * **I** is the Int type of multi-index (use int)
 //! * **CacheType** should wither match **I** (for level, iptotal and qptotal types) or **double** for curved and hyperbolic rules
@@ -327,12 +323,11 @@ void generateWeightedTensorsCached(const std::vector<I> &weights, CacheType norm
                                     }, mset);
 }
 
+//! \internal
+//! \brief Generates a multi-index set based on the combination of weights, rule_exactness, offset and type, assume cache has to be build dynamically (non-lower set case)
+//! \ingroup TasmanianMultiIndexManipulations
 template<typename I, typename CacheType>
 void generateWeightedTensorsDynamicCached(const std::vector<I> &weights, CacheType normalized_offset, std::function<long long(I i)> rule_exactness, MultiIndexSet &mset){
-//! \internal
-//! \brief generates a multi-index set based on the combination of weights, rule_exactness, offset and type, assume cache has to be build dynamically (non-lower set case)
-//! \ingroup TasmanianMultiIndexManipulations
-//!
 //! Simplifies the calls to caching and generating multi-indexes
 //! * **I** is the Int type of multi-index (use int)
 //! * **CacheType** should wither match **I** (for level, iptotal and qptotal types) or **double** for curved and hyperbolic rules
@@ -358,44 +353,44 @@ void generateWeightedTensorsDynamicCached(const std::vector<I> &weights, CacheTy
 }
 
 //! \internal
-//! \brief generate the multi-index set defined by the parameters, **rule** cannot be custom
+//! \brief Generate the multi-index set defined by the parameters, **rule** cannot be custom
 //! \ingroup TasmanianMultiIndexManipulations
 void selectTensors(int offset, TypeDepth type, std::function<long long(int i)> rule_exactness, const std::vector<int> &anisotropic_weights, MultiIndexSet &set);
 
 //! \internal
-//! \brief returns a vector that is the sum of entries of each multi-index in the set
+//! \brief Returns a vector that is the sum of entries of each multi-index in the set
 //! \ingroup TasmanianMultiIndexManipulations
 void computeLevels(const MultiIndexSet &mset, std::vector<int> &level);
 
 //! \internal
-//! \brief returns a vector that is the maximum index in each direction and a total maximum index, **max_levels** must be empty
+//! \brief Returns a vector that is the maximum index in each direction and a total maximum index, **max_levels** must be empty
 //! \ingroup TasmanianMultiIndexManipulations
 void getMaxIndex(const MultiIndexSet &mset, std::vector<int> &max_levels, int &total_max);
 
 //! \internal
-//! \brief returns a Data2D structure where each strip holds the indexes of the parents of indexes of mset (for each direction), using one-point-growth hierarchy
+//! \brief Returns a Data2D structure where each strip holds the indexes of the parents of indexes of mset (for each direction), using one-point-growth hierarchy
 //! \ingroup TasmanianMultiIndexManipulations
 void computeDAGup(const MultiIndexSet &mset, Data2D<int> &parents);
 
 //! \internal
-//! \brief returns a Data2D structure where each strip holds the indexes of the parents of indexes of mset (for each direction), using hierarchy defined by **rule**
+//! \brief Returns a Data2D structure where each strip holds the indexes of the parents of indexes of mset (for each direction), using hierarchy defined by **rule**
 //! \ingroup TasmanianMultiIndexManipulations
 void computeDAGup(const MultiIndexSet &mset, const BaseRuleLocalPolynomial *rule, Data2D<int> &parents);
 
 //! \internal
-//! \brief using the **flagged** map, create **new_set** with the flagged children of **mset** but only if they obey the **level_limits**
+//! \brief Using the **flagged** map, create **new_set** with the flagged children of **mset** but only if they obey the **level_limits**
 //! \ingroup TasmanianMultiIndexManipulations
 void selectFlaggedChildren(const MultiIndexSet &mset, const std::vector<bool> &flagged, const std::vector<int> &level_limits, MultiIndexSet &new_set);
 
 //! \internal
-//! \brief using the **flagged** map, create **new_set** with the flagged children of **mset** but only if they obey the **level_limits**
+//! \brief Using the **flagged** map, create **new_set** with the flagged children of **mset** but only if they obey the **level_limits**
 //! \ingroup TasmanianMultiIndexManipulations
 void removeIndexesByLimit(const std::vector<int> &level_limits, MultiIndexSet &mset);
 
 //! \internal
-//! \brief assuming that **tensors** describe a set of nested tensor operators, and each 1-D operators has **getNumPoints()**, then generate the actual points
+//! \brief Assuming that **tensors** describe a set of nested tensor operators, and each 1-D operators has **getNumPoints()**, then generate the actual points
 //! \ingroup TasmanianMultiIndexManipulations
-//!
+
 //! Assuming that we are working with a nested rule, then instead of generating the points for all tensor rules and taking the union,
 //! it is much faster to generate just the surplus points and union those, i.e., the points included by this tensor and excluded from the other differences.
 //! Working with surplus points ensures that there is no repetition of points.
@@ -405,9 +400,9 @@ void removeIndexesByLimit(const std::vector<int> &level_limits, MultiIndexSet &m
 void generateNestedPoints(const MultiIndexSet &tensors, std::function<int(int)> getNumPoints, MultiIndexSet &points);
 
 //! \internal
-//! \brief assuming that **tensors** describe a set of non-nested tensor operators described by the **wrapper**, then generate the actual **points**
+//! \brief Assuming that **tensors** describe a set of non-nested tensor operators described by the **wrapper**, then generate the actual **points**
 //! \ingroup TasmanianMultiIndexManipulations
-//!
+
 //! Assuming that we are working with a non-nested rule, then for each tensor we must generate the points and map them to the global indexing,
 //! then take the union of all the tensors
 //! * **tensors** is a set of tensor rules, non-necessarily lower
@@ -416,7 +411,7 @@ void generateNestedPoints(const MultiIndexSet &tensors, std::function<int(int)> 
 void generateNonNestedPoints(const MultiIndexSet &tensors, const OneDimensionalWrapper &wrapper, MultiIndexSet &points);
 
 //! \internal
-//! \brief given a tensor defined by **levels** find the references to all tensor points in the **points** set (assuming the standard order of the tensor entries)
+//! \brief Given a tensor defined by **levels** find the references to all tensor points in the **points** set (assuming the standard order of the tensor entries)
 //! \ingroup TasmanianMultiIndexManipulations
 template<bool nested>
 void referencePoints(const int levels[], const OneDimensionalWrapper &wrapper, const MultiIndexSet &points, std::vector<int> &refs){
@@ -441,17 +436,17 @@ void referencePoints(const int levels[], const OneDimensionalWrapper &wrapper, c
 }
 
 //! \internal
-//! \brief computes the weights for the tensor linear combination, **mset** is a lower multi-index set and **weight** is resized
+//! \brief Computes the weights for the tensor linear combination, **mset** is a lower multi-index set and **weight** is resized
 //! \ingroup TasmanianMultiIndexManipulations
 void computeTensorWeights(const MultiIndexSet &mset, std::vector<int> &weights);
 
 //! \internal
-//! \brief on exit, **active** is the set containing the multi-indexes of **mset** corresponding to non-zero **weights**
+//! \brief On exit, **active** is the set containing the multi-indexes of **mset** corresponding to non-zero **weights**
 //! \ingroup TasmanianMultiIndexManipulations
 void createActiveTensors(const MultiIndexSet &mset, const std::vector<int> &weights, MultiIndexSet &active);
 
 //! \internal
-//! \brief for a set of **tensors** compute the corresponding polynomial **space** assuming the 1D rules have given **exactness**
+//! \brief For a set of **tensors** compute the corresponding polynomial **space** assuming the 1D rules have given **exactness**
 //! \ingroup TasmanianMultiIndexManipulations
 void createPolynomialSpace(const MultiIndexSet &tensors, std::function<int(int)> exactness, MultiIndexSet &space);
 }

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -109,7 +109,6 @@ void push_merge_map(const std::vector<T> &a, const std::vector<B> &b,
 }
 }
 
-//! \internal
 //! \brief Generic 2D data structure divided into contiguous strips of fixed length (similar to a matrix)
 //! \ingroup TasmanianSets
 
@@ -124,12 +123,12 @@ void push_merge_map(const std::vector<T> &a, const std::vector<B> &b,
 template<typename T>
 class Data2D{
 public:
-    //! \internal \brief Default constructor makes an empty data-structure
+    //! \brief Default constructor makes an empty data-structure
     Data2D() : stride(0), num_strips(0), data(0){}
-    //! \internal \brief Default destructor
+    //! \brief Default destructor
     ~Data2D(){}
 
-    //! \internal \brief Clear any existing data and allocate a new data-structure with given **stride** and number of **strips**
+    //! \brief Clear any existing data and allocate a new data-structure with given **stride** and number of **strips**
     void resize(int new_stride, int new_num_strips){
         stride = (size_t) new_stride;
         num_strips = (size_t) new_num_strips;
@@ -137,7 +136,7 @@ public:
         data = vec.data();
         cdata = vec.data();
     }
-    //! \internal \brief Clear any existing data, allocate a new data-structure with given **stride** and number of **strips** and initializes the data to **val** (using `std::vector::resize()`)
+    //! \brief Clear any existing data, allocate a new data-structure with given **stride** and number of **strips** and initializes the data to **val** (using `std::vector::resize()`)
     void resize(int new_stride, int new_num_strips, T val){
         stride = (size_t) new_stride;
         num_strips = (size_t) new_num_strips;
@@ -145,7 +144,7 @@ public:
         data = vec.data();
         cdata = vec.data();
     }
-    //! \internal \brief Wrap around an existing array, the size of the array must be at least **new_stride** times **new_num_strips**
+    //! \brief Wrap around an existing array, the size of the array must be at least **new_stride** times **new_num_strips**
     void load(int new_stride, int new_num_strips, T* new_data){
         stride = (size_t) new_stride;
         num_strips = (size_t) new_num_strips;
@@ -153,7 +152,7 @@ public:
         cdata = data;
         vec.resize(0);
     }
-    //! \internal \brief Wrap around an existing const array, the size of the array must be at least **new_stride** times **new_num_strips**
+    //! \brief Wrap around an existing const array, the size of the array must be at least **new_stride** times **new_num_strips**
     void cload(int new_stride, int new_num_strips, const T* new_data){
         stride = (size_t) new_stride;
         num_strips = (size_t) new_num_strips;
@@ -162,21 +161,21 @@ public:
         vec.resize(0);
     }
 
-    //! \internal \brief Returns a reference to the **i**-th strip, cannot be called after **cload()** since the reference is non-const
+    //! \brief Returns a reference to the **i**-th strip, cannot be called after **cload()** since the reference is non-const
     T* getStrip(int i){ return &(data[i*stride]); }
-    //! \internal \brief Returns a const reference to the **i**-th strip, can be called even after **cload()**
+    //! \brief Returns a const reference to the **i**-th strip, can be called even after **cload()**
     const T* getCStrip(int i) const{ return &(cdata[i*stride]); }
-    //! \internal \brief Returns the stride
+    //! \brief Returns the stride
     int getStride() const{ return (int) stride; }
-    //! \internal \brief Returns the number of strips
+    //! \brief Returns the number of strips
     int getNumStrips() const{ return (int) num_strips; }
-    //! \internal \brief Returns **getStride()** times **getNumStrips()** but using `size_t` arithmetic avoiding a potential `int` overflow
+    //! \brief Returns **getStride()** times **getNumStrips()** but using `size_t` arithmetic avoiding a potential `int` overflow
     size_t getTotalEntries() const{ return stride * num_strips; }
-    //! \internal \brief Returns a reference to the `std::vector` that holds the internal data, can be used only after a call to **resize()**
+    //! \brief Returns a reference to the `std::vector` that holds the internal data, can be used only after a call to **resize()**
     std::vector<T>* getVector(){ return &vec; }
-    //! \internal \brief Returns a const reference to the `std::vector` that holds the internal data, can be used only after a call to **resize()**
+    //! \brief Returns a const reference to the `std::vector` that holds the internal data, can be used only after a call to **resize()**
     const std::vector<T>* getVector() const{ return &vec; }
-    //! \internal \brief Clear all used data (redundant, remove)
+    //! \brief Clear all used data (redundant, remove)
     void clear(){
         stride = 0;
         num_strips = 0;
@@ -184,7 +183,7 @@ public:
         vec.shrink_to_fit();
     }
 
-    //! \internal \brief Uses `std::vector::insert` to append a strip **x** to the existing data
+    //! \brief Uses `std::vector::insert` to append a strip **x** to the existing data
     void appendStrip(const std::vector<T> &x){
         vec.insert(vec.end(), x.begin(), x.end());
         num_strips++;
@@ -197,7 +196,7 @@ private:
     std::vector<T> vec;
 };
 
-//! \internal
+
 //! \brief Class that stores multi-indexes in sorted (lexicographical) order
 //! \ingroup TasmanianSets
 
@@ -210,76 +209,71 @@ private:
 //! * basic file I/O
 class MultiIndexSet{
 public:
-    //! \internal \brief Default constructor, makes an empty set
+    //! \brief Default constructor, makes an empty set
     MultiIndexSet();
-    //! \internal \brief Constructor, makes an empty set and assigns the dimension of the future indexes
+    //! \brief Constructor, makes an empty set and assigns the dimension of the future indexes
     MultiIndexSet(int cnum_dimensions);
-    //! \internal \brief Default destructor
+    //! \brief Default destructor
     ~MultiIndexSet();
 
-    //! \internal
     //! \brief Write to file **ofs** in ASCII format
     //!
     //! The format consists of two `int` values corresponding to the number of dimensions and number of indexes,
     //! followed by all the entries of the array on a single line separated by a space.
     void write(std::ofstream &ofs) const;
 
-    //! \internal
     //! \brief Read from file **ofs** in ASCII format
     //!
     //! See **write()** for the ASCII file format.
     void read(std::ifstream &ifs);
 
-    //! \internal
     //! \brief Write to file **ofs** in binary format
     //!
     //! The format consists of two `int` values corresponding to the number of dimensions and number of indexes,
     //! followed by all the entries of the array written by a single `write()` command.
     void writeBinary(std::ofstream &ofs) const;
 
-    //! \internal
     //! \brief Write to file **ofs** in binary format
     //!
     //! See **writeBinary()** for the binary file format.
     void readBinary(std::ifstream &ifs);
 
-    //! \internal \brief Returns **true** if there are no multi-indexes in the set, **false** otherwise
+    //! \brief Returns **true** if there are no multi-indexes in the set, **false** otherwise
     inline bool empty() const{ return indexes.empty(); }
 
-    //! \internal \brief Clears any currently loaded multi-indexes and set the dimensions to **new_dimensions**
+    //! \brief Clears any currently loaded multi-indexes and set the dimensions to **new_dimensions**
     void setNumDimensions(int new_dimensions);
-    //! \internal \brief Returns the number of dimensions
+    //! \brief Returns the number of dimensions
     inline int getNumDimensions() const{ return (int) num_dimensions; }
-    //! \internal \brief Returns the number of indexes
+    //! \brief Returns the number of indexes
     inline int getNumIndexes() const{ return cache_num_indexes; }
 
-    //! \internal \brief Overwrites the existing set of indexes using `std::move()`, note that **new_indexes** must be sorted before this call
+    //! \brief Overwrites the existing set of indexes using `std::move()`, note that **new_indexes** must be sorted before this call
     void setIndexes(std::vector<int> &new_indexes);
-    //! \internal \brief Add more indexes to the set, note that **addition** must be sorted before this call
+    //! \brief Add more indexes to the set, note that **addition** must be sorted before this call
     void addSortedInsexes(const std::vector<int> &addition);
-    //! \internal \brief Add more indexes to the set, **addition** is assumed unsorted (will be sorted first)
+    //! \brief Add more indexes to the set, **addition** is assumed unsorted (will be sorted first)
     void addUnsortedInsexes(const std::vector<int> &addition);
-    //! \internal \brief Add indexes from another **MultiIndexSet**, makes a call to **addSortedInsexes()**
+    //! \brief Add indexes from another **MultiIndexSet**, makes a call to **addSortedInsexes()**
     inline void addMultiIndexSet(const MultiIndexSet &addition){ addSortedInsexes(*addition.getVector()); }
-    //! \internal \brief Add indexes from a general **Data<>** structure, makes a call to **addUnsortedInsexes()**
+    //! \brief Add indexes from a general **Data<>** structure, makes a call to **addUnsortedInsexes()**
     inline void addData2D(const Data2D<int> &addition){ addUnsortedInsexes(*addition.getVector()); }
 
-    //! \internal \brief Returns a const reference to the internal data
+    //! \brief Returns a const reference to the internal data
     inline const std::vector<int>* getVector() const{ return &indexes; }
-    //! \internal \brief Returns a reference to the internal data, must not modify the lexicographical order or the size of the vector
+    //! \brief Returns a reference to the internal data, must not modify the lexicographical order or the size of the vector
     inline std::vector<int>* getVector(){ return &indexes; } // used for remapping during tensor generic points
 
-    //! \internal \brief Returns the slot containing index **p**, returns `-1` if not found
+    //! \brief Returns the slot containing index **p**, returns `-1` if not found
     int getSlot(const int *p) const;
-    //! \internal \brief Returns the slot containing index **p**, returns `-1` if not found
+    //! \brief Returns the slot containing index **p**, returns `-1` if not found
     inline int getSlot(const std::vector<int> &p) const{ return getSlot(p.data()); }
-    //! \internal \brief Returns **true** if **p** is missing from the set, **false** otherwise
+    //! \brief Returns **true** if **p** is missing from the set, **false** otherwise
     inline bool missing(const std::vector<int> &p) const{ return (getSlot(p.data()) == -1); }
 
-    //! \internal \brief Returns the **i**-th index of the set, useful to loop over all indexes or to cross reference with values
+    //! \brief Returns the **i**-th index of the set, useful to loop over all indexes or to cross reference with values
     inline const int *getIndex(int i) const{ return &(indexes[((size_t) i) * num_dimensions]); }
 
-    //! \internal
     //! \brief A new ordered set is created in **result**, which holds the indexes from this set that are not present in **substract**
     //!
     //! The implementation uses an algorithm similar to merge with complexity linear in the number of multi-indexes of the two sets,
@@ -292,7 +286,6 @@ private:
     std::vector<int> indexes;
 };
 
-//! \internal
 //! \brief Class that stores values, i.e., model outputs, the order of the values is in sync with the order of some **MultiIndexSet**
 //! \ingroup TasmanianSets
 
@@ -303,57 +296,52 @@ private:
 //! the **addValues()** is called with the old and new multi-index sets and the new values.
 class StorageSet{
 public:
-    //! \internal \brief Default constructor, makes an empty set
+    //! \brief Default constructor, makes an empty set
     StorageSet();
-    //! \internal \brief Default destructor
+    //! \brief Default destructor
     ~StorageSet();
 
-    //! \internal
     //! \brief Write to file **ofs** in ASCII format
     //!
     //! The format consists of two `int` values corresponding to the number of outputs and number of values,
     //! followed by all the entries of the array on a single line separated by a space.
     void write(std::ofstream &ofs) const;
 
-    //! \internal
     //! \brief Read from file **ofs** in ASCII format
     //!
     //! See **write()** for the ASCII file format.
     void read(std::ifstream &ifs);
 
-    //! \internal
     //! \brief Write to file **ofs** in binary format
     //!
     //! The format consists of two `int` values corresponding to the number of outputs and number of values,
     //! followed by all the entries of the array written in a single `write()` command.
     void writeBinary(std::ofstream &ofs) const;
 
-    //! \internal
     //! \brief Write to file **ofs** in binary format
     //!
     //! See **writeBinary()** for the binary file format.
     void readBinary(std::ifstream &ifs);
 
-    //! \internal \brief Clear the existing values and assigns new dimensions, does not allocate memory for the new values
+    //! \brief Clear the existing values and assigns new dimensions, does not allocate memory for the new values
     void resize(int cnum_outputs, int cnum_values);
 
-    //! \internal \brief Returns const reference to the **i**-th value, the **i** index matches the corresponding **MultiIndexSet**
+    //! \brief Returns const reference to the **i**-th value, the **i** index matches the corresponding **MultiIndexSet**
     const double* getValues(int i) const;
-    //! \internal \brief Returns reference to the **i**-th value, the **i** index matches the corresponding **MultiIndexSet**
+    //! \brief Returns reference to the **i**-th value, the **i** index matches the corresponding **MultiIndexSet**
     double* getValues(int i);
-    //! \internal \brief Returns reference to the internal data vector
+    //! \brief Returns reference to the internal data vector
     std::vector<double>* aliasValues(); // alternative to setValues()
-    //! \internal \brief Returns const reference to the internal data vector
+    //! \brief Returns const reference to the internal data vector
     const std::vector<double>* aliasValues() const; // alternative to setValues()
-    //! \internal \brief Read the number of outputs
+    //! \brief Read the number of outputs
     int getNumOutputs() const;
 
-    //! \internal \brief Replace the existing values with a copy of **vals**, the size must be at least **num_outputs** times **num_values**
+    //! \brief Replace the existing values with a copy of **vals**, the size must be at least **num_outputs** times **num_values**
     void setValues(const double vals[]);
-    //! \internal \brief Replace the existing values with **vals** using `std::move()`, the size of **vals** must be **num_outputs** times **num_values**
+    //! \brief Replace the existing values with **vals** using `std::move()`, the size of **vals** must be **num_outputs** times **num_values**
     void setValues(std::vector<double> &vals);
 
-    //! \internal
     //! \brief Add more values to the set, the **old_set** and **new_set** define the order of the current values and the **new_vals**
     //!
     //! Add more values to an existing set of values, where **old_set** and **new_set** indicate the order.
@@ -362,7 +350,7 @@ public:
     void addValues(const MultiIndexSet &old_set, const MultiIndexSet &new_set, const double new_vals[]);
 
 protected:
-    //! \internal \brief Returns the relation between **a** and **b**, used for the merge
+    //! \brief Returns the relation between **a** and **b**, used for the merge
     TypeIndexRelation compareIndexes(int num_dimensions, const int a[], const int b[]) const;
 
 private:

--- a/SparseGrids/tsgLinearSolvers.cpp
+++ b/SparseGrids/tsgLinearSolvers.cpp
@@ -305,8 +305,6 @@ void TasmanianFourierTransform::fast_fourier_transform1D(std::vector<std::vector
     for(auto i : indexes) data[i] = *v++;
 }
 
-}
-
 namespace TasSparse{
 
 SparseMatrix::SparseMatrix() : tol(TSG_NUM_TOL), num_rows(0){}
@@ -577,4 +575,5 @@ void SparseMatrix::solve(const double b[], double x[], bool transposed) const{ /
 
 } /* namespace TasSparse */
 
+}
 #endif

--- a/SparseGrids/tsgLinearSolvers.hpp
+++ b/SparseGrids/tsgLinearSolvers.hpp
@@ -109,10 +109,9 @@ namespace TasmanianFourierTransform{
     void fast_fourier_transform1D(std::vector<std::vector<std::complex<double>>> &data, std::vector<int> &indexes);
 }
 
-}
-
-// Sparse linear algebra is used by the wavelet grids only
-// tsgEnumerates.hpp is needed by TasSparse for the hardcoded constants, i.e., TSG_DROP_TOL
+//! \internal
+//! \brief Methods for sparse linear algebra.
+//! \ingroup TasmanianLinearSolvers
 namespace TasSparse{
 
 //! \internal
@@ -147,6 +146,8 @@ private:
     std::vector<int> pntr, indx, indxD;
     std::vector<double> vals, ilu;
 };
+
+}
 
 }
 

--- a/SparseGrids/tsgLinearSolvers.hpp
+++ b/SparseGrids/tsgLinearSolvers.hpp
@@ -39,23 +39,74 @@
 
 #include "tsgEnumerates.hpp"
 
+//! \internal
+//! \file tsgLinearSolvers.hpp
+//! \brief Linear solvers.
+//! \author Miroslav Stoyanov
+//! \ingroup TasmanianLinearSolvers
+//!
+//! Many sparse grids methods rely on various linear solvers, sparse iterative, eigenvalue,
+//! fast-fourier-transform, and least-squares. The solvers are tuned for the specific
+//! problems and can perform as good (or even better) than general third-party methods.
+//! In addition, this reduces the external dependencies.
+
+//! \internal
+//! \defgroup TasmanianLinearSolvers Linear solvers.
+//!
+//! \par Linear Solvers
+//! Many sparse grids methods rely on various linear solvers, sparse iterative, eigenvalue,
+//! fast-fourier-transform, and least-squares. The solvers are tuned for the specific
+//! problems and can perform as good (or even better) than general third-party methods.
+//! In addition, this reduces the external dependencies.
+
 namespace TasGrid{
 
+//! \internal
+//! \brief Methods for dense linear algebra.
+//! \ingroup TasmanianLinearSolvers
 namespace TasmanianDenseSolver{
+    //! \internal
+    //! \brief Least squares solver, used to infer anisotropic coefficients and thus rarely exceeds 10 - 20.
+    //! \ingroup TasmanianLinearSolvers
+
+    //! Matrix \b A is \b n by \b m (with \b n much larger), vector \b b has length \b n,
+    //! the result is given in \b x (length \b m). The regularized term \b reg is added to the diagonal of
+    //! the product `transpose(A) * A` to stabilize the Cholesky decomposition.
     void solveLeastSquares(int n, int m, const double A[], const double b[], double reg, double *x);
 }
 
+//! \internal
+//! \brief Methods for tridiagonal eigenvalue problems.
+//! \ingroup TasmanianLinearSolvers
 namespace TasmanianTridiagonalSolver{
+    //! \internal
+    //! \brief Methods for tridiagonal eigenvalue problems, used to compute nodes and weights for Gaussian rules.
+    //! \ingroup TasmanianLinearSolvers
     void decompose(int n, std::vector<double> &d, std::vector<double> &e, std::vector<double> &z);
 }
 
+//! \internal
+//! \brief Methods for Fast-Fourier-Transform.
+//! \ingroup TasmanianLinearSolvers
 namespace TasmanianFourierTransform{
+    //! \internal
+    //! \brief Transfrom the data for a multi-dimensional tensor.
+    //! \ingroup TasmanianLinearSolvers
+
+    //! The \b num_points vector defines the number of points used by the tensor in different directions.
+    //! The \b data holds the values for each point in the tensor, each point has a vector of values
+    //! with size equal to the number of model outputs.
+    //!
+    //! The data is split into one-dimensional \a lines and each is tackled with \b fast_fourier_transform1D()
     void fast_fourier_transform(std::vector<std::vector<std::complex<double>>> &data, std::vector<int> &num_points);
-    // num_points describes the dimension and number of points in the tensor
-    // data holds the corresponding strips with size num_outputs
+
+    //! \internal
+    //! \brief Perform one dimensional fast-fourier-transform (using radix-3).
+    //! \ingroup TasmanianLinearSolvers
+
+    //! Consider the line which is a subset of \b data defined by \b indexes and perform the radix-3 fast-fourier-transform.
+    //! Called from \b fast_fourier_transform().
     void fast_fourier_transform1D(std::vector<std::vector<std::complex<double>>> &data, std::vector<int> &indexes);
-    // indexes lists the indexes that play a role in this strip, i.e., 1D transform
-    // data holds the corresponding strips with size num_outputs
 }
 
 }
@@ -64,21 +115,30 @@ namespace TasmanianFourierTransform{
 // tsgEnumerates.hpp is needed by TasSparse for the hardcoded constants, i.e., TSG_DROP_TOL
 namespace TasSparse{
 
-// Make a new matrix class that would store the ILU preconditioner and solve either the regular or adjoined problem all in one class
+//! \internal
+//! \brief Used to manipulate the wavelet values and solve for the wavelet coefficients.
+//! \ingroup TasmanianLinearSolvers
 class SparseMatrix{
 public:
+    //! \brief Default constructor, create an empty matrix.
     SparseMatrix();
+    //! \brief Default destructor.
     ~SparseMatrix();
 
+    //! \brief Load the sparse matrix in row-compressed form.
     void load(const std::vector<int> &lpntr, const std::vector<std::vector<int>> &lindx, const std::vector<std::vector<double>> &lvals);
 
+    //! \brief Return the number of rows in the matrix.
     int getNumRows() const;
 
+    //! \brief Solve `op(A) x = b` where `op` is either identity (find the coefficients) or transpose (find the interpolation weights).
 	void solve(const double b[], double x[], bool transposed = false) const;
 
 protected:
+    //! \brief Clear the internal data structures (maybe not needed?)
     void clear();
 
+    //! \brief Compute the incomplete lower-upper decomposition of the matrix (zero extra fill).
     void computeILU();
 
 private:

--- a/SparseGrids/tsgOneDimensionalWrapper.hpp
+++ b/SparseGrids/tsgOneDimensionalWrapper.hpp
@@ -36,27 +36,54 @@
 #include "tsgSequenceOptimizer.hpp"
 #include "tsgHardCodedTabulatedRules.hpp"
 
+//! \internal
+//! \file tsgOneDimensionalWrapper.hpp
+//! \brief Cache for one dimensional rules.
+//! \author Miroslav Stoyanov
+//! \ingroup TasmanianCoreOneDimensional
+//!
+//! A class to cache one dimensional rules, nodes, weight, etc.
+
 namespace TasGrid{
 
+//! \brief A class to cache one dimensional rules, nodes, weight, meta-data, etc.
+//! \ingroup TasmanianCoreOneDimensional
 class OneDimensionalWrapper{
 public:
+    //! \brief Default constructor, create an emptry cache.
     OneDimensionalWrapper();
+    //! \brief Default destructor.
     ~OneDimensionalWrapper();
 
+    //! \brief Load the cache.
+
+    //! Load \b max_level of cache for a rule given by \b crule. If the rule is not
+    //! custom tabulated, then \b custom is not used (could be empty).
+    //! Similarly, \b alpha and \b beta are used only by rules that use the corresponding
+    //! transformation parameters.
     void load(const CustomTabulated &custom, int max_level, TypeOneDRule crule, double alpha, double beta);
 
+    //! \brief Get the number of points for the \b level, can only querry loaded levels.
     int getNumPoints(int level) const;
+    //! \brief Get the global index of point \b j on \b level (used only by non-nested rules).
     int getPointIndex(int level, int j) const;
 
+    //! \brief Get the canonical coordinate of the node with global index \b j.
     double getNode(int j) const;
+    //! \brief Get the quadrature weight of the \b j-th node on the \b level (for non-nested rules, using index local to the level)
     double getWeight(int level, int j) const;
 
+    //! \brief Get an array of all nodes associated with the \b level (the array is ordered by local index).
     const double* getNodes(int level) const;
+    //! \brief Get an array of the Lagrange coefficients associated with the \b level, the order matches \b getNodes().
     const double* getCoefficients(int level) const;
 
+    //! \brief Get a reference to the offsets of all point counts used by the \b CacheLagrange class.
     const std::vector<int>* getPointsCount() const;
 
+    //! \brief Get the loaded rule.
     TypeOneDRule getType() const;
+    //! \brief Get the number of cached levels.
     int getNumLevels() const;
 
 private:


### PR DESCRIPTION
* fix the way internal documentation is skipped without `-D DOXYGEN_INTERNAL_DOCS=YES`
* document core one dimensional methods, one-d wrapper and linear solvers
* fix documentation for the multi-index templates