### PR TITLE
More dependency cleanup

### DIFF
--- a/Config/CMakeIncludes/sanity_check_and_xsdk.cmake
+++ b/Config/CMakeIncludes/sanity_check_and_xsdk.cmake
@@ -70,7 +70,7 @@ endif()
 if (Tasmanian_ENABLE_OPENMP OR Tasmanian_ENABLE_RECOMMENDED)
     find_package(OpenMP)
 
-    if ((NOT OPENMP_FOUND) AND (NOT OPENMP_CXX_FOUND)) # OPENMP_FOUND is used prior to cmake 3.9
+    if (NOT OPENMP_CXX_FOUND)
         if (Tasmanian_ENABLE_RECOMMENDED)
             set(Tasmanian_ENABLE_OPENMP OFF)
             message(STATUS "Tasmanian could not find OpenMP, the library will run in single-threaded mode")

--- a/Doxygen/CMakeLists.txt
+++ b/Doxygen/CMakeLists.txt
@@ -7,6 +7,9 @@ set(DOXYGEN_SORT_GROUP_NAMES    "NO") # use the order in the source files (logic
 set(DOXYGEN_SORT_MEMBER_DOCS    "NO") # use the order in the source files (logical order)
 
 set(DOXYGEN_PREDEFINED "__TASMANIAN_DOXYGEN_SKIP") # indicate sections to skip from documentation
+if (Tasmanian_ENABLE_CUDA)
+    list(APPEND DOXYGEN_PREDEFINED "Tasmanian_ENABLE_CUDA")
+endif()
 
 set(DOXYGEN_HTML_EXTRA_STYLESHEET  ${CMAKE_CURRENT_SOURCE_DIR}/tasmanian.css)
 set(DOXYGEN_HTML_COLORSTYLE_HUE    "110") # green-ish pages
@@ -34,6 +37,7 @@ doxygen_add_docs(Tasmanian_doxygen
                  Doxygen/Installation.md
                  DREAM/TasmanianDREAM.hpp
                  SparseGrids/tsgEnumerates.hpp
+                 SparseGrids/tsgAcceleratedDataStructures.hpp
                  SparseGrids/tsgIOHelpers.hpp
                  SparseGrids/tsgIndexManipulator.hpp
                  SparseGrids/tsgIndexSets.hpp

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -906,7 +906,7 @@ void TasmanianSparseGrid::formTransformedPoints(int num_points, double x[]) cons
 }
 
 #ifdef Tasmanian_ENABLE_CUDA
