### PR TITLE
updating cxx standard to the new cmake way

### DIFF
--- a/Config/CMakeLists.examples.txt
+++ b/Config/CMakeLists.examples.txt
@@ -30,9 +30,6 @@ add_executable(example_dream         example_dream_01.cpp
                                      example_dream_03.cpp
                                      example_dream.cpp)
 
-set_property(TARGET example_sparse_grids PROPERTY CXX_STANDARD 11)
-set_property(TARGET example_dream        PROPERTY CXX_STANDARD 11)
-
 target_link_libraries(example_sparse_grids  Tasmanian_libsparsegrid)
 target_link_libraries(example_dream         Tasmanian_libdream)
 

--- a/DREAM/CMakeLists.txt
+++ b/DREAM/CMakeLists.txt
@@ -32,8 +32,6 @@ target_include_directories(${Tasmanian_libtdr_target_name} PUBLIC $<BUILD_INTERF
 
 set_target_properties(${Tasmanian_libtdr_target_name} PROPERTIES OUTPUT_NAME "tasmaniandream")
 
-set_property(TARGET ${Tasmanian_libtdr_target_name} PROPERTY CXX_STANDARD 11)
-
 ########################################################################
 # Option setup
 ########################################################################
@@ -79,9 +77,6 @@ add_executable(Tasmanian_example_dream Examples/example_dream_01.cpp
                                        Examples/example_dream_02.cpp
                                        Examples/example_dream_03.cpp
                                        Examples/example_dream.cpp)
-
-set_property(TARGET Tasmanian_dreamtest     PROPERTY CXX_STANDARD 11)
-set_property(TARGET Tasmanian_example_dream PROPERTY CXX_STANDARD 11)
 
 set_target_properties(Tasmanian_dreamtest     PROPERTIES OUTPUT_NAME "dreamtest")
 set_target_properties(Tasmanian_example_dream PROPERTIES OUTPUT_NAME "example_dream")

--- a/SparseGrids/CMakeLists.txt
+++ b/SparseGrids/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(${Tasmanian_libtsg_target_name} PUBLIC $<BUILD_INTERF
 
 set_target_properties(${Tasmanian_libtsg_target_name} PROPERTIES OUTPUT_NAME "tasmaniansparsegrid")
 
-set_property(TARGET ${Tasmanian_libtsg_target_name} PROPERTY CXX_STANDARD 11)
+target_compile_features(${Tasmanian_libtsg_target_name} PUBLIC cxx_std_11)
 
 # as MAGMA potentially depends on OpenMP, BLAS, and CuBLAS, it should be set first
 if (Tasmanian_ENABLE_MAGMA)
@@ -145,10 +145,6 @@ add_executable(Tasmanian_gridtest gridtest_main.cpp
                                   tasgridUnitTests.cpp
                                   tasgridTestInterfaceC.cpp)
 add_executable(Tasmanian_example_sparse_grids Examples/example_sparse_grids.cpp)
-
-set_property(TARGET Tasmanian_tasgrid              PROPERTY CXX_STANDARD 11)
-set_property(TARGET Tasmanian_gridtest             PROPERTY CXX_STANDARD 11)
-set_property(TARGET Tasmanian_example_sparse_grids PROPERTY CXX_STANDARD 11)
 
 set_target_properties(Tasmanian_tasgrid PROPERTIES OUTPUT_NAME "tasgrid")
 set_target_properties(Tasmanian_gridtest PROPERTIES OUTPUT_NAME "gridtest")


### PR DESCRIPTION
* C++11 standard is set in a new way in CMake post 3.8 (old way doesn't propagate transitively)