### PR TITLE
Dynamic construction global

### DIFF
--- a/SparseGrids/CMakeLists.txt
+++ b/SparseGrids/CMakeLists.txt
@@ -83,6 +83,8 @@ set(Tasmanian_source_libsparsegrid
         tsgCacheLagrange.hpp
         tsgCoreOneDimensional.hpp
         tsgCoreOneDimensional.cpp
+        tsgDConstructGridGlobal.hpp
+        tsgDConstructGridGlobal.cpp
         tsgCudaMacros.hpp
         tsgEnumerates.hpp
         tsgGridCore.hpp

--- a/SparseGrids/Makefile
+++ b/SparseGrids/Makefile
@@ -11,12 +11,14 @@ LHEADERS = tsgIndexSets.hpp tsgCoreOneDimensional.hpp tsgIndexManipulator.hpp ts
            tsgRuleLocalPolynomial.hpp tsgHardCodedTabulatedRules.hpp tsgGridLocalPolynomial.hpp tsgGridFourier.hpp \
            tsgRuleWavelet.hpp tsgCudaMacros.hpp tsgGridWavelet.hpp \
            tsgCudaLinearAlgebra.hpp tsgCudaBasisEvaluations.hpp tsgAcceleratedDataStructures.hpp \
+           tsgDConstructGridGlobal.hpp \
            tasgridTestFunctions.hpp tasgridExternalTests.hpp tasgridWrapper.hpp tasgridUnitTests.hpp \
            TasmanianSparseGrid.hpp
 
 LIBOBJ = tsgIndexSets.o tsgCoreOneDimensional.o tsgIndexManipulator.o tsgGridGlobal.o tsgSequenceOptimizer.o tsgOneDimensionalWrapper.o \
          tsgGridCore.o tsgLinearSolvers.o tsgGridSequence.o tsgHardCodedTabulatedRules.o \
          tsgGridLocalPolynomial.o tsgRuleWavelet.o tsgGridWavelet.o tsgGridFourier.o \
+         tsgDConstructGridGlobal.o \
          tsgAcceleratedDataStructures.o $(TASMANIAN_CUDA_KERNELS) \
          TasmanianSparseGrid.o
 

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -1085,9 +1085,13 @@ void TasmanianSparseGrid::beginConstruction(){
         getGridGlobal()->beginConstruction();
     }
 }