-const double* TasmanianSparseGrid::formCanonicalPointsGPU(const double *gpu_x, int num_x, cudaDoubles &gpu_x_temp) const{
+const double* TasmanianSparseGrid::formCanonicalPointsGPU(const double *gpu_x, int num_x, CudaVector<double> &gpu_x_temp) const{
     if (domain_transform_a.size() != 0){
         if (acc_domain.empty()) acc_domain.load(domain_transform_a, domain_transform_b);
         acc_domain.getCanonicalPoints(isFourier(), gpu_x, num_x, gpu_x_temp);
@@ -1159,7 +1159,7 @@ void TasmanianSparseGrid::evaluateHierarchicalFunctions(const std::vector<double
 #ifdef Tasmanian_ENABLE_CUDA
 void TasmanianSparseGrid::evaluateHierarchicalFunctionsGPU(const double gpu_x[], int cpu_num_x, double gpu_y[]) const{
     _TASMANIAN_SETGPU
-    cudaDoubles gpu_temp_x;
+    CudaVector<double> gpu_temp_x;
     const double *gpu_canonical_x = formCanonicalPointsGPU(gpu_x, cpu_num_x, gpu_temp_x);
     if (isLocalPolynomial()){
         getGridLocalPolynomial()->buildDenseBasisMatrixGPU(gpu_canonical_x, cpu_num_x, gpu_y);
@@ -1171,7 +1171,7 @@ void TasmanianSparseGrid::evaluateHierarchicalFunctionsGPU(const double gpu_x[],
 }
 void TasmanianSparseGrid::evaluateSparseHierarchicalFunctionsGPU(const double gpu_x[], int cpu_num_x, int* &gpu_pntr, int* &gpu_indx, double* &gpu_vals, int &num_nz) const{
     _TASMANIAN_SETGPU
-    cudaDoubles gpu_temp_x;
+    CudaVector<double> gpu_temp_x;
     const double *gpu_canonical_x = formCanonicalPointsGPU(gpu_x, cpu_num_x, gpu_temp_x);
     getGridLocalPolynomial()->buildSparseBasisMatrixGPU(gpu_canonical_x, cpu_num_x, gpu_pntr, gpu_indx, gpu_vals, num_nz);
 }

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -36,10 +36,8 @@
 
 #include "TasmanianSparseGrid.hpp"
 
-#include "tsgCudaMacros.hpp"
-
 #ifdef Tasmanian_ENABLE_CUDA
-#define _TASMANIAN_SETGPU cudaSetDevice(gpuID);
+#define _TASMANIAN_SETGPU AccelerationMeta::setDefaultCudaDevice(gpuID);
 #else
 #define _TASMANIAN_SETGPU
 #endif // defined
@@ -1773,9 +1771,7 @@ int TasmanianSparseGrid::getGPUID() const{ return gpuID; }
 
 int TasmanianSparseGrid::getNumGPUs(){
     #ifdef Tasmanian_ENABLE_CUDA
-    int gpu_count = 0;
-    cudaGetDeviceCount(&gpu_count);
-    return gpu_count;
+    return AccelerationMeta::getNumCudaDevices();
     #else
     return 0;
     #endif // Tasmanian_ENABLE_CUDA
@@ -1783,32 +1779,11 @@ int TasmanianSparseGrid::getNumGPUs(){
 
 #ifdef Tasmanian_ENABLE_CUDA
 int TasmanianSparseGrid::getGPUMemory(int gpu){
-    if (gpu < 0) return 0;
-    int gpu_count = 0;
-    cudaGetDeviceCount(&gpu_count);
-    if (gpu >= gpu_count) return 0;
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, gpu);
-    unsigned long long memB = prop.totalGlobalMem;
-    return (int) (memB / 1048576);
+    if ((gpu < 0) || (gpu >= AccelerationMeta::getNumCudaDevices())) return 0;
+    return (int) (AccelerationMeta::getTotalGPUMemory(gpu) / 1048576);
 }
 char* TasmanianSparseGrid::getGPUName(int gpu){
-    char *name = new char[1];
-    name[0] = '\0';
-    if (gpu < 0) return name;
-    int gpu_count = 0;
-    cudaGetDeviceCount(&gpu_count);
-    if (gpu >= gpu_count) return name;
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, gpu);
-
-    int c = 0; while(prop.name[c] != '\0'){ c++; }
-    delete[] name;
-    name = new char[c+1];
-    for(int i=0; i<c; i++){ name[i] = prop.name[i]; }
-    name[c] = '\0';
-
-    return name;
+    return AccelerationMeta::getCudaDeviceName(gpu);
 }
 #else
 int TasmanianSparseGrid::getGPUMemory(int){ return 0; }

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -267,7 +267,7 @@ protected:
 
     const double* formCanonicalPoints(const double *x, Data2D<double> &x_temp, int num_x) const;
     #ifdef Tasmanian_ENABLE_CUDA
-    const double* formCanonicalPointsGPU(const double *gpu_x, int num_x, cudaDoubles &gpu_x_temp) const;
+    const double* formCanonicalPointsGPU(const double *gpu_x, int num_x, CudaVector<double> &gpu_x_temp) const;
     #endif
     void formTransformedPoints(int num_points, double x[]) const; // when calling get***Points()
 

--- a/SparseGrids/tasgridExternalTests.cpp
+++ b/SparseGrids/tasgridExternalTests.cpp
@@ -1766,7 +1766,7 @@ bool ExternalTester::testGPU2GPUevaluations() const{
         for(int gpuID=gpu_index_first; gpuID < gpu_end_gpus; gpuID++){
             bool dense_pass = true;
 
-            cudaSetDevice(gpuID);
+            TasGrid::AccelerationMeta::setDefaultCudaDevice(gpuID);
             double *gpux = TasGrid::TasCUDA::cudaSend<double>(xt);
             double *gpuy = TasGrid::TasCUDA::cudaNew<double>(grid.getNumPoints() * nump);
 
@@ -1857,7 +1857,7 @@ bool ExternalTester::testGPU2GPUevaluations() const{
 
     for(int gpuID=gpu_index_first; gpuID < gpu_end_gpus; gpuID++){
         grid.makeSequenceGrid(dims, 0, 20, type_level, rule_rleja);
-        cudaSetDevice(gpuID);
+        TasGrid::AccelerationMeta::setDefaultCudaDevice(gpuID);
         grid.enableAcceleration(TasGrid::accel_gpu_cuda);
         grid.setGPUID(gpuID);
 
@@ -1902,7 +1902,7 @@ bool ExternalTester::testGPU2GPUevaluations() const{
     for(int gpuID=gpu_index_first; gpuID < gpu_end_gpus; gpuID++){
         grid.makeFourierGrid(dims, 0, 5, type_level);
         grid.setDomainTransform(a, b);
-        cudaSetDevice(gpuID);
+        TasGrid::AccelerationMeta::setDefaultCudaDevice(gpuID);
         grid.enableAcceleration(TasGrid::accel_gpu_cuda);
         grid.setGPUID(gpuID);
 

--- a/SparseGrids/tasgridUnitTests.cpp
+++ b/SparseGrids/tasgridUnitTests.cpp
@@ -465,14 +465,6 @@ bool GridUnitTester::testCoverUnimportant(){
     std::vector<TypeOneDRule> rules = {rule_none, rule_clenshawcurtis, rule_clenshawcurtis0, rule_chebyshev, rule_chebyshevodd, rule_gausslegendre, rule_gausslegendreodd, rule_gausspatterson, rule_leja, rule_lejaodd, rule_rleja, rule_rlejadouble2, rule_rlejadouble4, rule_rlejaodd, rule_rlejashifted, rule_rlejashiftedeven, rule_rlejashifteddouble, rule_maxlebesgue, rule_maxlebesgueodd, rule_minlebesgue, rule_minlebesgueodd, rule_mindelta, rule_mindeltaodd, rule_gausschebyshev1, rule_gausschebyshev1odd, rule_gausschebyshev2, rule_gausschebyshev2odd, rule_fejer2, rule_gaussgegenbauer, rule_gaussgegenbauerodd, rule_gaussjacobi, rule_gaussjacobiodd, rule_gausslaguerre, rule_gausslaguerreodd, rule_gausshermite, rule_gausshermiteodd, rule_customtabulated, rule_localp, rule_localp0, rule_semilocalp, rule_localpb, rule_wavelet, rule_fourier};
     for(auto r : rules) str = OneDimensionalMeta::getHumanString(r);
 
-    if (!AccelerationMeta::isAccTypeFullMemoryGPU(accel_gpu_default)){
-        cout << "ERROR: mismatch in isAccTypeFullMemoryGPU(accel_gpu_default)" << endl;
-        return false;
-    }
-    if (AccelerationMeta::isAccTypeFullMemoryGPU(accel_cpu_blas)){
-        cout << "ERROR: mismatch in isAccTypeFullMemoryGPU(accel_cpu_blas)" << endl;
-        return false;
-    }
     if (!AccelerationMeta::isAccTypeGPU(accel_gpu_default)){
         cout << "ERROR: mismatch in isAccTypeFullMemoryGPU()" << endl;
         return false;

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -401,16 +401,6 @@ TypeAcceleration AccelerationMeta::getIOIntAcceleration(int accel){
         default: return accel_none;
     }
 }
-bool AccelerationMeta::isAccTypeFullMemoryGPU(TypeAcceleration accel){
-    switch (accel){
-        case accel_gpu_default:
-        case accel_gpu_cublas:
-        case accel_gpu_cuda:
-        case accel_gpu_magma: return true;
-        default:
-            return false;
-    }
-}
 bool AccelerationMeta::isAccTypeGPU(TypeAcceleration accel){
     switch (accel){
         case accel_gpu_default:

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -539,9 +539,17 @@ void AccelerationMeta::cusparseCheckError(void *cusparseStatus, const char *info
 void AccelerationMeta::setDefaultCudaDevice(int deviceID){
     cudaSetDevice(deviceID);
 }
+template<typename T> void AccelerationMeta::recvCudaArray(size_t num_entries, const T *gpu_data, std::vector<T> &cpu_data){
+    cpu_data.resize(num_entries);
+    cudaError_t cudaStat = cudaMemcpy(cpu_data.data(), gpu_data, num_entries * sizeof(T), cudaMemcpyDeviceToHost);
+    AccelerationMeta::cudaCheckError((void*) &cudaStat, "cudaRecv(type, type)");
+}
 template<typename T> void AccelerationMeta::delCudaArray(T *x){
     TasCUDA::cudaDel<T>(x);
 }
+
+template void AccelerationMeta::recvCudaArray<double>(size_t num_entries, const double*, std::vector<double>&);
+template void AccelerationMeta::recvCudaArray<int>(size_t num_entries, const int*, std::vector<int>&);
 
 template void AccelerationMeta::delCudaArray<double>(double*);
 template void AccelerationMeta::delCudaArray<int>(int*);

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -127,8 +127,8 @@ void cudaDoubles::eject(double* &destination){
 }
 
 template<typename T> void CudaVector<T>::resize(size_t count){
-    if (count != num_entries){
-        clear();
+    if (count != num_entries){ // if the current array is not big enough
+        clear(); // resets dynamic_mode
         num_entries = count;
         cudaError_t cudaStat = cudaMalloc(((void**) &gpu_data), num_entries * sizeof(T));
         AccelerationMeta::cudaCheckError((void*) &cudaStat, "CudaVector::resize(), call to cudaMalloc()");
@@ -136,12 +136,12 @@ template<typename T> void CudaVector<T>::resize(size_t count){
 }
 template<typename T> void CudaVector<T>::clear(){
     num_entries = 0;
-    if (dynamic_mode && (gpu_data != nullptr)){
+    if (dynamic_mode && (gpu_data != nullptr)){ // if I own the data and the data is not null
         cudaError_t cudaStat = cudaFree(gpu_data);
         AccelerationMeta::cudaCheckError((void*) &cudaStat, "CudaVector::clear(), call to cudaFree()");
     }
     gpu_data = nullptr;
-    dynamic_mode = true;
+    dynamic_mode = true; // The old data is gone and I own the current (null) data
 }
 template<typename T> void CudaVector<T>::load(size_t count, const T* cpu_data){
     resize(count);

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -126,7 +126,7 @@ void cudaDoubles::eject(double* &destination){
     num = 0;
 }
 
-template<typename T> void cudaVector<T>::resize(size_t count){
+template<typename T> void CudaVector<T>::resize(size_t count){
     if (count != num_entries){
         clear();
         dynamic_mode = true;
@@ -134,30 +134,30 @@ template<typename T> void cudaVector<T>::resize(size_t count){
         gpu_data = TasCUDA::cudaNew<T>(count);
     }
 }
-template<typename T> void cudaVector<T>::clear(){
+template<typename T> void CudaVector<T>::clear(){
     num_entries = 0;
     if (dynamic_mode && (gpu_data != nullptr))
         TasCUDA::cudaDel<T>(gpu_data);
     gpu_data = nullptr;
     dynamic_mode = true;
 }
-template<typename T> void cudaVector<T>::load(size_t count, const T* cpu_data){
+template<typename T> void CudaVector<T>::load(size_t count, const T* cpu_data){
     resize(count);
     TasCUDA::cudaSend<T>(num_entries, cpu_data, gpu_data);
 }
-template<typename T> void cudaVector<T>::unload(T* cpu_data) const{
+template<typename T> void CudaVector<T>::unload(T* cpu_data) const{
     TasCUDA::cudaRecv<T>(num_entries, gpu_data, cpu_data);
 }
 
-template void cudaVector<double>::resize(size_t);
-template void cudaVector<double>::clear();
-template void cudaVector<double>::load(size_t, const double*);
-template void cudaVector<double>::unload(double*) const;
+template void CudaVector<double>::resize(size_t);
+template void CudaVector<double>::clear();
+template void CudaVector<double>::load(size_t, const double*);
+template void CudaVector<double>::unload(double*) const;
 
-template void cudaVector<int>::resize(size_t);
-template void cudaVector<int>::clear();
-template void cudaVector<int>::load(size_t, const int*);
-template void cudaVector<int>::unload(int*) const;
+template void CudaVector<int>::resize(size_t);
+template void CudaVector<int>::clear();
+template void CudaVector<int>::load(size_t, const int*);
+template void CudaVector<int>::unload(int*) const;
 
 LinearAlgebraEngineGPU::LinearAlgebraEngineGPU() : cublasHandle(0), cusparseHandle(0)
 #ifdef Tasmanian_ENABLE_MAGMA

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -539,6 +539,12 @@ void AccelerationMeta::cusparseCheckError(void *cusparseStatus, const char *info
 void AccelerationMeta::setDefaultCudaDevice(int deviceID){
     cudaSetDevice(deviceID);
 }
+template<typename T> void AccelerationMeta::delCudaArray(T *x){
+    TasCUDA::cudaDel<T>(x);
+}
+
+template void AccelerationMeta::delCudaArray<double>(double*);
+template void AccelerationMeta::delCudaArray<int>(int*);
 #endif // Tasmanian_ENABLE_CUDA
 
 

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -503,6 +503,9 @@ void AccelerationMeta::cusparseCheckError(void *cusparseStatus, const char *info
         throw std::runtime_error(message);
     }
 }
+void AccelerationMeta::setDefaultCudaDevice(int deviceID){
+    cudaSetDevice(deviceID);
+}
 #endif // Tasmanian_ENABLE_CUDA
 
 

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -536,8 +536,33 @@ void AccelerationMeta::cusparseCheckError(void *cusparseStatus, const char *info
         throw std::runtime_error(message);
     }
 }
+int AccelerationMeta::getNumCudaDevices(){
+    int gpu_count = 0;
+    cudaGetDeviceCount(&gpu_count);
+    return gpu_count;
+}
 void AccelerationMeta::setDefaultCudaDevice(int deviceID){
     cudaSetDevice(deviceID);
+}
+unsigned long long AccelerationMeta::getTotalGPUMemory(int deviceID){
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, deviceID);
+    return prop.totalGlobalMem;
+}
+char* AccelerationMeta::getCudaDeviceName(int deviceID){
+    char *name = new char[1];
+    name[0] = '\0';
+    if ((deviceID < 0) || (deviceID >= getNumCudaDevices())) return name;
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, deviceID);
+
+    int c = 0; while(prop.name[c] != '\0'){ c++; }
+    delete[] name;
+    name = new char[c+1];
+    for(int i=0; i<c; i++){ name[i] = prop.name[i]; }
+    name[c] = '\0';
+
+    return name;
 }
 template<typename T> void AccelerationMeta::recvCudaArray(size_t num_entries, const T *gpu_data, std::vector<T> &cpu_data){
     cpu_data.resize(num_entries);

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -262,7 +262,10 @@ namespace AccelerationMeta{
 
     TypeAcceleration getAvailableFallback(TypeAcceleration accel);
 
+    int getNumCudaDevices();
     void setDefaultCudaDevice(int deviceID);
+    unsigned long long getTotalGPUMemory(int deviceID);
+    char* getCudaDeviceName(int deviceID);
     template<typename T> void recvCudaArray(size_t num_entries, const T *gpu_data, std::vector<T> &cpu_data);
     template<typename T> void delCudaArray(T *x);
 }

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -89,13 +89,13 @@ private:
 };
 
 template<typename T>
-class cudaVector{
+class CudaVector{
 public:
-    cudaVector() : num_entries(0), dynamic_mode(true), gpu_data(nullptr){}
-    cudaVector(size_t count) : num_entries(0), dynamic_mode(true), gpu_data(nullptr){ resize(count); }
-    cudaVector(int a, int b) : num_entries(0), dynamic_mode(true), gpu_data(nullptr){ resize(((size_t) a) * ((size_t) b)); }
-    cudaVector(const std::vector<T> &x) : num_entries(0), dynamic_mode(true), gpu_data(nullptr){ load(x); }
-    ~cudaVector(){ clear(); }
+    CudaVector() : num_entries(0), dynamic_mode(true), gpu_data(nullptr){}
+    CudaVector(size_t count) : num_entries(0), dynamic_mode(true), gpu_data(nullptr){ resize(count); }
+    CudaVector(int a, int b) : num_entries(0), dynamic_mode(true), gpu_data(nullptr){ resize(((size_t) a) * ((size_t) b)); }
+    CudaVector(const std::vector<T> &x) : num_entries(0), dynamic_mode(true), gpu_data(nullptr){ load(x); }
+    ~CudaVector(){ clear(); }
 
     size_t size() const{ return num_entries; }
     T* data(){ return gpu_data; }

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -282,20 +282,37 @@ private:
 };
 #endif
 
-// stores domain transforms, to be used by the top class TasmanianSparseGrid
+//! \internal
+//! \brief Implements the domain transform algorithms in case the user data is provided on the GPU.
+//! \ingroup TasmanianAcceleration
+
+//! Takes the upper and lower bounds of a hypercube and transforms the user provided points to the canonical domain (-1, 1) or (0, 1).
+//! The transformation is done on the GPU to avoid extraneous data movement.
+//!
+//! \b Note: Conformal mapping and the non-linear Gauss-Hermite and Gauss-Laguerre transforms are not supported.
 class AccelerationDomainTransform{
 public:
+    //! \brief Default constructor, the object cannot be used until \b load() is called.
     AccelerationDomainTransform();
+    //! \brief Destructor, clear all loaded data.
     ~AccelerationDomainTransform();
 
+    //! \brief Clear the transform (if loaded), used when the grid is reset of \b clearDomainTransform() is called.
     void clear();
+    //! \brief Return \b false if \b load() has already been called.
     bool empty();
+    //! \brief Load the transform data to the GPU, the vectors are the same as used in the \b TasmanianSparseGrid class.
     void load(const std::vector<double> &transform_a, const std::vector<double> &transform_b);
-    void getCanonicalPoints(bool use01, const double *gpu_transformed_x, int num_x, cudaDoubles &gpu_canonical_x);
+    //! \brief Transform a set of points, used in the calls to \b evaluateHierarchicalFunctionsGPU()
+
+    //! Takes the user provided \b gpu_transformed_x points of dimension matching the grid num_dimensions and total number \b num_x.
+    //! The \b gpu_canonical_x is resized to match \b gpu_transformed_x and it loaded with the corresponding canonical points.
+    //! The \b use01 flag indicates whether to use canonical domain (0, 1) (Fourier grids), or (-1, 1) (almost everything else).
+    void getCanonicalPoints(bool use01, const double *gpu_transformed_x, int num_x, CudaVector<double> &gpu_canonical_x);
 
 private:
     // these actually store the rate and shift and not the hard upper/lower limits
-    cudaDoubles gpu_trans_a, gpu_trans_b;
+    CudaVector<double> gpu_trans_a, gpu_trans_b;
     int num_dimensions, padded_size;
 };
 #endif

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -263,6 +263,7 @@ namespace AccelerationMeta{
     TypeAcceleration getAvailableFallback(TypeAcceleration accel);
 
     void setDefaultCudaDevice(int deviceID);
+    template<typename T> void recvCudaArray(size_t num_entries, const T *gpu_data, std::vector<T> &cpu_data);
     template<typename T> void delCudaArray(T *x);
 }
 

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -353,22 +353,76 @@ namespace TasCUDA{
 }
 #endif
 
-// generic error checking function and types I/O
+//! \internal
+//! \brief Common methods for manipulating acceleration options and reading CUDA environment properties.
+//! \ingroup TasmanianAcceleration
 namespace AccelerationMeta{
+    //! \internal
+    //! \brief Convert the string (coming from C or Python) into an enumerated type.
+    //! \ingroup TasmanianAcceleration
     TypeAcceleration getIOAccelerationString(const char * name);
+    //! \internal
+    //! \brief Convert the enumerated type to a string, the inverse of \b getIOAccelerationString()
+    //! \ingroup TasmanianAcceleration
     const char* getIOAccelerationString(TypeAcceleration accel);
+    //! \internal
+    //! \brief Convert the integer (coming from Fortran) into an enumerated type.
+    //! \ingroup TasmanianAcceleration
     int getIOAccelerationInt(TypeAcceleration accel);
+    //! \internal
+    //! \brief Convert the enumerated type to an integer, the inverse of \b getIOAccelerationInt()
+    //! \ingroup TasmanianAcceleration
     TypeAcceleration getIOIntAcceleration(int accel);
-    bool isAccTypeFullMemoryGPU(TypeAcceleration accel);
+    //! \internal
+    //! \brief Returns \b true if \b accele is cuda, cublas or magma.
+    //! \ingroup TasmanianAcceleration
     bool isAccTypeGPU(TypeAcceleration accel);
 
+    //! \internal
+    //! \brief Implements fallback logic, if \b accel has been enabled through CMake then this returns \b accel, otherwise it returns the "next-best-thing".
+    //! \ingroup TasmanianAcceleration
+
+    //! This function always returns a valid acceleration type.
+    //! The fallback logic is documented with the enumerated type \b TasGrid::TypeAcceleration.
     TypeAcceleration getAvailableFallback(TypeAcceleration accel);
 
+    //! \internal
+    //! \brief Return the number of visible CUDA devices, uses cudaGetDeviceCount() (see the Nvidia documentation).
+    //! \ingroup TasmanianAcceleration
     int getNumCudaDevices();
+
+    //! \internal
+    //! \brief Selects the active device for this CPU thread using cudaSetDevice() (see the Nvidia documentation).
+    //! \ingroup TasmanianAcceleration
+
+    //! The \b deviceID must be a valid ID (between 0 and getNumCudaDevices() -1).
     void setDefaultCudaDevice(int deviceID);
+
+    //! \internal
+    //! \brief Return the memory available in the device (in units of bytes), uses cudaGetDeviceProperties() (see the Nvidia documentation).
+    //! \ingroup TasmanianAcceleration
+
+    //! The \b deviceID must be a valid ID (between 0 and getNumCudaDevices() -1).
     unsigned long long getTotalGPUMemory(int deviceID);
+
+    //! \internal
+    //! \brief Return a character array that is a copy of the CUDA device name, uses cudaGetDeviceProperties() (see the Nvidia documentation).
+    //! \ingroup TasmanianAcceleration
+
+    //! The \b deviceID must be a valid ID (between 0 and getNumCudaDevices() -1).
+    //! The character array has to be manually deleted to avoid memory leaks.
+    //! This causes issues between different versions of CUDA, Nvidia uses fixed length character arrays and Tasmanian makes a copy;
+    //! sometimes different versions of CUDA use different name length which causes unexpected crashes on the CUDA side.
     char* getCudaDeviceName(int deviceID);
+
+    //! \internal
+    //! \brief Copy a device array to the main memory, used for testing only, always favor using \b CudaVector (if possible).
+    //! \ingroup TasmanianAcceleration
     template<typename T> void recvCudaArray(size_t num_entries, const T *gpu_data, std::vector<T> &cpu_data);
+
+    //! \internal
+    //! \brief Deallocate  device array, used primarily for testing, always favor using \b CudaVector (if possible).
+    //! \ingroup TasmanianAcceleration
     template<typename T> void delCudaArray(T *x);
 }
 

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -88,6 +88,47 @@ private:
     double *gpu_data;
 };
 
+template<typename T>
+class cudaVector{
+public:
+    cudaVector() : num_entries(0), dynamic_mode(true), gpu_data(nullptr){}
+    cudaVector(size_t count) : num_entries(0), dynamic_mode(true), gpu_data(nullptr){ resize(count); }
+    cudaVector(int a, int b) : num_entries(0), dynamic_mode(true), gpu_data(nullptr){ resize(((size_t) a) * ((size_t) b)); }
+    cudaVector(const std::vector<T> &x) : num_entries(0), dynamic_mode(true), gpu_data(nullptr){ load(x); }
+    ~cudaVector(){ clear(); }
+
+    size_t size() const{ return num_entries; }
+    T* data(){ return gpu_data; }
+    const T* data() const{ return gpu_data; }
+
+    void resize(size_t count);
+    void clear();
+
+    void load(const std::vector<T> &cpu_data){ load(cpu_data.size(), cpu_data.data()); }
+    void load(size_t count, const T* cpu_data);
+    void unload(std::vector<T> &cpu_data) const{
+        cpu_data.resize(num_entries);
+        unload(cpu_data.data());
+    }
+    void unload(T* cpu_data) const;
+
+    void eject(T* &external){
+        external = gpu_data;
+        gpu_data = nullptr; num_entries = 0;
+        dynamic_mode = true;
+    }
+    void wrap(size_t count, T* external){
+        gpu_data = external;
+        num_entries = count;
+        dynamic_mode = false;
+    }
+
+private:
+    size_t num_entries;
+    bool dynamic_mode; // was the memory allocated or wrapped aroun an exiting object
+    T *gpu_data;
+};
+
 
 class LinearAlgebraEngineGPU{
 public:

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -220,6 +220,8 @@ namespace AccelerationMeta{
     bool isAccTypeGPU(TypeAcceleration accel);
 
     TypeAcceleration getAvailableFallback(TypeAcceleration accel);
+
+    void setDefaultCudaDevice(int deviceID);
 }
 
 }

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -263,6 +263,7 @@ namespace AccelerationMeta{
     TypeAcceleration getAvailableFallback(TypeAcceleration accel);
 
     void setDefaultCudaDevice(int deviceID);
+    template<typename T> void delCudaArray(T *x);
 }
 
 }


### PR DESCRIPTION
* Found a way to template the CudaVector while still hiding the CUDA API calls and thus removing the need to transitively include the CUDA headers
* The transitive inclusion of the CUDA headers creates havoc with CMake "CUDA as a language"
* Documented the API updates and the remaining useful acceleration methods and classes
* Updated the tests and domain transforms to use the cleaner CudaVectors templates