### PR TITLE
merge the dogygen groups into sub-groups and add numerous fixes

### DIFF
--- a/DREAM/Examples/example_dream.cpp
+++ b/DREAM/Examples/example_dream.cpp
@@ -15,7 +15,7 @@
 //! The header will include all files needed by the DREAM module including
 //! the TasmanianSparseGrid.hpp header.
 
-//! \defgroup TasmanianDREAMExamples Examples for the Tasmanian DREAM module.
+//! \defgroup TasmanianDREAMExamples Examples for the Tasmanian DREAM module
 //!
 //! Several examples are included that demonstrate the proper usage of the DREAM interface.
 //! The examples include random sampling from an arbitrary probability distribution,

--- a/DREAM/Examples/example_dream_01.cpp
+++ b/DREAM/Examples/example_dream_01.cpp
@@ -14,11 +14,14 @@ using namespace std;
 //!
 //! Tasmanian DREAM Example 1
 
-//! \defgroup TasmanianDREAMExamples1 Tasmanian DREAM module, example 1.
-//!
-//! Example 1:
-//! Demonstrates how to make a custom probability distribution and use Tasmanian DREAM
-//! to generate random samples.
+/*!
+ * \ingroup TasmanianDREAMExamples
+ * \addtogroup TasmanianDREAMExamples1 Tasmanian DREAM module, example 1
+ *
+ * Example 1:
+ * Demonstrates how to make a custom probability distribution and use Tasmanian DREAM
+ * to generate random samples.
+ */
 
 //! \brief DREAM Example 1: sample from a custom defined probability distribution.
 //! \ingroup TasmanianDREAMExamples1

--- a/DREAM/Examples/example_dream_02.cpp
+++ b/DREAM/Examples/example_dream_02.cpp
@@ -14,11 +14,14 @@ using namespace std;
 //!
 //! Tasmanian DREAM Example 2
 
-//! \defgroup TasmanianDREAMExamples2 Tasmanian DREAM module, example 2.
-//!
-//! Example 2:
-//! Demonstrates how to solve a Bayesian inference problem for parameter calibration
-//! using a sparse grid approximation to the Bayesian likelihood function.
+/*!
+ * \ingroup TasmanianDREAMExamples
+ * \addtogroup TasmanianDREAMExamples2 Tasmanian DREAM module, example 2
+ *
+ * Example 2:
+ * Demonstrates how to solve a Bayesian inference problem for parameter calibration
+ * using a sparse grid approximation to the Bayesian likelihood function.
+ */
 
 //! \brief DREAM Example 2: perform parameter calibration using likelihood that is approximated with a sparse grid.
 //! \ingroup TasmanianDREAMExamples2

--- a/DREAM/Examples/example_dream_03.cpp
+++ b/DREAM/Examples/example_dream_03.cpp
@@ -14,13 +14,16 @@ using namespace std;
 //!
 //! Tasmanian DREAM Example 3
 
-//! \defgroup TasmanianDREAMExamples3 Tasmanian DREAM module, example 3.
-//!
-//! Example 3:
-//! Given data that is the superposition of two sin-waves,
-//! use Sparse Grid and Bayesian inference to identify the frequencies and shifts of each wave.
-//! Higher dimensions and bi-modal posterior will decrease the acceptance rate,
-//! thus we need more samples than the previous example.
+/*!
+ * \ingroup TasmanianDREAMExamples
+ * \addtogroup TasmanianDREAMExamples3 Tasmanian DREAM module, example 3
+ *
+ * Example 3:
+ * Given data that is the superposition of two sin-waves,
+ * use Sparse Grid and Bayesian inference to identify the frequencies and shifts of each wave.
+ * Higher dimensions and bi-modal posterior will decrease the acceptance rate,
+ * thus we need more samples than the previous example.
+ */
 
 //! \brief DREAM Example 3: signal decomposition, using bi-modal posterior distribution.
 //! \ingroup TasmanianDREAMExamples3

--- a/DREAM/Examples/example_dream_04.cpp
+++ b/DREAM/Examples/example_dream_04.cpp
@@ -14,13 +14,16 @@ using namespace std;
 //!
 //! Tasmanian DREAM Example 4
 
-//! \defgroup TasmanianDREAMExamples4 Tasmanian DREAM module, example 4.
-//!
-//! Example 4:
-//! Given data that is the superposition of two exponential curves,
-//! use Sparse Grid and Bayesian inference to identify the rate and scale of each wave.
-//! Higher dimensions and bi-modal posterior will decrease the acceptance rate,
-//! thus we need more samples than the previous example.
+/*!
+ * \ingroup TasmanianDREAMExamples
+ * \addtogroup TasmanianDREAMExamples4 Tasmanian DREAM module, example 4
+ *
+ * Example 4:
+ * Given data that is the superposition of two sin-waves,
+ * use Sparse Grid and Bayesian inference to identify the frequencies and shifts of each wave.
+ * Higher dimensions and bi-modal posterior will decrease the acceptance rate,
+ * thus we need more samples than the previous example.
+ */
 
 //! \brief DREAM Example 4: signal decomposition, using bi-modal posterior distribution.
 //! \ingroup TasmanianDREAMExamples4

--- a/DREAM/TasmanianDREAM.hpp
+++ b/DREAM/TasmanianDREAM.hpp
@@ -50,7 +50,7 @@
 //! The header will include all files needed by the DREAM module including
 //! the TasmanianSparseGrid.hpp header.
 
-//! \defgroup TasmanianDREAM DREAM: DiffeRential Evolution Adaptive Metropolis.
+//! \defgroup TasmanianDREAM DREAM: DiffeRential Evolution Adaptive Metropolis
 //!
 //! \par DREAM
 //! DiffeRential Evolution Adaptive Metropolis ...