-void TasmanianSparseGrid::getCandidateConstructionPoints(std::vector<double> &x){
+void TasmanianSparseGrid::getCandidateConstructionPoints(std::vector<double> &x, const std::vector<int> &level_limits){
     if (!usingDynamicConstruction) throw std::runtime_error("ERROR: getCandidateConstructionPoints() called before beginConstruction()");
-    getGridGlobal()->getCandidateConstructionPoints(x);
+    int dims = base->getNumDimensions();
+    if ((!level_limits.empty()) && (level_limits.size() != (size_t) dims)) throw std::invalid_argument("ERROR: getCandidateConstructionPoints() requires level_limits with either 0 or num-dimensions entries");
+
+    if (!level_limits.empty()) llimits = level_limits;
+    getGridGlobal()->getCandidateConstructionPoints(x, llimits);
 }
 void TasmanianSparseGrid::loadConstructedPoint(const std::vector<double> &x, const std::vector<double> &y){
     if (!usingDynamicConstruction) throw std::runtime_error("ERROR: loadConstructedPoint() called before beginConstruction()");

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -1079,17 +1079,25 @@ void TasmanianSparseGrid::mergeRefinement(){
 
 void TasmanianSparseGrid::beginConstruction(){
     if (!isGlobal()) throw std::runtime_error("ERROR: beginConstruction() called for grid that is not Global");
-    clearRefinement();
-    usingDynamicConstruction = false;
+    if (!usingDynamicConstruction){
+        if (getNumLoaded() > 0) clearRefinement();
+        usingDynamicConstruction = true;
+        getGridGlobal()->beginConstruction();
+    }
 }
 void TasmanianSparseGrid::getCandidateConstructionPoints(std::vector<double> &x){
     if (!usingDynamicConstruction) throw std::runtime_error("ERROR: getCandidateConstructionPoints() called before beginConstruction()");
+    getGridGlobal()->getCandidateConstructionPoints(x);
 }
 void TasmanianSparseGrid::loadConstructedPoint(const std::vector<double> &x, const std::vector<double> &y){
     if (!usingDynamicConstruction) throw std::runtime_error("ERROR: loadConstructedPoint() called before beginConstruction()");
+    Data2D<double> x_tmp;
+    const double *x_canonical = formCanonicalPoints(x.data(), x_tmp, 1);
+    getGridGlobal()->loadConstructedPoint(x_canonical, y);
 }
 void TasmanianSparseGrid::finishConstruction(){
-    usingDynamicConstruction = true;
+    if (usingDynamicConstruction) getGridGlobal()->finishConstruction();
+    usingDynamicConstruction = false;
 }
 
 void TasmanianSparseGrid::removePointsByHierarchicalCoefficient(double tolerance, int output, const double *scale_correction){

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -1085,13 +1085,31 @@ void TasmanianSparseGrid::beginConstruction(){
         getGridGlobal()->beginConstruction();
     }
 }
-void TasmanianSparseGrid::getCandidateConstructionPoints(TypeDepth type, std::vector<double> &x, const std::vector<int> &level_limits){
+void TasmanianSparseGrid::getCandidateConstructionPoints(TypeDepth type, std::vector<double> &x, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits){
     if (!usingDynamicConstruction) throw std::runtime_error("ERROR: getCandidateConstructionPoints() called before beginConstruction()");
-    int dims = base->getNumDimensions();
+    size_t dims = (size_t) base->getNumDimensions();
     if ((!level_limits.empty()) && (level_limits.size() != (size_t) dims)) throw std::invalid_argument("ERROR: getCandidateConstructionPoints() requires level_limits with either 0 or num-dimensions entries");
+    if (!anisotropic_weights.empty()){
+        if ((type == type_curved) || (type == type_ipcurved) || (type == type_qpcurved)){
+            if (anisotropic_weights.size() != 2 * dims) throw std::invalid_argument("ERROR: getCandidateConstructionPoints() called with curved type and incorrect size for anisotropic_weights (must be twice the number of dimensions)");
+        }else{
+            if (anisotropic_weights.size() != dims) throw std::invalid_argument("ERROR: getCandidateConstructionPoints() called with incorrect size for anisotropic_weights (must match number of dimensions)");
+        }
+    }
 
     if (!level_limits.empty()) llimits = level_limits;
-    getGridGlobal()->getCandidateConstructionPoints(type, std::vector<int>(), x, llimits);
+    getGridGlobal()->getCandidateConstructionPoints(type, anisotropic_weights, x, llimits);
+}
+void TasmanianSparseGrid::getCandidateConstructionPoints(TypeDepth type, int output, std::vector<double> &x, const std::vector<int> &level_limits){
+    if (!usingDynamicConstruction) throw std::runtime_error("ERROR: getCandidateConstructionPoints() called before beginConstruction()");
+    size_t dims = (size_t) base->getNumDimensions();
+    if ((!level_limits.empty()) && (level_limits.size() != dims)) throw std::invalid_argument("ERROR: getCandidateConstructionPoints() requires level_limits with either 0 or num-dimensions entries");
+    int outs = base->getNumOutputs();
+    if (outs == 0) throw std::runtime_error("ERROR: calling getCandidateConstructionPoints() for a grid that has no outputs");
+    if ((output < -1) || (output >= outs)) throw std::invalid_argument("ERROR: calling getCandidateConstructionPoints() with invalid output");
+
+    if (!level_limits.empty()) llimits = level_limits;
+    getGridGlobal()->getCandidateConstructionPoints(type, output, x, llimits);
 }
 void TasmanianSparseGrid::loadConstructedPoint(const std::vector<double> &x, const std::vector<double> &y){
     if (!usingDynamicConstruction) throw std::runtime_error("ERROR: loadConstructedPoint() called before beginConstruction()");

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -1085,13 +1085,13 @@ void TasmanianSparseGrid::beginConstruction(){
         getGridGlobal()->beginConstruction();
     }
 }
-void TasmanianSparseGrid::getCandidateConstructionPoints(std::vector<double> &x, const std::vector<int> &level_limits){
+void TasmanianSparseGrid::getCandidateConstructionPoints(TypeDepth type, std::vector<double> &x, const std::vector<int> &level_limits){
     if (!usingDynamicConstruction) throw std::runtime_error("ERROR: getCandidateConstructionPoints() called before beginConstruction()");
     int dims = base->getNumDimensions();
     if ((!level_limits.empty()) && (level_limits.size() != (size_t) dims)) throw std::invalid_argument("ERROR: getCandidateConstructionPoints() requires level_limits with either 0 or num-dimensions entries");
 
     if (!level_limits.empty()) llimits = level_limits;
-    getGridGlobal()->getCandidateConstructionPoints(x, llimits);
+    getGridGlobal()->getCandidateConstructionPoints(type, std::vector<int>(), x, llimits);
 }
 void TasmanianSparseGrid::loadConstructedPoint(const std::vector<double> &x, const std::vector<double> &y){
     if (!usingDynamicConstruction) throw std::runtime_error("ERROR: loadConstructedPoint() called before beginConstruction()");

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -179,8 +179,8 @@ public:
 
     //! \brief Begin a dynamic construction procedure, also calls \b clearRefinement() (cheap to call, only sets some flags)
     void beginConstruction();
-    //! \brief Generate a sorted list of points weighted by descending importance (expensive call, equivalent to set-refinement)
-    void getCandidateConstructionPoints(std::vector<double> &x);
+    //! \brief Generate a sorted list of points weighted by descending importance (expensive call, roughly equivalent to set-refinement)
+    void getCandidateConstructionPoints(std::vector<double> &x, const std::vector<int> &level_limits = std::vector<int>());
     //! \brief Add the value of a single point (if the tensor of the point is not complete, the grid will not be updated but the value will be stored)
     void loadConstructedPoint(const std::vector<double> &x, const std::vector<double> &y);
     //! \brief End the procedure, clears flags and unused constructed points, can go back to using regular refinement

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -180,7 +180,7 @@ public:
     //! \brief Begin a dynamic construction procedure, also calls \b clearRefinement() (cheap to call, only sets some flags)
     void beginConstruction();
     //! \brief Generate a sorted list of points weighted by descending importance (expensive call, roughly equivalent to set-refinement)
-    void getCandidateConstructionPoints(std::vector<double> &x, const std::vector<int> &level_limits = std::vector<int>());
+    void getCandidateConstructionPoints(TypeDepth type, std::vector<double> &x, const std::vector<int> &level_limits = std::vector<int>());
     //! \brief Add the value of a single point (if the tensor of the point is not complete, the grid will not be updated but the value will be stored)
     void loadConstructedPoint(const std::vector<double> &x, const std::vector<double> &y);
     //! \brief End the procedure, clears flags and unused constructed points, can go back to using regular refinement

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -179,8 +179,15 @@ public:
 
     //! \brief Begin a dynamic construction procedure, also calls \b clearRefinement() (cheap to call, only sets some flags)
     void beginConstruction();
-    //! \brief Generate a sorted list of points weighted by descending importance (expensive call, roughly equivalent to set-refinement)
-    void getCandidateConstructionPoints(TypeDepth type, std::vector<double> &x, const std::vector<int> &level_limits = std::vector<int>());
+    //! \brief Generate a sorted list of points weighted by descending importance using the \b type and provided anisotropic_weights (expensive call, roughly equivalent to set-refinement)
+
+    //! If no weights are provided, isotropic weights will be imposed. Tensor types fall-back to \b type_level (not recommended to use here).
+    void getCandidateConstructionPoints(TypeDepth type, std::vector<double> &x, const std::vector<int> &anisotropic_weights = std::vector<int>(), const std::vector<int> &level_limits = std::vector<int>());
+    //! \brief Same as \b getCandidateConstructionPoints() but the weights are obtained from a call to \b estimateAnisotropicCoefficients().
+
+    //! Unlike \b estimateAnisotropicCoefficients(), this function will not throw if the grid is empty; instead, isotropic coefficient will be used
+    //! until enough points are loaded so that coefficients can be estimated.
+    void getCandidateConstructionPoints(TypeDepth type, int output, std::vector<double> &x, const std::vector<int> &level_limits = std::vector<int>());
     //! \brief Add the value of a single point (if the tensor of the point is not complete, the grid will not be updated but the value will be stored)
     void loadConstructedPoint(const std::vector<double> &x, const std::vector<double> &y);
     //! \brief End the procedure, clears flags and unused constructed points, can go back to using regular refinement

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -177,6 +177,15 @@ public:
     void clearRefinement();
     void mergeRefinement(); // merges all points but resets all loaded values to 0.0
 
+    //! \brief Begin a dynamic construction procedure, also calls \b clearRefinement() (cheap to call, only sets some flags)
+    void beginConstruction();
+    //! \brief Generate a sorted list of points weighted by descending importance (expensive call, equivalent to set-refinement)
+    void getCandidateConstructionPoints(std::vector<double> &x);
+    //! \brief Add the value of a single point (if the tensor of the point is not complete, the grid will not be updated but the value will be stored)
+    void loadConstructedPoint(const std::vector<double> &x, const std::vector<double> &y);
+    //! \brief End the procedure, clears flags and unused constructed points, can go back to using regular refinement
+    void finishConstruction();
+
     const double* getHierarchicalCoefficients() const; // formerly getSurpluses();  returns an alias to internal data structure
     void evaluateHierarchicalFunctions(const double x[], int num_x, double y[]) const;
     void evaluateSparseHierarchicalFunctions(const double x[], int num_x, int* &pntr, int* &indx, double* &vals) const;
@@ -266,6 +275,8 @@ private:
 
     TypeAcceleration acceleration;
     int gpuID;
+
+    bool usingDynamicConstruction;
 
     #ifdef Tasmanian_ENABLE_CUDA
     mutable AccelerationDomainTransform acc_domain;

--- a/SparseGrids/tasgridExternalTests.hpp
+++ b/SparseGrids/tasgridExternalTests.hpp
@@ -37,6 +37,7 @@
 #include <fstream>
 #include <string>
 #include <iomanip>
+#include <random>
 #include <string.h>
 #include <math.h>
 
@@ -82,6 +83,7 @@ public:
     bool testLocalWaveletRule(const BaseFunction *f, const int depths[], const double tols[]) const;
     bool testSurplusRefinement(const BaseFunction *f, TasmanianSparseGrid *grid, double tol, TypeRefinement rtype, const int np[], const double errs[], int max_iter ) const;
     bool testAnisotropicRefinement(const BaseFunction *f, TasmanianSparseGrid *grid, TypeDepth type, int min_growth, const int np[], const double errs[], int max_iter ) const;
+    bool testDynamicRefinement(const BaseFunction *f, TasmanianSparseGrid *grid, TypeDepth type, const std::vector<int> &np, const std::vector<double> &errs) const;
     bool testAcceleration(const BaseFunction *f, TasmanianSparseGrid *grid) const;
     bool testGPU2GPUevaluations() const;
 

--- a/SparseGrids/tsgDConstructGridGlobal.cpp
+++ b/SparseGrids/tsgDConstructGridGlobal.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, Miroslav Stoyanov
+ *
+ * This file is part of
+ * Toolkit for Adaptive Stochastic Modeling And Non-Intrusive ApproximatioN: TASMANIAN
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * UT-BATTELLE, LLC AND THE UNITED STATES GOVERNMENT MAKE NO REPRESENTATIONS AND DISCLAIM ALL WARRANTIES, BOTH EXPRESSED AND IMPLIED.
+ * THERE ARE NO EXPRESS OR IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE SOFTWARE WILL NOT INFRINGE ANY PATENT,
+ * COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS, OR THAT THE SOFTWARE WILL ACCOMPLISH THE INTENDED RESULTS OR THAT THE SOFTWARE OR ITS USE WILL NOT RESULT IN INJURY OR DAMAGE.
+ * THE USER ASSUMES RESPONSIBILITY FOR ALL LIABILITIES, PENALTIES, FINES, CLAIMS, CAUSES OF ACTION, AND COSTS AND EXPENSES, CAUSED BY, RESULTING FROM OR ARISING OUT OF,
+ * IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
+ */
+
+#ifndef __TASMANIAN_SPARSE_GRID_DYNAMIC_CONST_GLOBAL_CPP
+#define __TASMANIAN_SPARSE_GRID_DYNAMIC_CONST_GLOBAL_CPP
+
+#include "tsgDConstructGridGlobal.hpp"
+
+namespace TasGrid{
+
+DynamicConstructorDataGlobal::DynamicConstructorDataGlobal(){}
+DynamicConstructorDataGlobal::~DynamicConstructorDataGlobal(){}
+
+}
+
+
+
+#endif

--- a/SparseGrids/tsgDConstructGridGlobal.cpp
+++ b/SparseGrids/tsgDConstructGridGlobal.cpp
@@ -92,7 +92,10 @@ void DynamicConstructorDataGlobal::getNodesIndexes(std::vector<int> &inodes){
     tensors.sort([&](const TensorData &a, const TensorData &b)->bool{ return (a.weight < b.weight); });
     auto t = tensors.begin();
     while(t != tensors.end()){
-        inodes.insert(inodes.end(), (*t).points.getVector()->begin(), (*t).points.getVector()->end());
+        for(int i=0; i<(*t).points.getNumIndexes(); i++){
+            if (!(*t).loaded[i])
+                inodes.insert(inodes.end(), (*t).points.getIndex(i), (*t).points.getIndex(i) + num_dimensions);
+        }
         t++;
     }
 }

--- a/SparseGrids/tsgDConstructGridGlobal.cpp
+++ b/SparseGrids/tsgDConstructGridGlobal.cpp
@@ -35,11 +35,131 @@
 
 namespace TasGrid{
 
-DynamicConstructorDataGlobal::DynamicConstructorDataGlobal(){}
+DynamicConstructorDataGlobal::DynamicConstructorDataGlobal(int cnum_dimensions, int cnum_outputs)
+    : num_dimensions(cnum_dimensions), num_outputs(cnum_outputs){}
 DynamicConstructorDataGlobal::~DynamicConstructorDataGlobal(){}
 
+void DynamicConstructorDataGlobal::clearTesnors(){
+    auto p = tensors.before_begin();
+    auto t = tensors.begin();
+    while(t != tensors.end()){
+        if ((*t).weight >= 0.0){
+            tensors.erase_after(p);
+            t = p;
+        }else{
+            p++;
+        }
+        t++;
+    }
 }
 
+void DynamicConstructorDataGlobal::getInitialTensors(MultiIndexSet &set) const{
+    Data2D<int> tens;
+    tens.resize(num_dimensions, 0);
+    auto t = tensors.begin();
+    while(t != tensors.end()){
+        if ((*t).weight < 0.0){
+            tens.appendStrip((*t).tensor);
+        }
+        t++;
+    }
+    set = MultiIndexSet(num_dimensions);
+    if (tens.getNumStrips() > 0)
+        set.addData2D(tens);
+}
 
+void DynamicConstructorDataGlobal::addTensor(const int *tensor, std::function<int(int)> getNumPoints, double weight){
+    TensorData t;
+    std::vector<int> v(tensor, tensor + num_dimensions);
+    t.tensor = v;
+    MultiIndexSet dummy_set(num_dimensions);
+    dummy_set.setIndexes(v);
+    t.points.setNumDimensions(num_dimensions);
+    MultiIndexManipulations::generateNestedPoints(dummy_set, getNumPoints, t.points);
+    t.loaded = std::vector<bool>(t.points.getNumIndexes(), false);
+    auto d = data.begin();
+    while(d != data.end()){
+        int slot = t.points.getSlot((*d).point);
+        if (slot != -1) t.loaded[slot] = true;
+        d++;
+    }
+    t.weight = weight;
+    tensors.push_front(std::move(t));
+}
+
+void DynamicConstructorDataGlobal::getNodesIndexes(std::vector<int> &inodes){
+    inodes = std::vector<int>();
+    tensors.sort([&](const TensorData &a, const TensorData &b)->bool{ return (a.weight < b.weight); });
+    auto t = tensors.begin();
+    while(t != tensors.end()){
+        inodes.insert(inodes.end(), (*t).points.getVector()->begin(), (*t).points.getVector()->end());
+        t++;
+    }
+}
+
+bool DynamicConstructorDataGlobal::addNewNode(const std::vector<int> &point, const std::vector<double> &value){
+    data.push_front({point, value});
+    auto t = tensors.begin();
+    while(t != tensors.end()){
+        int slot = (*t).points.getSlot(point);
+        if (slot != -1){
+            (*t).loaded[slot] = true;
+            if (std::all_of((*t).loaded.begin(), (*t).loaded.end(), [](bool a)-> bool{ return a; })){ // if all entries are true
+                (*t).loaded = std::vector<bool>();
+                return true; // all points associated with this tensor have been loaded, signal to call ejectCompleteTensor()
+            }else{
+                return false; // point added to the tensor, but the tensor is not complete yet
+            }
+        }
+        t++;
+    }
+    return false; // could not find a tensor that contains this node???
+}
+
+bool DynamicConstructorDataGlobal::ejectCompleteTensor(const MultiIndexSet &current_tensors, std::vector<int> &tensor, MultiIndexSet &points, std::vector<double> &vals){
+    auto p = tensors.before_begin();
+    auto t = tensors.begin();
+    while(t != tensors.end()){
+        if ((*t).loaded.empty()){ // empty loaded means all have been loaded
+            std::vector<int> test = (*t).tensor;
+            bool parents_exist = true;
+            for(auto &pt : test){
+                if (pt > 0){
+                    pt--;
+                    if (current_tensors.empty() || current_tensors.missing(test)) parents_exist = false;
+                    pt++;
+                }
+            }
+            if (parents_exist){
+                tensor = (*t).tensor;
+                points = (*t).points;
+                vals.resize(points.getNumIndexes() *  num_outputs);
+                auto d = data.before_begin();
+                auto v = data.begin();
+                int found = 0;
+                while(found < points.getNumIndexes()){
+                    int slot = points.getSlot((*v).point);
+                    if (slot == -1){
+                        d++;
+                        v++;
+                    }else{
+                        std::copy_n((*v).value.begin(), num_outputs, &(vals[slot * num_outputs]));
+                        data.erase_after(d);
+                        v = d;
+                        v++;
+                        found++;
+                    }
+                }
+                tensors.erase_after(p);
+                return true;
+            }
+        }
+        t++;
+        p++;
+    }
+    return false; // could not find a complete tensor with parents present in tensors
+}
+
+}
 
 #endif

--- a/SparseGrids/tsgDConstructGridGlobal.hpp
+++ b/SparseGrids/tsgDConstructGridGlobal.hpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017, Miroslav Stoyanov
+ *
+ * This file is part of
+ * Toolkit for Adaptive Stochastic Modeling And Non-Intrusive ApproximatioN: TASMANIAN
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * UT-BATTELLE, LLC AND THE UNITED STATES GOVERNMENT MAKE NO REPRESENTATIONS AND DISCLAIM ALL WARRANTIES, BOTH EXPRESSED AND IMPLIED.
+ * THERE ARE NO EXPRESS OR IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE SOFTWARE WILL NOT INFRINGE ANY PATENT,
+ * COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS, OR THAT THE SOFTWARE WILL ACCOMPLISH THE INTENDED RESULTS OR THAT THE SOFTWARE OR ITS USE WILL NOT RESULT IN INJURY OR DAMAGE.
+ * THE USER ASSUMES RESPONSIBILITY FOR ALL LIABILITIES, PENALTIES, FINES, CLAIMS, CAUSES OF ACTION, AND COSTS AND EXPENSES, CAUSED BY, RESULTING FROM OR ARISING OUT OF,
+ * IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
+ */
+
+#ifndef __TASMANIAN_SPARSE_GRID_DYNAMIC_CONST_GLOBAL_HPP
+#define __TASMANIAN_SPARSE_GRID_DYNAMIC_CONST_GLOBAL_HPP
+
+#include "tsgEnumerates.hpp"
+
+namespace TasGrid{
+
+class DynamicConstructorDataGlobal{
+public:
+    DynamicConstructorDataGlobal();
+    ~DynamicConstructorDataGlobal();
+private:
+};
+
+}
+
+#endif

--- a/SparseGrids/tsgDConstructGridGlobal.hpp
+++ b/SparseGrids/tsgDConstructGridGlobal.hpp
@@ -31,15 +31,53 @@
 #ifndef __TASMANIAN_SPARSE_GRID_DYNAMIC_CONST_GLOBAL_HPP
 #define __TASMANIAN_SPARSE_GRID_DYNAMIC_CONST_GLOBAL_HPP
 
+#include <forward_list>
+
 #include "tsgEnumerates.hpp"
+#include "tsgIndexSets.hpp"
+#include "tsgIndexManipulator.hpp"
 
 namespace TasGrid{
 
+struct NodeData{
+    std::vector<int> point;
+    std::vector<double> value;
+};
+
+struct TensorData{
+    std::vector<int> tensor;
+    MultiIndexSet points;
+    std::vector<bool> loaded;
+    double weight;
+};
+
 class DynamicConstructorDataGlobal{
 public:
-    DynamicConstructorDataGlobal();
+    DynamicConstructorDataGlobal(int cnum_dimensions, int cnum_outputs);
     ~DynamicConstructorDataGlobal();
+
+    //! \brief Delete the tensors with non-negative weights, i.e., clear all by the tensors selected by the initial grid.
+    void clearTesnors();
+
+    //! \brief Get a set of all tensors with negative weight, i.e., the tensors selected for the initial run.
+    void getInitialTensors(MultiIndexSet &set) const;
+
+    //! \brief Add a new tensor to the candidates, with the given \b weight and using \b getNumPoints() to define the associated nodes.
+    void addTensor(const int *tensor, std::function<int(int)> getNumPoints, double weight);
+
+    //! \brief Get the node indexes of the points associated with the candidate tensors, the order matches the weights of the tensors.
+    void getNodesIndexes(std::vector<int> &inodes);
+
+    //! \brief Add a new data point with the index and the value, returns \b true if there is enough data to complete a tensor.
+    bool addNewNode(const std::vector<int> &point, const std::vector<double> &value); // returns whether a tensor is complete
+
+    //! \brief Return a completed tensor with parent-tensors included in tensors, returns \b true if such tensor has been found.
+    bool ejectCompleteTensor(const MultiIndexSet &current_tensors, std::vector<int> &tensor, MultiIndexSet &points, std::vector<double> &vals);
+
 private:
+    int num_dimensions, num_outputs;
+    std::forward_list<NodeData> data;
+    std::forward_list<TensorData> tensors;
 };
 
 }

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -551,23 +551,17 @@ void GridGlobal::beginConstruction(){
         values.resize(num_outputs, 0);
     }
 }
-void GridGlobal::getCandidateConstructionPoints(std::vector<double> &x){
+void GridGlobal::getCandidateConstructionPoints(std::vector<double> &x, const std::vector<int> &level_limits){
     dynamic_values->clearTesnors(); // clear old tensors
     MultiIndexSet init_tensors;
     dynamic_values->getInitialTensors(init_tensors); // get the initial tensors (created with make grid)
-    Data2D<int> tens;
-    tens.resize(num_dimensions, 0);
-    for(int i=0; i<tensors.getNumIndexes(); i++){ // add the new tensors (so long as they are not included in the initial grid)
-        const int *t = tensors.getIndex(i);
-        std::vector<int> kid(t, t + num_dimensions);
-        for(auto &k : kid){
-            k++;
-            if (init_tensors.missing(kid) && tensors.missing(kid)) tens.appendStrip(kid);
-            k--;
-        }
+
+    MultiIndexSet new_tensors;
+    if (level_limits.empty()){
+        MultiIndexManipulations::addExclusiveChildren<false>(tensors, init_tensors, level_limits, new_tensors);
+    }else{
+        MultiIndexManipulations::addExclusiveChildren<true>(tensors, init_tensors, level_limits, new_tensors);
     }
-    MultiIndexSet new_tensors(num_dimensions); // set of new tensors
-    new_tensors.addData2D(tens);
 
     if (!new_tensors.empty()){
         int max_level;

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -551,6 +551,15 @@ void GridGlobal::beginConstruction(){
         values.resize(num_outputs, 0);
     }
 }
+void GridGlobal::getCandidateConstructionPoints(TypeDepth type, int output, std::vector<double> &x, const std::vector<int> &level_limits){
+    std::vector<int> weights;
+    if ((type == type_iptotal) || (type == type_ipcurved) || (type == type_qptotal) || (type == type_qpcurved)){
+        int min_needed_points = ((type == type_ipcurved) || (type == type_qpcurved)) ? 4 * num_dimensions : 2 * num_dimensions;
+        if (points.getNumIndexes() > min_needed_points) // if there are enough points to estimate coefficients
+            estimateAnisotropicCoefficients(type, output, weights);
+    }
+    getCandidateConstructionPoints(type, weights, x, level_limits);
+}
 void GridGlobal::getCandidateConstructionPoints(TypeDepth type, const std::vector<int> &weights, std::vector<double> &x, const std::vector<int> &level_limits){
     std::vector<int> proper_weights = weights;
     std::vector<double> curved_weights;

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -115,6 +115,7 @@ public:
 
     void beginConstruction();
     void getCandidateConstructionPoints(TypeDepth type, const std::vector<int> &weights, std::vector<double> &x, const std::vector<int> &level_limits);
+    void getCandidateConstructionPoints(TypeDepth type, int output, std::vector<double> &x, const std::vector<int> &level_limits);
     void getCandidateConstructionPoints(std::function<double(const int *)> getTensorWeight, std::vector<double> &x, const std::vector<int> &level_limits);
     void loadConstructedPoint(const double x[], const std::vector<double> &y);
     void finishConstruction();

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -114,7 +114,7 @@ public:
     void mergeRefinement();
 
     void beginConstruction();
-    void getCandidateConstructionPoints(std::vector<double> &x);
+    void getCandidateConstructionPoints(std::vector<double> &x, const std::vector<int> &level_limits);
     void loadConstructedPoint(const double x[], const std::vector<double> &y);
     void finishConstruction();
 

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -113,6 +113,11 @@ public:
     void clearRefinement();
     void mergeRefinement();
 
+    void beginConstruction();
+    void getCandidateConstructionPoints(std::vector<double> &x);
+    void loadConstructedPoint(const double x[], const std::vector<double> &y);
+    void finishConstruction();
+
     void evaluateHierarchicalFunctions(const double x[], int num_x, double y[]) const;
     void setHierarchicalCoefficients(const double c[], TypeAcceleration acc);
 
@@ -136,6 +141,9 @@ protected:
     void proposeUpdatedTensors();
     void acceptUpdatedTensors();
     void getPolynomialSpace(bool interpolation, MultiIndexSet &polynomial_set) const;
+
+    void mapIndexesToNodes(const std::vector<int> *indexes, double *x) const;
+    void loadConstructedTensors();
 
 private:
     int num_dimensions, num_outputs;

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -32,6 +32,7 @@
 #define __TASMANIAN_SPARSE_GRID_GLOBAL_HPP
 
 #include <cstdlib>
+#include <memory>
 
 #include "tsgEnumerates.hpp"
 #include "tsgIndexSets.hpp"
@@ -160,6 +161,8 @@ private:
     std::vector<int> updated_active_w;
 
     CustomTabulated custom;
+
+    std::unique_ptr<DynamicConstructorDataGlobal> dynamic_values;
 
     #ifdef Tasmanian_ENABLE_CUDA
     mutable LinearAlgebraEngineGPU cuda_engine;

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -40,6 +40,7 @@
 #include "tsgLinearSolvers.hpp"
 #include "tsgCacheLagrange.hpp"
 #include "tsgOneDimensionalWrapper.hpp"
+#include "tsgDConstructGridGlobal.hpp"
 #include "tsgGridCore.hpp"
 
 #include "tsgAcceleratedDataStructures.hpp"

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -114,7 +114,8 @@ public:
     void mergeRefinement();
 
     void beginConstruction();
-    void getCandidateConstructionPoints(std::vector<double> &x, const std::vector<int> &level_limits);
+    void getCandidateConstructionPoints(TypeDepth type, const std::vector<int> &weights, std::vector<double> &x, const std::vector<int> &level_limits);
+    void getCandidateConstructionPoints(std::function<double(const int *)> getTensorWeight, std::vector<double> &x, const std::vector<int> &level_limits);
     void loadConstructedPoint(const double x[], const std::vector<double> &y);
     void finishConstruction();
 

--- a/SparseGrids/tsgIndexManipulator.hpp
+++ b/SparseGrids/tsgIndexManipulator.hpp
@@ -454,6 +454,37 @@ void createActiveTensors(const MultiIndexSet &mset, const std::vector<int> &weig
 //! \brief For a set of **tensors** compute the corresponding polynomial **space** assuming the 1D rules have given **exactness**
 //! \ingroup TasmanianMultiIndexManipulations
 void createPolynomialSpace(const MultiIndexSet &tensors, std::function<int(int)> exactness, MultiIndexSet &space);
+
+//! \internal
+//! \brief For a set of \b tensors create an \b mset that contain the children of indexes in \b tensors that are missing from \b exclude and obey the \b level_limits.
+//! \ingroup TasmanianMultiIndexManipulations
+template<bool limited>
+void addExclusiveChildren(const MultiIndexSet &tensors, const MultiIndexSet &exclude, const std::vector<int> level_limits, MultiIndexSet &mset){
+    int num_dimensions = tensors.getNumDimensions();
+    Data2D<int> tens;
+    tens.resize(num_dimensions, 0);
+    for(int i=0; i<tensors.getNumIndexes(); i++){ // add the new tensors (so long as they are not included in the initial grid)
+        const int *t = tensors.getIndex(i);
+        std::vector<int> kid(t, t + num_dimensions);
+        auto ilimit = level_limits.begin();
+        for(auto &k : kid){
+            k++;
+            if (exclude.missing(kid) && tensors.missing(kid)){
+                if (limited){
+                    if ((*ilimit == -1) || (k <= *ilimit))
+                        tens.appendStrip(kid);
+                    ilimit++;
+                }else{
+                    tens.appendStrip(kid);
+                }
+            }
+            k--;
+        }
+    }
+    mset.setNumDimensions(num_dimensions); // set of new tensors
+    mset.addData2D(tens);
+}
+
 }
 
 }

--- a/SparseGrids/tsgIndexSets.cpp
+++ b/SparseGrids/tsgIndexSets.cpp
@@ -176,8 +176,8 @@ void MultiIndexSet::addUnsortedInsexes(const std::vector<int> &addition){
 }
 
 int MultiIndexSet::getSlot(const int *p) const{
-    size_t sstart = 0, send = (size_t)(cache_num_indexes - 1);
-    size_t current = (sstart + send) / 2;
+    int sstart = 0, send = cache_num_indexes - 1;
+    int current = (sstart + send) / 2;
     while (sstart <= send){
         TypeIndexRelation t = [&](const int *a, const int *b) ->
             TypeIndexRelation{
@@ -186,13 +186,13 @@ int MultiIndexSet::getSlot(const int *p) const{
                     if (a[j] > b[j]) return type_bbeforea;
                 }
                 return type_asameb;
-            }(&(indexes[current * num_dimensions]), p);
+            }(&(indexes[(size_t) current * num_dimensions]), p);
         if (t == type_abeforeb){
             sstart = current+1;
         }else if (t == type_bbeforea){
             send = current-1;
         }else{
-            return (int) current;
+            return current;
         };
         current = (sstart + send) / 2;
     }


### PR DESCRIPTION
Implemented a dynamic construction procedure for global grids.
* construction must be explicitly initiated
* a new set of nodes can be requested at any time similar to get `getNeeded()` but the points will be ordered according in descending order in terms of contribution to the overall accuracy (according to anisotropic quasi-optimal estimate)
* the points can be given to Tasmanian in any arbitrary order and one point at a time, the grid will be updated on the fly
* a new updated and reordered list of points can be requested regardless whether the current set has been loaded or not
* the dynamic procedure does not interfere with evaluate
* construction must be explicitly finalized, at which point the grid works just as before