--- a/DREAM/tsgDreamCorePDF.hpp
+++ b/DREAM/tsgDreamCorePDF.hpp
@@ -36,7 +36,7 @@
 namespace TasDREAM{
 
 //! \brief Returns the unscaled probability density of \b distribution (defined by \b params) at the point \b x.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMPDF
 
 //! Variadric template that defines different one dimensional probability density function.
 //! Each function is defined by the \b distribution type and a set of parameters \b params,

--- a/DREAM/tsgDreamCoreRandom.hpp
+++ b/DREAM/tsgDreamCoreRandom.hpp
@@ -39,19 +39,27 @@
 //!
 //! Implements several methods for random sampling and defines specific probability density functions.
 
+/*!
+ * \ingroup TasmanianDREAM
+ * \addtogroup DREAMPDF Probability distributions, analytic formulas and sampling algorithms
+ *
+ * Contains the analytic definitions of several probability distributions
+ * and algorithms to draw samples from several known distributions.
+ */
+
 #include <math.h>
 
 namespace TasDREAM{
 
 //! \internal
 //! \brief Default random sampler, using \b rand() divided by \b RAND_MAX
-//! \ingroup TasmanianDREAM
-    
+//! \ingroup DREAMPDF
+
 //! Generates random numbers uniformly distributed in (0, 1), uses the \b rand() command.
 inline double tsgCoreUniform01(){ return ((double) rand()) / ((double) RAND_MAX); }
 
 //! \brief Add a correction to every entry in \b x, use uniform samples over (-\b magnitude, \b magnitude).
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMPDF
 
 //! The function \b get_random01() returns random numbers distributed over (0, 1).
 inline void applyUniformUpdate(std::vector<double> &x, double magnitude, std::function<double(void)> get_random01 = tsgCoreUniform01){
@@ -60,7 +68,7 @@ inline void applyUniformUpdate(std::vector<double> &x, double magnitude, std::fu
 }
 
 //! \brief  Add a correction to every entry in \b x, sue Gaussian distribution with zero mean and standard deviation equal to \b magnitude.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMPDF
 
 //! The function \b get_random01() returns random numbers distributed over (0, 1).
 //! Gaussian numbers are generated using the Box-Muller algorithm.
@@ -81,7 +89,7 @@ inline void applyGaussianUpdate(std::vector<double> &x, double magnitude, std::f
 }
 
 //! \brief Generate uniform random samples in the hypercube defined by \b lower and \b upper limits.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMPDF
 
 //! The size of the \b lower and \b upper must match.
 //! The output vector \b x will be resized to match \b num_samples times \b upper.size(), and the values will be overwritten.
@@ -90,10 +98,10 @@ inline void genUniformSamples(const std::vector<double> &lower, const std::vecto
     if (lower.size() != upper.size()) throw std::runtime_error("ERROR: genUniformSamples() requires lower and upper vectors with matching size.");
     if (x.size() != lower.size() * num_samples) x.resize(lower.size() * num_samples);
     for(auto &v : x) v = get_random01();
-    
+
     std::vector<double> length(lower.size());
     std::transform(lower.begin(), lower.end(), upper.begin(), length.begin(), [&](double l, double u)->double{ return (u - l); });
-    
+
     auto ix = x.begin();
     while(ix != x.end()){
         auto ilow = lower.begin();
@@ -105,7 +113,7 @@ inline void genUniformSamples(const std::vector<double> &lower, const std::vecto
 }
 
 //! \brief Generate standard normal samples with given \b means and standard \b deviations.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMPDF
 
 //! Generate Gaussian (normal) vectors with given means and standard deviations.
 //! The \b means and \b deviations must have the same size.
@@ -113,10 +121,10 @@ inline void genUniformSamples(const std::vector<double> &lower, const std::vecto
 inline void genGaussianSamples(const std::vector<double> &means, const std::vector<double> &deviations, int num_samples, std::vector<double> &x, std::function<double(void)> get_random01 = tsgCoreUniform01){
     if (means.size() != deviations.size()) throw std::runtime_error("ERROR: genGaussianSamples() means and deviations vectors must have the same size.");
     if (x.size() != means.size() * num_samples) x.resize(means.size() * num_samples);
-    
+
     std::fill_n(x.data(), x.size(), 0.0);
     applyGaussianUpdate(x, 1.0, get_random01);
-    
+
     auto ix = x.begin();
     while(ix != x.end()){
         auto im = means.begin();

--- a/DREAM/tsgDreamEnumerates.hpp
+++ b/DREAM/tsgDreamEnumerates.hpp
@@ -33,10 +33,27 @@
 
 #include "TasmanianConfig.hpp"
 
+/*!
+ * \file tsgDreamEnumerates.hpp
+ * \brief The enumerated types used in the DREAM module.
+ * \author Miroslav Stoyanov
+ * \ingroup TasmanianDREAM
+ *
+ * Defines the enumerated types used throughout the DREAM module.
+ * The file is included in every other DREAM header.
+ */
+
+/*!
+ * \ingroup TasmanianDREAM
+ * \addtogroup DREAMEnumerates Enumerated types
+ *
+ * The Enumerate types used in the external and internal API of the DREAM module.
+ */
+
 namespace TasDREAM{
 
 //! \brief Describes whether sampling should be done with the regular or logarithm form of the probability density.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMEnumerates
 
 //! Probability distributions with very localized support will have values close to zero over most of the sampling domain.
 //! Sampling using the logarithm of the probability density can be more stable, when operations with very small numbers cause problems.
@@ -50,7 +67,7 @@ enum TypeSamplingForm{
 };
 
 //! \brief Indicates a specific probability distribution for the associated function.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMEnumerates
 
 //! Used to instantiate the \b getDensity() variadric template. See the template documentation for the specific formulas.
 enum TypeDistribution{

--- a/DREAM/tsgDreamInternalBlas.hpp
+++ b/DREAM/tsgDreamInternalBlas.hpp
@@ -31,6 +31,27 @@
 #ifndef __TASMANIAN_DREAM_INTERNAL_BLAS_HPP
 #define __TASMANIAN_DREAM_INTERNAL_BLAS_HPP
 
+/*!
+ * \internal
+ * \file tsgDreamInternalBlas.hpp
+ * \brief C++ inline functions that make calls to BLAS.
+ * \author Miroslav Stoyanov
+ * \ingroup TasmanianDREAM
+ *
+ * Wrappers that provide C++ API to BLAS-Fortran calls.
+ */
+
+/*!
+ * \internal
+ * \ingroup TasmanianDREAM
+ * \addtogroup DREAMBLAS C++ to BLAS wrappers
+ *
+ * Defined several inline functions that provde C++ wrappers for BLAS,
+ * specifically translation is provided for the vector vs raw pointer
+ * and the pass-by-value vs pass-by-reference API.
+ * \endinternal
+ */
+
 #ifndef __TASMANIAN_DOXYGEN_SKIP
 // avoiding including BLAS headers, use the standard to define the functions, only the BLAS library is needed without include directories
 #ifdef Tasmanian_ENABLE_BLAS
@@ -49,7 +70,7 @@ namespace TasBLAS{
 #ifdef Tasmanian_ENABLE_BLAS
 //! \internal
 //! \brief Wrapper to BLAS 2-norm
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMBLAS
 inline double dnrm2squared(int N, const double x[]){
     int ione = 1;
     double nrm = dnrm2_(&N, x, &ione);
@@ -58,7 +79,7 @@ inline double dnrm2squared(int N, const double x[]){
 
 //! \internal
 //! \brief Wrapper to BLAS matrix-vector product, \b y = \b alpha * \b A-transpose * \b x + \b beta * \b y
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMBLAS
 inline void dgemtv(int M, int N, const double A[], const double x[], double y[], double alpha = 1.0, double beta = 0.0){ // y = A*x, A is M by N
     char charT = 'T'; int blas_one = 1;
     dgemv_(&charT, &M, &N, &alpha, A, &M, x, &blas_one, &beta, y, &blas_one);

--- a/DREAM/tsgDreamLikelihoodCore.hpp
+++ b/DREAM/tsgDreamLikelihoodCore.hpp
@@ -40,10 +40,17 @@
 //!
 //! Defines the TasmanianLikelihood class which implements the relation between model outputs and measurement data.
 
+/*!
+ * \ingroup TasmanianDREAM
+ * \addtogroup DREAMLikelihood Likelihood definitions
+ *
+ * Classes that define the likelihood relation between an observed data and a model output.
+ */
+
 namespace TasDREAM{
 
 //! \brief Interface for the likelihood classes.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMLikelihood
 
 //! \par Likelihood
 //! In the framework of Bayesian inference the likelihood is a measure of how likely is a specific outcome (i.e., model output), given some observed data.

--- a/DREAM/tsgDreamLikelyGaussian.hpp
+++ b/DREAM/tsgDreamLikelyGaussian.hpp
@@ -47,7 +47,7 @@
 namespace TasDREAM{
 
 //! \brief Implements likelihood under the assumption of isotropic white noise.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMLikelihood
 
 //! \par Gaussian Likelihood
 //! The general formula for Gaussian likelihood is \f$ L(y | d_1 \cdots d_n) = \exp\left( 0.5 sum_{i=1}^n (y - d_i)^T \Sigma^{-1} (y - d_i) \right)\f$

--- a/DREAM/tsgDreamSample.hpp
+++ b/DREAM/tsgDreamSample.hpp
@@ -45,11 +45,29 @@
 //!
 //! Defines the core MCMC template for sampling from an arbitrarily defined unscaled probability density.
 
+/*!
+ * \internal
+ * \ingroup TasmanianDREAM
+ * \addtogroup DREAMAux Macros and Simall Auxilary functions
+ *
+ * Several mactos and one-two line function to simplify the work-flow.
+ * \endinternal
+ */
+
+/*!
+ * \ingroup TasmanianDREAM
+ * \addtogroup DREAMSampleCore Level 1 DREAM templates, sampling from a user defined distribution
+ *
+ * Level 1 templates use a custom propability distribution defined wither with a \b lambda.
+ * There is no assumption whether the distribution is associated with a Bayesian
+ * inference problem or a completely different context.
+ */
+
 namespace TasDREAM{
 
 //! \internal
 //! \brief Checks if vectors with names \b lower and \b upper have the same size as the dimensions in TasmanianDREAM \b state.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMAux
 
 //! Throws \b runtime_error if the size of vectors \b lower and \b upper does not match \b state.getNumDimensions().
 //! Does not compile if the variables do not exit.
@@ -59,7 +77,7 @@ namespace TasDREAM{
 
 //! \internal
 //! \brief Make a lambda that matches the \b inside signature in \b SampleDREAM() and the vector x is in the hyperbube described by \b lower and \b upper.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMAux
 
 //! Assumes two vectors \b lower and \b upper are defined and creates a lambda using \b inHypercube().
 #define __TASDREAM_HYPERCUBE_DOMAIN \
@@ -67,7 +85,7 @@ namespace TasDREAM{
 
 //! \internal
 //! \brief Returns \b true if the entries in \b x obey the \b lower and \b upper values (sizes must match, does not check).
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMAux
 
 //! The three vectors \b lower, \b upper and \b x must have the same size,
 //! returns \b true if every entry of \b x lies between the \b lower and \b upper boundaries.
@@ -79,13 +97,13 @@ inline bool inHypercube(const std::vector<double> &lower, const std::vector<doub
 
 //! \internal
 //! \brief Dummy function that returns 1.0, used as default for the \b differential_update() in \b SampleDREAM().
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMAux
 
 //! Just an inline function that returns 1.0.
 inline double const_one(){ return 1.0; }
 
 //! \brief Template that returns a constant based on the percentage, i.e., \b weight_percent / 100.0
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleCore
 
 //! The template simplifies the syntax when calling \b SampleDREAM() with a constant differential update.
 //! For example, setting the update to 0.5 can be done with
@@ -97,14 +115,14 @@ template<int weight_percent>
 double const_percent(){ return ((double) weight_percent) / 100.0; }
 
 //! \brief Uniform prior distribution for both regular and log form.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleCore
 
 //! Applies uniform (non-informative) prior, can be used with any of the Bayesian inference methods.
 //! In practice, this is no-op, since adding zero (in \b logform) or mulitplying by 1 (in \b regform) amounts to nothing.
 inline void uniform_prior(const std::vector<double> &, std::vector<double> &values){ values.clear(); }
 
 //! \brief Core template for the sampling algorithm, usually called through any of the overloads.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleCore
 
 //! Evolves the chains of the \b state using the Metropolis algorithm where the updates are comprised of two components, independent and differential.
 //! The independent component relies on independently sampled (pesudo)-random numbers with zero mean and could also be constant zero.
@@ -230,7 +248,7 @@ void SampleDREAM(int num_burnup, int num_collect,
 
 
 //! \brief Overload of \b SampleDREAM() assuming independent update from a list of internals.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleCore
 
 //! Uses independent update is applied uniformly to all dimensions and comes from a list of internal functions, e.g., uniform or Gaussian.
 //! This overload wraps around functions such as \b applyUniformCorrection() and \b applyGaussianCorrection().
@@ -253,7 +271,7 @@ void SampleDREAM(int num_burnup, int num_collect,
 
 
 //! \brief Overload of \b SampleDREAM() assuming the domain is a hyperbube with min/max values given by \b lower and \b upper.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleCore
 
 //! The two vectors \b lower and \b upper must have the same size as the dimensions of the state
 //! and the lower/upper limits of the internals are stores in the corresponding entries.
@@ -271,7 +289,7 @@ void SampleDREAM(int num_burnup, int num_collect,
 
 
 //! \brief Overload of \b SampleDREAM() assuming the domain is a hyperbube and independent update is from a known list.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleCore
 
 //! The two vectors \b lower and \b upper must have the same size as the dimensions of the state
 //! and the lower/upper limits of the internals are stores in the corresponding entries.

--- a/DREAM/tsgDreamSampleGrid.hpp
+++ b/DREAM/tsgDreamSampleGrid.hpp
@@ -45,11 +45,21 @@
 //!
 //! Defines the templates and overloads for sampling a posterior distribution using a likelihood defined by a sparse grid approximation.
 
+/*!
+ * \ingroup TasmanianDREAM
+ * \addtogroup DREAMSampleGrid Level 2 DREAM templates, sampling using a sparse grids likelihood
+ *
+ * Level 2 templates assume sampling from a posterior distribution (i.e., Bayesian inference),
+ * where the likelihood is approximated using a Sparse Grid.
+ * Note that using \b uniform_prior() effectively samples from a sparse grids approximated
+ * probability distribution, and hence the templates have a whider potential usage.
+ */
+
 namespace TasDREAM{
 
 //! \internal
 //! \brief Macro creating a \b lambda for the probability distribution combining a sparse grid and a prior.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMAux
 
 //! The same \b lambda function is used for multiple overloads, so long as the variable names match, this will work.
 //! The variable names must match, in order to have consistency anyway. Specifically,
@@ -72,7 +82,7 @@ namespace TasDREAM{
 
 //! \internal
 //! \brief Macro that checks if \b grid and \b state have the same number of dimensions.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMAux
 
 //! Throws runtime_error if \b grid and \b state have different number of dimensions.
 #define __TASDREAM_CHECK_GRID_STATE_DIMS \
@@ -80,7 +90,7 @@ namespace TasDREAM{
 
 //! \internal
 //! \brief Extract the \b grid rule and domain.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMAux
 
 //! Extract the \b grid rule and domain.
 #define __TASDREAM_GRID_EXTRACT_RULE \
@@ -90,14 +100,14 @@ namespace TasDREAM{
 
 //! \internal
 //! \brief Get the Gauss-Hermite lambda.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMAux
 
 //! Get the Gauss-Hermite lambda.
 #define __TASDREAM_GRID_DOMAIN_GHLAMBDA [&](const std::vector<double> &)->bool{ return true; }
 
 //! \internal
 //! \brief Get the Gauss-Laguerre lambda.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMAux
 
 //! Get the Gauss-Laguerre lambda.
 #define __TASDREAM_GRID_DOMAIN_GLLAMBDA [&](const std::vector<double> &x)->bool{ \
@@ -107,7 +117,7 @@ namespace TasDREAM{
 
 //! \internal
 //! \brief Get the default transform weights.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMAux
 
 //! Get the default transform weights.
 #define __TASDREAM_GRID_DOMAIN_DEFAULTS \
@@ -118,7 +128,7 @@ namespace TasDREAM{
 
 
 //! \brief Variation of \b SampleDREAM() which assumes a Bayesian inference problem with likelihood approximated by a sparse grid.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleGrid
 
 //! The inputs are identical to the ones defined in \b SampleDREAM(), with \b probability_distribution() replaced by the combination of sparse grid and \b prior.
 //! The values obtained from the grid are multiplied (or incremented in \b logform) with the values from the prior.
@@ -140,7 +150,7 @@ void SampleDREAMGrid(int num_burnup, int num_collect,
 
 
 //! \brief Overload of \b SampleDREAMGrid() assuming the domain is a hyperbube with min/max values given by \b lower and \b upper.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleGrid
 
 //! See the overloads of \b SampleDREAM() regarding the vectors \b lower and \b upper.
 template<TypeSamplingForm form = regform>
@@ -158,7 +168,7 @@ void SampleDREAMGrid(int num_burnup, int num_collect,
 
 
 //! \brief Overload of \b SampleDREAMGrid() assuming the domain matches the sparse grid domain.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleGrid
 
 //! Grid constructed using a Gauss-Hermite rule will use the entire real plane as domain, the \b inside() function is always true.
 //! The Gauss-Laguerre rule is bounded from below, but not above.
@@ -186,7 +196,7 @@ void SampleDREAMGrid(int num_burnup, int num_collect,
 
 
 //! \brief Overload of \b SampleDREAMGrid() assuming independent update from a list of internals.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleGrid
 
 //! See the overloads of \b SampleDREAM() regarding the known updates.
 template<TypeSamplingForm form = regform>
@@ -203,7 +213,7 @@ void SampleDREAMGrid(int num_burnup, int num_collect,
 
 
 //! \brief Overload of \b SampleDREAMGrid() assuming hypercube domain and independent update from a list of internals.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleGrid
 
 //! See the overloads of \b SampleDREAM() regarding the known updates and the \b lower and \b upper vectors.
 template<TypeSamplingForm form = regform>
@@ -220,7 +230,7 @@ void SampleDREAMGrid(int num_burnup, int num_collect,
 
 
 //! \brief Overload of \b SampleDREAMGrid() assuming independent update from a list of internals and domain matching the grid.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleGrid
 
 //! See other overloads for details.
 template<TypeSamplingForm form = regform>

--- a/DREAM/tsgDreamSamplePosterior.hpp
+++ b/DREAM/tsgDreamSamplePosterior.hpp
@@ -46,11 +46,21 @@
 //!
 //! Defines the DREAM template for sampling from a posterior distribution.
 
+/*!
+ * \ingroup TasmanianDREAM
+ * \addtogroup DREAMSampleModel Level 3 DREAM templates, sampling a posterior from a user provided model
+ *
+ * Level 3 templates assume sampling from a posterior distribution composed of
+ * a \b TasDREAM::TasmanianLikelihood, a \b model defined by a user provided \b lambda,
+ * and a \b prior distribution. The likelihood is either one of the Gaussian variations
+ * provided by the user, or a use defined class that inherits from the \b TasDREAM::TasmanianLikelihood.
+ */
+
 namespace TasDREAM{
 
 //! \internal
 //! \brief Macro to create a probability distribution lambda from the model, likelihood and prior.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMAux
 
 //! The same \b lambda function is used for multiple overloads, so long as the variable names match, this will work.
 //! The variable names must match, in order to have consistency anyway. Specifically,
@@ -77,7 +87,7 @@ namespace TasDREAM{
 
 
 //! \brief Variation of \b SampleDREAM() which assumes a Bayesian inference problem with likelihood, model and prior.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleModel
 
 //! The inputs are identical to the ones defined in \b SampleDREAM(), with \b probability_distribution() replaced by the combination of
 //! \b TasmanianLikelihood, a \b model lambda and \b prior.
@@ -104,7 +114,7 @@ void SampleDREAMPost(int num_burnup, int num_collect,
 
 
 //! \brief Overload of \b SampleDREAMPost() that works on a hypercube domain, see the overloads of \b SampleDREAM() for the \b lower and \b upper definition.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleModel
 template<TypeSamplingForm form = regform>
 void SampleDREAMPost(int num_burnup, int num_collect,
                      const TasmanianLikelihood &likelihood,
@@ -120,7 +130,7 @@ void SampleDREAMPost(int num_burnup, int num_collect,
 
 
 //! \brief Overload of \b SampleDREAMPost() that uses independent update from a list of known ones, see the overloads of \b SampleDREAM() for details.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleModel
 template<TypeSamplingForm form = regform>
 void SampleDREAMPost(int num_burnup, int num_collect,
                      const TasmanianLikelihood &likelihood,
@@ -136,7 +146,7 @@ void SampleDREAMPost(int num_burnup, int num_collect,
 
 
 //! \brief Overload of \b SampleDREAMPost() that uses independent update from a list of known ones and operates on a hypercube domain, see the other overloads for details.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMSampleModel
 template<TypeSamplingForm form = regform>
 void SampleDREAMPost(int num_burnup, int num_collect,
                      const TasmanianLikelihood &likelihood,

--- a/DREAM/tsgDreamSamplePosteriorGrid.hpp
+++ b/DREAM/tsgDreamSamplePosteriorGrid.hpp
@@ -48,18 +48,28 @@
 //!
 //! Defines the DREAM template for sampling from a posterior distribution with sparse grid model.
 
+/*!
+ * \ingroup TasmanianDREAM
+ * \addtogroup DREAMGridModel Level 4 DREAM templates, sampling a posterior from a sparse grids model
+ *
+ * Level 4 templates assume sampling from a posterior distribution composed of
+ * a \b TasDREAM::TasmanianLikelihood, a \b TasGrid::TasmanianSparseGrid approximation to the model,
+ * and a \b prior distribution. The likelihood is either one of the Gaussian variations
+ * provided by the user, or a use defined class that inherits from the \b TasDREAM::TasmanianLikelihood.
+ */
+
 namespace TasDREAM{
 
 //! \internal
 //! \brief Macro to create a model lambda from sparse grid.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMAux
 
 //! The same \b lambda function is used for multiple overloads, so long as the spaes grid is called \b grid.
 #define __TASDREAM_LIKELIHOOD_GRID_LIKE [&](const std::vector<double> &candidates, std::vector<double> &values)->void{ grid.evaluateBatch(candidates, values); }
 
 
 //! \brief Overloads of \b SampleDREAMPost() which uses a sparse grid as model.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMGridModel
 
 //! The \b model variable is replaced by the \b grid, see the other overloads for the rest of the variables.
 template<TypeSamplingForm form = regform>
@@ -78,7 +88,7 @@ void SampleDREAMPost(int num_burnup, int num_collect,
 
 
 //! \brief Overloads of \b SampleDREAMPost() which uses a sparse grid as model, domain is a hypercube.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMGridModel
 
 //! The \b model variable is replaced by the \b grid, see the other overloads for the rest of the variables.
 template<TypeSamplingForm form = regform>
@@ -97,7 +107,7 @@ void SampleDREAMPost(int num_burnup, int num_collect,
 
 
 //! \brief Overloads of \b SampleDREAMPost() which uses a sparse grid as model with domain matching the grid.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMGridModel
 
 //! The \b model variable is replaced by the \b grid, see the other overloads for the rest of the variables.
 template<TypeSamplingForm form = regform>
@@ -113,7 +123,7 @@ void SampleDREAMPost(int num_burnup, int num_collect,
     if ((rule == TasGrid::rule_gausshermite) || (rule == TasGrid::rule_gausshermiteodd)){ // unbounded domain
         SampleDREAMPost<form>(num_burnup, num_collect, likelihood, __TASDREAM_LIKELIHOOD_GRID_LIKE, prior, __TASDREAM_GRID_DOMAIN_GHLAMBDA, independent_update, state, differential_update, get_random01);
     }else if ((rule == TasGrid::rule_gausslaguerre) || (rule == TasGrid::rule_gausslaguerreodd)){ // bounded from below
-        SampleDREAMPost<form>(num_burnup, num_collect, likelihood, 
+        SampleDREAMPost<form>(num_burnup, num_collect, likelihood,
                               __TASDREAM_LIKELIHOOD_GRID_LIKE, prior, __TASDREAM_GRID_DOMAIN_GHLAMBDA, independent_update, state, differential_update, get_random01);
     }else{
         __TASDREAM_GRID_DOMAIN_DEFAULTS
@@ -124,7 +134,7 @@ void SampleDREAMPost(int num_burnup, int num_collect,
 
 
 //! \brief Overloads of \b SampleDREAMPost() which uses a sparse grid as model with independent update from known distribution.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMGridModel
 
 //! The \b model variable is replaced by the \b grid, see the other overloads for the rest of the variables.
 template<TypeSamplingForm form = regform>
@@ -137,13 +147,13 @@ void SampleDREAMPost(int num_burnup, int num_collect,
                      TasmanianDREAM &state,
                      std::function<double(void)> differential_update = const_one,
                      std::function<double(void)> get_random01 = tsgCoreUniform01){
-    SampleDREAMPost<form>(num_burnup, num_collect, likelihood, 
+    SampleDREAMPost<form>(num_burnup, num_collect, likelihood,
                           __TASDREAM_LIKELIHOOD_GRID_LIKE, prior, inside, independent_dist, independent_magnitude, state, differential_update, get_random01);
 }
 
 
 //! \brief Overloads of \b SampleDREAMPost() which uses a sparse grid as model with independent update from known distribution and a hypercube.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMGridModel
 
 //! The \b model variable is replaced by the \b grid, see the other overloads for the rest of the variables.
 template<TypeSamplingForm form = regform>
@@ -156,13 +166,13 @@ void SampleDREAMPost(int num_burnup, int num_collect,
                      TasmanianDREAM &state,
                      std::function<double(void)> differential_update = const_one,
                      std::function<double(void)> get_random01 = tsgCoreUniform01){
-    SampleDREAMPost<form>(num_burnup, num_collect, likelihood, 
+    SampleDREAMPost<form>(num_burnup, num_collect, likelihood,
                           __TASDREAM_LIKELIHOOD_GRID_LIKE, prior, lower, upper, independent_dist, independent_magnitude, state, differential_update, get_random01);
 }
 
 
 //! \brief Overload of \b SampleDREAMGrid() assuming independent update from a list of internals and domain matching the grid.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMGridModel
 
 //! See other overloads for details.
 template<TypeSamplingForm form = regform>

--- a/DREAM/tsgDreamState.hpp
+++ b/DREAM/tsgDreamState.hpp
@@ -45,10 +45,18 @@
 //!
 //! Defines the TasmanianDREAM class which stores the history of the MCMC samples.
 
+/*!
+ * \ingroup TasmanianDREAM
+ * \addtogroup DREAMState TasmanianDREAM State
+ *
+ * Keeps the current state of the DREAM chains and stores the history
+ * of a MCMC sampling.
+ */
+
 namespace TasDREAM{
 
 //! \brief Contains the current state and the history of the DREAM chains.
-//! \ingroup TasmanianDREAM
+//! \ingroup DREAMState
 
 //! \par DREAM State
 //! The DREAM state consists of \b num_chains vectors of size \b num_dimensions,

--- a/Doxygen/CMakeLists.txt
+++ b/Doxygen/CMakeLists.txt
@@ -3,8 +3,9 @@ find_package(Doxygen REQUIRED OPTIONAL_COMPONENTS dot)
 set(DOXYGEN_GENERATE_HTML      "YES")
 set(DOXYGEN_DISABLE_INDEX       "NO")
 set(DOXYGEN_GENERATE_TREEVIEW  "YES") # left-hand index
-set(DOXYGEN_SORT_GROUP_NAMES    "NO") # use the order in the source files (logical order)
+set(DOXYGEN_SORT_GROUP_NAMES    "NO") # disable automatic sorting
 set(DOXYGEN_SORT_MEMBER_DOCS    "NO") # use the order in the source files (logical order)
+set(DOXYGEN_SORT_BRIEF_DOCS     "NO") # which is more logical than the alphabetical one
 
 set(DOXYGEN_PREDEFINED "__TASMANIAN_DOXYGEN_SKIP") # indicate sections to skip from the documentation
 if (Tasmanian_ENABLE_BLAS)
@@ -33,19 +34,21 @@ if (NOT DOXYGEN_INTERNAL_DOCS)
 # have to exclude the classes manually
     set(DOXYGEN_EXCLUDE_SYMBOLS TasGrid::Data2D TasGrid::MultiIndexSet TasGrid::StorageSet TasGrid::CustomTabulated TasGrid::OneDimensionalWrapper
         TasGrid::TasSparse::SparseMatrix TasGrid::CudaEngine TasGrid::AccelerationDomainTransform TasGrid::DynamicConstructorDataGlobal
-        TasGrid::NodeData TasGrid::TensorData)
+        TasGrid::NodeData TasGrid::TensorData TasGrid::CacheLagrange)
 endif()
 
 doxygen_add_docs(Tasmanian_doxygen
                  README.md
                  Doxygen/Installation.md
+                 SparseGrids/TasmanianSparseGrid.hpp
                  DREAM/TasmanianDREAM.hpp
                  SparseGrids/tsgEnumerates.hpp
-                 SparseGrids/tsgAcceleratedDataStructures.hpp
-                 SparseGrids/tsgHiddenExternals.hpp
-                 SparseGrids/tsgIOHelpers.hpp
-                 SparseGrids/tsgIndexManipulator.hpp
                  SparseGrids/tsgIndexSets.hpp
+                 SparseGrids/tsgIndexManipulator.hpp
+                 SparseGrids/tsgIOHelpers.hpp
+                 SparseGrids/tsgHiddenExternals.hpp
+                 SparseGrids/tsgAcceleratedDataStructures.hpp
+                 SparseGrids/tsgCacheLagrange.hpp
                  SparseGrids/tsgCoreOneDimensional.hpp
                  SparseGrids/tsgOneDimensionalWrapper.hpp
                  SparseGrids/tsgLinearSolvers.hpp

--- a/Doxygen/Installation.md
+++ b/Doxygen/Installation.md
@@ -12,7 +12,7 @@ Recommended additional features:
 
 Optional features:
 * Acceleration using Nvidia [linear algebra libraries](https://developer.nvidia.com/cublas) and custom [CUDA kernels](https://developer.nvidia.com/cuda-zone)
-* GPU accelerated linear algebra [using UTK MAGMA library](http://icl.cs.utk.edu/magma/)
+* GPU accelerated linear algebra using [UTK MAGMA library](http://icl.cs.utk.edu/magma/)
 * Basic [Python matplotlib](https://matplotlib.org/) support
 * Fully featured [MATLAB/Octave](https://www.gnu.org/software/octave/) interface via wrappers around the command-line tool
 * Fortran 90/95 interface using [gfortran](https://gcc.gnu.org/wiki/GFortran) or [ifort](https://software.intel.com/en-us/intel-compilers)

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -28,6 +28,16 @@
  * IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
  */
 
+/*!
+ * \file TasmanianSparseGrid.hpp
+ * \brief Main header for the Sparse Grid module.
+ * \author Miroslav Stoyanov
+ * \ingroup TasmanianDREAM
+ *
+ * The header needed to access the Tasmanian sparse grids module,
+ * the TasGrid::TasmanianSparseGrids class is defined here.
+ */
+
 #ifndef __TASMANIAN_SPARSE_GRID_HPP
 #define __TASMANIAN_SPARSE_GRID_HPP
 
@@ -43,8 +53,20 @@
 
 #include <iomanip> // only needed for printStats()
 
+/*!
+ * \defgroup TasmanianSG Sparse Grids
+ *
+ * \par Sparse Grids
+ * A family of algorithms for multidimensional integration and interpolation ...
+ */
+
+/*!
+ * \ingroup TasmanianSG
+ * \brief Encapsulates the Tasmanian Sparse Grid module.
+ */
 namespace TasGrid{
 
+#ifndef __TASMANIAN_DOXYGEN_SKIP // suppress Doxygen warnings ... for now
 class TasmanianSparseGrid{
 public:
     TasmanianSparseGrid();
@@ -294,6 +316,7 @@ private:
     mutable AccelerationDomainTransform acc_domain;
     #endif
 };
+#endif // Doxygen skip
 
 }
 

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -48,34 +48,38 @@
 //! the classes allow RAII style of memory management for CUDA GPU arrays,
 //! as well as handy encapsulation of the cuBlas/cuSparse/MAGMA handles and streams.
 
-//! \internal
-//! \defgroup TasmanianAcceleration Classes and functions used for acceleration methods.
-//!
-//! \par RAII Memory Management
-//! CUDA uses C-style of memory management with cudaMalloc(), cudaMemcopy(), cudaFree(),
-//! but templated C++ std::vector-style class is more handy and more fail-safe.
-//! The \b CudaVector template class guards against memory leaks and offers more seamless
-//! integration between CPU and GPU data structures.
-//! See the \b CudaVector documentation for details.
-//!
-//! \par Streams and Handles Encapsulation
-//! CUDA linear algebra libraries (as well as MAGAM), use streams and handles for all their calls.
-//! The handles have to be allocated, deleted, and passed around which causes unnecessary code clutter.
-//! Encapsulating the handles in a single \b CudaEngine class greatly simplifies the work-flow.
-//! Furthermore, some (sparse) linear operations require multiple calls to CUDA/MAGMA libraries,
-//! and it is cleaner to wrap those into a single call to a \b CudaEngine method.
-//!
-//! \par Acceleration Metadata
-//! The \b AccelerationMeta namespace offers several methods used throughout the library and in the testing:
-//! - Tasmanian specific acceleration fallback logic
-//! - Reading CUDA device properties, e.g., number of devices or total memory
-//! - Error handling for common CUDA/cuBlas/cuSparse calls
-//!
-//! \par C++ Wrappers to Fortran BLAS API
-//! The standard BLAS API follows Fortran calling conventions,
-//! e.g., call by value and underscore at the end of function names.
-//! A C++ wrapper is provided that handles Tasmanian specific cases of
-//! dense matrix-matrix and matrix-vector multiplication using C++ compatible API.
+/*!
+ * \internal
+ * \ingroup TasmanianSG
+ * \addtogroup TasmanianAcceleration Classes and functions used for acceleration methods
+ *
+ * \par RAII Memory Management
+ * CUDA uses C-style of memory management with cudaMalloc(), cudaMemcopy(), cudaFree(),
+ * but templated C++ std::vector-style class is far more handy and more fail-safe.
+ * The \b CudaVector template class guards against memory leaks and offers more seamless
+ * integration between CPU and GPU data structures.
+ * See the \b CudaVector documentation for details.
+ *
+ * \par Streams and Handles Encapsulation
+ * CUDA linear algebra libraries (as well as MAGAM), use streams and handles for all their calls.
+ * The handles have to be allocated, deleted, and passed around which causes unnecessary code clutter.
+ * Encapsulating the handles in a single \b CudaEngine class greatly simplifies the work-flow.
+ * Furthermore, some (sparse) linear operations require multiple calls to CUDA/MAGMA libraries,
+ * and it is easier to combine those into a single call to a \b CudaEngine method.
+ *
+ * \par Acceleration Metadata
+ * The \b AccelerationMeta namespace offers several methods used throughout the library and in the testing:
+ * - Tasmanian specific acceleration fallback logic
+ * - Reading CUDA device properties, e.g., number of devices or total memory
+ * - Error handling for common CUDA/cuBlas/cuSparse calls
+ *
+ * \par C++ Wrappers to Fortran BLAS API
+ * The standard BLAS API follows Fortran calling conventions,
+ * e.g., call by value and underscore at the end of function names.
+ * A C++ wrapper is provided that handles Tasmanian specific cases of
+ * dense matrix-matrix and matrix-vector multiplication using C++ compatible API.
+ * \endinternal
+ */
 
 namespace TasGrid{
 

--- a/SparseGrids/tsgCacheLagrange.hpp
+++ b/SparseGrids/tsgCacheLagrange.hpp
@@ -31,15 +31,46 @@
 #ifndef __TSG_CACHE_LAGRANGE_HPP
 #define __TSG_CACHE_LAGRANGE_HPP
 
+/*!
+ * \file tsgCacheLagrange.hpp
+ * \brief Cache data structure for evaluate with Global grids.
+ * \author Miroslav Stoyanov
+ * \ingroup TasmanianAcceleration
+ */
+
 #include "tsgEnumerates.hpp"
 #include "tsgCoreOneDimensional.hpp"
 #include "tsgOneDimensionalWrapper.hpp"
 
 namespace TasGrid{
 
+/*!
+ * \internal
+ * \ingroup TasmanianAcceleration
+ * \brief Cache that holds the values of 1D Lagrange polynomials.
+ *
+ * Global grids have the most complex evaluation procedure,
+ * Lagrange polynomials have to be evaluated for each direction and \em each \em level,
+ * before the weighted sum can be accumulated to compute the values of the basis functions.
+ * The CacheLagrange class computes the values of the Lagrange polynomials
+ * and caches them for easy access.
+ * \endinternal
+ */
 template <typename T>
 class CacheLagrange{
 public:
+    /*!
+     * \brief Constructor that takes into account a single canonical point \b x.
+     *
+     * The cache is constructed for each dimension and each level up to \b max_levels,
+     * the values of the Lagrange polynomials are computed in two passes resulting in O(n) operations.
+     * - \b num_dimensions is the number of dimensions to consider
+     * - \b max_levels indicates how many levels to consider in each direction,
+     *   heavily anisotropic grids require only a few levels for the "less important" directions
+     * - \b rule is the wrapper of the Global grid that contains information about number of points per level
+     *   and the actual nodes with the pre-computed Lagrange coefficients
+     * - \b holds the coordinates of the canonical point to cache
+     */
     CacheLagrange(int num_dimensions, const std::vector<int> &max_levels, const OneDimensionalWrapper *rule, const double x[]){
         cache.resize(num_dimensions);
         offsets = *(rule->getPointsCount());
@@ -65,8 +96,10 @@ public:
             }
         }
     }
+    //! \brief Destructor, clear all used data.
     ~CacheLagrange(){}
 
+    //! \brief Return the Lagrange cache for given \b dimension, \b level and offset local to the level
     T getLagrange(int dimension, int level, int local) const{
         return cache[dimension][offsets[level] + local];
     }

--- a/SparseGrids/tsgCoreOneDimensional.hpp
+++ b/SparseGrids/tsgCoreOneDimensional.hpp
@@ -46,12 +46,16 @@
 //! Contains core information about one dimensional rules, custom tabulated,
 //! Chebyshev and Gaussian rules. Also, generic I/O data.
 
-//! \internal
-//! \defgroup TasmanianCoreOneDimensional Core data for Gauuss, Chebyshev and custom rules.
-//!
-//! \par Core One Dimensional Rules
-//! Contains core information about one dimensional rules, custom tabulated,
-//! Chebyshev and Gaussian rules. Also, generic I/O data.
+/*!
+ * \internal
+ * \ingroup TasmanianSG
+ * \addtogroup TasmanianCoreOneDimensional Core meta-data for Gauuss, Chebyshev and custom rules
+ *
+ * \par Core One Dimensional Rules
+ * Contains information about all one dimensional rules, number of nodes, exactness, IO meta-data.
+ * The CustomTabulated class for managing a user provided rule is also included,
+ * as well as methods for generating Gaussian and Chebyshev nodes and weights.
+ */
 
 namespace TasGrid{
 

--- a/SparseGrids/tsgDConstructGridGlobal.hpp
+++ b/SparseGrids/tsgDConstructGridGlobal.hpp
@@ -37,27 +37,35 @@
 #include "tsgIndexSets.hpp"
 #include "tsgIndexManipulator.hpp"
 
-//! \file tsgDConstructGridGlobal.hpp
-//! \brief Class and data types used for dynamic construction of Global grids.
-//! \author Miroslav Stoyanov
-//! \ingroup TasmanianRefinement
-//!
-//! Defines the storage class and struct types used for
-//! construction of Global grids. The class is more complex than other
-//! examples because rules with growth of more than one point need
-//! to collect several samples before the grid can be extended with another
-//! tensor.
+/*!
+ * \internal
+ * \file tsgDConstructGridGlobal.hpp
+ * \brief Class and data types used for dynamic construction of Global grids.
+ * \author Miroslav Stoyanov
+ * \ingroup TasmanianRefinement
+ *
+ * Defines the storage class and struct types used for
+ * construction of Global grids. The class is more complex than other
+ * examples because rules with growth of more than one point need
+ * to collect several samples before the grid can be extended with another
+ * tensor.
+ * \endinternal
+ */
 
-//! \internal
-//! \defgroup TasmanianRefinement Refinement related classes, structures, and methods.
-//!
-//! \par Adaptive Refinement
-//! The most efficient sparse grids approximation strategies are adaptive,
-//! i.e., the grid is constructed to best capture the behavior of the specific
-//! target model. Adapting a grid requires analysis of the existing loaded
-//! model values followed by a decision on how to best expand the grid.
-//! Sometimes the complexity of the refinement algorithms requires additional
-//! data storage and methods implemented outside of the main grid classes.
+/*!
+ * \internal
+ * \ingroup TasmanianSG
+ * \addtogroup TasmanianRefinement Refinement related classes, structures, and methods
+ *
+ * \par Adaptive Refinement
+ * The most efficient sparse grids approximation strategies are adaptive,
+ * i.e., the grid is constructed to best capture the behavior of the specific
+ * target model. Adapting a grid requires analysis of the existing loaded
+ * model values followed by a decision on how to best expand the grid.
+ * Sometimes the complexity of the refinement algorithms requires additional
+ * data storage and methods implemented outside of the main grid classes.
+ * \endinternal
+ */
 
 namespace TasGrid{
 
@@ -103,11 +111,12 @@ struct TensorData{
     double weight;
 };
 
-//! \internal
-//! \brief Takes a list and creates a vector of references in reversed order, needed for I/O so that read can be followed by push_front.
-//! \ingroup TasmanianRefinement
-
-//! Used to preserve the order of a list upon write and read.
+/*!
+ * \internal
+ * \ingroup TasmanianRefinement
+ * \brief Takes a list and creates a vector of references in reversed order, needed for I/O so that read can be followed by push_front.
+ * \endinternal
+ */
 template <class T>
 void makeReverseReferenceVector(const std::forward_list<T> &list, std::vector<const T*> &refs){
     size_t num_entries = (size_t) std::distance(list.begin(), list.end());
@@ -117,12 +126,12 @@ void makeReverseReferenceVector(const std::forward_list<T> &list, std::vector<co
     while(p != list.end()) *r++ = &*p++;
 }
 
-//! \internal
-//! \brief Writes a NodeData forward_list to a file using the lambdas to write ints and doubles.
-//! \ingroup TasmanianRefinement
-
-//! (Probably over-engineered) uses a template with lambdas to traverse a list and write the
-//! integer and floating point data to a STREAMCONCEPT.
+/*!
+ * \internal
+ * \ingroup TasmanianRefinement
+ * \brief Writes a NodeData std::forward_list to a file using the lambdas to write ints and doubles.
+ * \endinternal
+ */
 template<class STREAMCONCEPT>
 void writeNodeDataList(const std::forward_list<NodeData> &data, STREAMCONCEPT &ofs, std::function<void(int, STREAMCONCEPT &)> write_an_int,
                        std::function<void(const NodeData *, STREAMCONCEPT &)> write_node){
@@ -133,11 +142,12 @@ void writeNodeDataList(const std::forward_list<NodeData> &data, STREAMCONCEPT &o
     for(auto d : data_refs) write_node(d, ofs);
 }
 
-//! \internal
-//! \brief Writes a NodeData forward_list to a file using either binary or ascii format.
-//! \ingroup TasmanianRefinement
-
-//! Wrapper around \b writeNodeDataList() that uses << and write() when dealing with ASCII and binary format.
+/*!
+ * \internal
+ * \ingroup TasmanianRefinement
+ * \brief Writes a NodeData std::forward_list to a file using either binary or ascii format.
+ * \endinternal
+ */
 template<class STREAMCONCEPT, bool useAscii>
 void writeNodeDataList(const std::forward_list<NodeData> &data, STREAMCONCEPT &ofs){
     if (useAscii){
@@ -157,11 +167,12 @@ void writeNodeDataList(const std::forward_list<NodeData> &data, STREAMCONCEPT &o
     }
 }
 
-//! \internal
-//! \brief Reads a NodeData forward_list from a file using either binary or ascii format.
-//! \ingroup TasmanianRefinement
-
-//! The reverse of \b writeNodeDataList(), simply reads the data and preserves the order.
+/*!
+ * \internal
+ * \ingroup TasmanianRefinement
+ * \brief Reads a NodeData std::forward_list from a file using either binary or ascii format.
+ * \endinternal
+ */
 template<class STREAMCONCEPT, bool useAscii>
 void readNodeDataList(int num_dimensions, int num_outputs, STREAMCONCEPT &ifs, std::forward_list<NodeData> &data){
     int num_nodes;

--- a/SparseGrids/tsgEnumerates.hpp
+++ b/SparseGrids/tsgEnumerates.hpp
@@ -48,35 +48,39 @@
 //! This header is included directly or transitively in every other
 //! file of the project including \b TasmanianSparseGrids.hpp
 
-//! \defgroup TasmanianEnumerates Enumerate types.
-//!
-//! \par Enumerated types
-//! Enumerations are used as input to many Tasmanian functions
-//! in both internal and external API.
-//!
-//! \internal
-//! \par Hardcoded constants
-//! Hardcoding constants is a bad coding practice and should be avoided,
-//! but numerical algorithms depend on many small tweaking parameters that require
-//! meaningful default values.
-//! For example, Tasmanian computes the nodes and abscissas of the Gauss-Legendre rule on the fly,
-//! which is done with an iterative eigenvalue decomposition method that needs a stopping criteria.
-//! Extra input parameters can be added to \b makeGlobalGrid() which will allow the user to
-//! choose the numeric tolerance and maximum number of iterations, but this will also
-//! add extra variables that the user has to understand and specify.
-//! The goal of Tasmanian is to provide a seamless experience where the user
-//! focuses on the desired properties of a quadrature/interpolation rule, and not
-//! worry about convergence of a hidden iterative schemes.
-//! Therefore, we hardcoded such variables with \a reasonable value,
-//! i.e., values that will work well for most use cases.
-//! In fringe cases, the values can be adjusted here and Tasmanian can be recompiled
-//! with new constants.
+/*!
+ * \ingroup TasmanianSG
+ * \addtogroup SGEnumerates Enumerated types
+ *
+ * \par Enumerated types
+ * Enumerations are used as input to many Tasmanian functions
+ * in both internal and external API.
+ *
+ * \internal
+ * \par Hardcoded constants
+ * Hardcoding constants is a bad coding practice and should be avoided,
+ * but numerical algorithms depend on many small tweaking parameters that require
+ * meaningful default values.
+ * For example, Tasmanian computes the nodes and abscissas of the Gauss-Legendre rule on the fly,
+ * which is done with an iterative eigenvalue decomposition method that needs a stopping criteria.
+ * Extra input parameters can be added to \b makeGlobalGrid() which will allow the user to
+ * choose the numeric tolerance and maximum number of iterations, but this will also
+ * add extra variables that the user has to understand and specify.
+ * The goal of Tasmanian is to provide a seamless experience where the user
+ * focuses on the desired properties of a quadrature/interpolation rule, and not
+ * worry about convergence of a hidden iterative schemes.
+ * Therefore, we hardcoded such variables with \a reasonable value,
+ * i.e., values that will work well for most use cases.
+ * In fringe cases, the values can be adjusted here and Tasmanian can be recompiled
+ * with new constants.
+ * \endinternal
+ */
 
 namespace TasGrid{
 
 //! \internal
 //! \brief Describes the relation between two multi-indexes when compared during sorting.
-//! \ingroup TasmanianEnumerates
+//! \ingroup SGEnumerates
 
 //! The standard C++11 algorithms std::merge and std::binary_search use bools as return
 //! types when comparing entries, thus in the case of many repeated entries, two
@@ -97,7 +101,7 @@ enum TypeIndexRelation{ // internal for IndexSets, unambiguous set comparison
 };
 
 //! \brief Used by Global Sequence and Fourier grids, indicates the selection criteria.
-//! \ingroup TasmanianEnumerates
+//! \ingroup SGEnumerates
 
 //! \par Approximation Error
 //! The approximation error when interpolating or integrating a target model with
@@ -219,7 +223,7 @@ enum TypeDepth{
 };
 
 //! \brief Used to specify the one dimensional family of rules that induces the sparse grid.
-//! \ingroup TasmanianEnumerates
+//! \ingroup SGEnumerates
 
 //! \par One Dimensional Rules
 //! A sparse grid is a superposition of tensors of one dimensional rules with varying precision
@@ -342,7 +346,7 @@ enum TypeOneDRule{
 };
 
 //! \brief Refinement strategy for local polynomial and wavelet grids.
-//! \ingroup TasmanianEnumerates
+//! \ingroup SGEnumerates
 
 //! \par Local Hierarchical Approximation
 //! The nodes and basis functions used in local polynomial and wavelet sparse grid form a complex multidimensional hierarchy,
@@ -403,7 +407,7 @@ enum TypeRefinement{
 };
 
 //! \brief Types of acceleration for \b TasmanianSparseGrid::evaluateFast() and \b TasmanianSparseGrid::evaluateBatch().
-//! \ingroup TasmanianEnumerates
+//! \ingroup SGEnumerates
 
 //! \par Evaluation Stages
 //! Computing the value of the interpolant at one or more nodes is done in two stages, first a matrix of basis function
@@ -531,7 +535,7 @@ enum TypeAcceleration{
 
 //! \internal
 //! \brief Numerical tolerance for various algorithms.
-//! \ingroup TasmanianEnumerates
+//! \ingroup SGEnumerates
 
 //! NUM_TOL is used in many places:
 //! - as a stopping criteria for various iterative schemes (e.g., finding leja points)
@@ -543,14 +547,14 @@ enum TypeAcceleration{
 
 //! \internal
 //! \brief Defines the maximum number of secant method iterations to be used for finding Leja, Lebesgue, and Delta points.
-//! \ingroup TasmanianEnumerates
+//! \ingroup SGEnumerates
 
 //! This is a simple safeguard criteria to prevent "hanging" in a loop.
 #define TSG_MAX_SECANT_ITERATIONS 1000
 
 //! \internal
 //! \brief Tuning parameter for dense vs sparse evaluations of Local Polynomial Grids when using CPU BLAS.
-//! \ingroup TasmanianEnumerates
+//! \ingroup SGEnumerates
 
 //! Defines the threshold for switching between sparse and dense version of batch evaluate for Local Polynomial Grids.
 //! Generally, because of caching and reuse of data, dense operations have 10x more flops per second than sparse ops;

--- a/SparseGrids/tsgHiddenExternals.hpp
+++ b/SparseGrids/tsgHiddenExternals.hpp
@@ -31,6 +31,16 @@
 #ifndef __TASMANIAN_SPARSE_GRID_HIDDEN_INTERNALS_HPP
 #define __TASMANIAN_SPARSE_GRID_HIDDEN_INTERNALS_HPP
 
+/*!
+ * \file tsgHiddenExternals.hpp
+ * \brief Wrappers to BLAS functionality.
+ * \author Miroslav Stoyanov
+ * \ingroup TasmanianAcceleration
+ *
+ * The header contains a inline wrappers that give C++ style of
+ * interface to BLAS operations.
+ */
+
 #include "TasmanianConfig.hpp"
 
 namespace TasGrid{

--- a/SparseGrids/tsgIOHelpers.hpp
+++ b/SparseGrids/tsgIOHelpers.hpp
@@ -47,8 +47,12 @@
 //! Several templates that simplify the I/O of Tasmanian.
 //! Commonly used operations are lumped into templates with simple binary/ascii switch.
 
-//! \internal
-//! \defgroup TasmanianIO Templates for common I/O methods, simple binary/ascii switch provided for all templates.
+/*!
+ * \internal
+ * \ingroup TasmanianSG
+ * \addtogroup TasmanianIO Templates for common I/O methods, simple binary/ascii switch provided for all templates
+ * \endinternal
+ */
 
 namespace TasGrid{
 

--- a/SparseGrids/tsgIndexManipulator.hpp
+++ b/SparseGrids/tsgIndexManipulator.hpp
@@ -52,15 +52,19 @@
 //! normalization of anisotropic weights, map parents and children within a set (which
 //! generates a DAG structure), complete a set to satisfy the lower-property, etc.
 
-//! \internal
-//! \defgroup TasmanianMultiIndexManipulations Multi-Index manipulation algorithms.
-//!
-//! \par Multi-Index manipulation algorithms
-//! A series of templates, lambda, and regular functions that allow the manipulation of
-//! multi-indexes and sets of multi-indexes. The algorithms include the selection of
-//! multi-indexes according to a criteria, union of a vector of multi-index sets,
-//! normalization of anisotropic weights, map parents and children within a set (which
-//! generates a DAG structure), complete a set to satisfy the lower-property, etc.
+/*!
+ * \internal
+ * \ingroup TasmanianSG
+ * \addtogroup TasmanianMultiIndexManipulations Multi-Index manipulation algorithms
+ *
+ * \par Multi-Index manipulation algorithms
+ * A series of templates, lambda, and regular functions that allow the manipulation of
+ * multi-indexes and sets of multi-indexes. The algorithms include the selection of
+ * multi-indexes according to a criteria, union of a vector of multi-index sets,
+ * normalization of anisotropic weights, map parents and children within a set (which
+ * generates a DAG structure), complete a set to satisfy the lower-property, etc.
+ * \endinternal
+ */
 
 namespace TasGrid{
 

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -48,17 +48,27 @@
 //! can be represented as two-dimensional data (or array/list of tuples), the three
 //! classes here correspond to sorted or unsorted, integer or floating point data.
 
-//! \internal
-//! \defgroup TasmanianSets Set data structures.
-//!
-//! \par Fundamental data structures
-//! Three classes for storage and easy access to multi-indexes and floating point values.
-//! The majority of internal data-structures associated with the five types of grids
-//! can be represented as two-dimensional data (or array/list of tuples), the three
-//! classes here correspond to sorted or unsorted, integer or floating point data.
+/*!
+ * \internal
+ * \ingroup TasmanianSG
+ * \addtogroup TasmanianSets Multi-Index set data structures
+ *
+ * \par Fundamental data structures
+ * Three classes for storage and easy access to multi-indexes and floating point values.
+ * The majority of internal data-structures associated with the five types of grids
+ * can be represented as two-dimensional data (or array/list of tuples), the three
+ * classes here correspond to sorted or unsorted, integer or floating point data.
+ * \endinternal
+ */
 
 namespace TasGrid{
 
+/*!
+ * \internal
+ * \ingroup TasmanianSets
+ * \brief Merge for multi-index sets.
+ * \endinternal
+ */
 namespace SetManipulations{
 
 //! \internal

--- a/SparseGrids/tsgLinearSolvers.hpp
+++ b/SparseGrids/tsgLinearSolvers.hpp
@@ -50,14 +50,17 @@
 //! problems and can perform as good (or even better) than general third-party methods.
 //! In addition, this reduces the external dependencies.
 
-//! \internal
-//! \defgroup TasmanianLinearSolvers Linear solvers.
-//!
-//! \par Linear Solvers
-//! Many sparse grids methods rely on various linear solvers, sparse iterative, eigenvalue,
-//! fast-fourier-transform, and least-squares. The solvers are tuned for the specific
-//! problems and can perform as good (or even better) than general third-party methods.
-//! In addition, this reduces the external dependencies.
+/*!
+ * \internal
+ * \ingroup TasmanianSG
+ * \addtogroup TasmanianLinearSolvers Linear solvers
+ *
+ * \par Linear Solvers
+ * Many sparse grids methods rely on various linear solvers, sparse iterative, eigenvalue,
+ * fast-fourier-transform, and least-squares. The solvers are tuned for the specific
+ * problems and can perform as good (or even better) than general third-party methods.
+ * In addition, this reduces the external dependencies.
+ */
 
 namespace TasGrid{
 


### PR DESCRIPTION
* reorganized the Doxygen documentation into Sparse Grid, DREAM and Examples master modules with numerous sub-modules
* fixed typos, Doxygen warnings, and added some clarifications