### PR TITLE
Reduce headers

### DIFF
--- a/DREAM/TasmanianDREAM.hpp
+++ b/DREAM/TasmanianDREAM.hpp
@@ -31,14 +31,6 @@
 #ifndef __TASMANIAN_DREAM_HPP
 #define __TASMANIAN_DREAM_HPP
 
-#include "TasmanianSparseGrid.hpp"
-
-#include "tsgDreamEnumerates.hpp"
-#include "tsgDreamState.hpp"
-#include "tsgDreamCoreRandom.hpp"
-#include "tsgDreamSample.hpp"
-#include "tsgDreamSampleGrid.hpp"
-#include "tsgDreamSamplePosterior.hpp"
 #include "tsgDreamSamplePosteriorGrid.hpp"
 
 //! \file TasmanianDREAM.hpp

--- a/DREAM/tsgDreamCorePDF.hpp
+++ b/DREAM/tsgDreamCorePDF.hpp
@@ -31,6 +31,13 @@
 #ifndef __TASMANIAN_DREAM_CORE_PDF_HPP
 #define __TASMANIAN_DREAM_CORE_PDF_HPP
 
+/*!
+ * \file tsgDreamCorePDF.hpp
+ * \brief Gives the unscaled formulas for several probability distributions.
+ * \author Miroslav Stoyanov
+ * \ingroup TasmanianDREAM
+ */
+
 #include "tsgDreamEnumerates.hpp"
 
 namespace TasDREAM{

--- a/DREAM/tsgDreamCoreRandom.hpp
+++ b/DREAM/tsgDreamCoreRandom.hpp
@@ -47,8 +47,6 @@
  * and algorithms to draw samples from several known distributions.
  */
 
-#include <math.h>
-
 namespace TasDREAM{
 
 //! \internal

--- a/DREAM/tsgDreamEnumerates.hpp
+++ b/DREAM/tsgDreamEnumerates.hpp
@@ -31,7 +31,7 @@
 #ifndef __TASMANIAN_DREAM_ENUMERATES_HPP
 #define __TASMANIAN_DREAM_ENUMERATES_HPP
 
-#include "TasmanianConfig.hpp"
+#include "TasmanianSparseGrid.hpp"
 
 /*!
  * \file tsgDreamEnumerates.hpp

--- a/DREAM/tsgDreamLikelyGaussian.hpp
+++ b/DREAM/tsgDreamLikelyGaussian.hpp
@@ -31,11 +31,8 @@
 #ifndef __TASMANIAN_DREAM_LIKELY_GAUSS_HPP
 #define __TASMANIAN_DREAM_LIKELY_GAUSS_HPP
 
-#include <vector>
 #include <numeric>
 #include <stdexcept>
-
-#include <math.h>
 
 #include "tsgDreamLikelihoodCore.hpp"
 

--- a/DREAM/tsgDreamSample.hpp
+++ b/DREAM/tsgDreamSample.hpp
@@ -31,9 +31,6 @@
 #ifndef __TASMANIAN_DREAM_SAMPLE_HPP
 #define __TASMANIAN_DREAM_SAMPLE_HPP
 
-#include <vector>
-
-#include "tsgDreamEnumerates.hpp"
 #include "tsgDreamState.hpp"
 #include "tsgDreamCoreRandom.hpp"
 #include "tsgDreamCorePDF.hpp"

--- a/DREAM/tsgDreamSampleGrid.hpp
+++ b/DREAM/tsgDreamSampleGrid.hpp
@@ -31,12 +31,7 @@
 #ifndef __TASMANIAN_DREAM_SAMPLE_GRID_HPP
 #define __TASMANIAN_DREAM_SAMPLE_GRID_HPP
 
-#include <vector>
-
-#include "TasmanianSparseGrid.hpp"
-
-#include "tsgDreamEnumerates.hpp"
-#include "tsgDreamState.hpp"
+#include "tsgDreamSample.hpp"
 
 //! \file tsgDreamSampleGrid.hpp
 //! \brief DREAM methods using likelihood approximated by a sparse grid.

--- a/DREAM/tsgDreamSamplePosterior.hpp
+++ b/DREAM/tsgDreamSamplePosterior.hpp
@@ -31,12 +31,7 @@
 #ifndef __TASMANIAN_DREAM_SAMPLE_POSTERIOR_HPP
 #define __TASMANIAN_DREAM_SAMPLE_POSTERIOR_HPP
 
-#include <vector>
-
-#include "tsgDreamEnumerates.hpp"
-#include "tsgDreamState.hpp"
-#include "tsgDreamCoreRandom.hpp"
-#include "tsgDreamCorePDF.hpp"
+#include "tsgDreamSample.hpp"
 #include "tsgDreamLikelyGaussian.hpp"
 
 //! \file tsgDreamSamplePosterior.hpp

--- a/DREAM/tsgDreamSamplePosteriorGrid.hpp
+++ b/DREAM/tsgDreamSamplePosteriorGrid.hpp
@@ -31,14 +31,7 @@
 #ifndef __TASMANIAN_DREAM_SAMPLE_POSTERIOR_GRID_HPP
 #define __TASMANIAN_DREAM_SAMPLE_POSTERIOR_GRID_HPP
 
-#include <vector>
-
-#include "tsgDreamEnumerates.hpp"
-#include "tsgDreamState.hpp"
-#include "tsgDreamState.hpp"
-#include "tsgDreamCoreRandom.hpp"
-#include "tsgDreamCorePDF.hpp"
-#include "tsgDreamLikelyGaussian.hpp"
+#include "tsgDreamSampleGrid.hpp"
 #include "tsgDreamSamplePosterior.hpp"
 
 //! \file tsgDreamSamplePosteriorGrid.hpp

--- a/DREAM/tsgDreamState.hpp
+++ b/DREAM/tsgDreamState.hpp
@@ -31,10 +31,6 @@
 #ifndef __TASMANIAN_DREAM_STATE_HPP
 #define __TASMANIAN_DREAM_STATE_HPP
 
-#include <vector>
-
-#include "TasmanianSparseGrid.hpp"
-
 #include "tsgDreamEnumerates.hpp"
 
 //! \internal

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -41,17 +41,11 @@
 #ifndef __TASMANIAN_SPARSE_GRID_HPP
 #define __TASMANIAN_SPARSE_GRID_HPP
 
-#include "TasmanianConfig.hpp"
-
-#include "tsgEnumerates.hpp"
-
 #include "tsgGridGlobal.hpp"
 #include "tsgGridSequence.hpp"
 #include "tsgGridLocalPolynomial.hpp"
 #include "tsgGridWavelet.hpp"
 #include "tsgGridFourier.hpp"
-
-#include <iomanip> // only needed for printStats()
 
 /*!
  * \defgroup TasmanianSG Sparse Grids

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -32,10 +32,7 @@
 #define __TASMANIAN_SPARSE_GRID_ACCELERATED_DATA_STRUCTURES_HPP
 
 #include <stdexcept>
-#include <string>
-#include <vector>
 
-#include "TasmanianConfig.hpp"
 #include "tsgEnumerates.hpp"
 
 //! \internal

--- a/SparseGrids/tsgCacheLagrange.hpp
+++ b/SparseGrids/tsgCacheLagrange.hpp
@@ -38,8 +38,6 @@
  * \ingroup TasmanianAcceleration
  */
 
-#include "tsgEnumerates.hpp"
-#include "tsgCoreOneDimensional.hpp"
 #include "tsgOneDimensionalWrapper.hpp"
 
 namespace TasGrid{

--- a/SparseGrids/tsgCoreOneDimensional.hpp
+++ b/SparseGrids/tsgCoreOneDimensional.hpp
@@ -31,11 +31,7 @@
 #ifndef __TSG_CORE_ONE_DIMENSIONAL_HPP
 #define __TSG_CORE_ONE_DIMENSIONAL_HPP
 
-#include "tsgEnumerates.hpp"
 #include "tsgLinearSolvers.hpp"
-
-#include <string>
-#include <math.h>
 
 //! \internal
 //! \file tsgCoreOneDimensional.hpp

--- a/SparseGrids/tsgDConstructGridGlobal.hpp
+++ b/SparseGrids/tsgDConstructGridGlobal.hpp
@@ -33,8 +33,6 @@
 
 #include <forward_list>
 
-#include "tsgEnumerates.hpp"
-#include "tsgIndexSets.hpp"
 #include "tsgIndexManipulator.hpp"
 
 /*!

--- a/SparseGrids/tsgEnumerates.hpp
+++ b/SparseGrids/tsgEnumerates.hpp
@@ -31,11 +31,14 @@
 #ifndef __TASMANIAN_SPARSE_GRID_ENUMERATES_HPP
 #define __TASMANIAN_SPARSE_GRID_ENUMERATES_HPP
 
-#include <iostream>
+// system headers used in many/many places
+#include <iomanip>
 #include <stdlib.h>
+#include <ostream>
 #include <fstream>
-#include <math.h>
 #include <string.h>
+#include <string>
+#include <vector>
 
 #include "TasmanianConfig.hpp"
 

--- a/SparseGrids/tsgIOHelpers.hpp
+++ b/SparseGrids/tsgIOHelpers.hpp
@@ -31,10 +31,7 @@
 #ifndef __TASMANIAN_IOHELPERS_HPP
 #define __TASMANIAN_IOHELPERS_HPP
 
-#include <ostream>
-#include <iostream> // for debugging
 #include <tuple>
-#include <vector>
 
 #include "tsgCoreOneDimensional.hpp"
 

--- a/SparseGrids/tsgIndexManipulator.hpp
+++ b/SparseGrids/tsgIndexManipulator.hpp
@@ -31,12 +31,9 @@
 #ifndef __TSG_INDEX_MANIPULATOR_HPP
 #define __TSG_INDEX_MANIPULATOR_HPP
 
-#include <functional>
 #include <numeric>
 
-#include "tsgEnumerates.hpp"
 #include "tsgIndexSets.hpp"
-#include "tsgCoreOneDimensional.hpp"
 #include "tsgOneDimensionalWrapper.hpp"
 #include "tsgRuleLocalPolynomial.hpp"
 

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -31,11 +31,10 @@
 #ifndef __TASMANIAN_SPARSE_GRID_INDEX_SETS_HPP
 #define __TASMANIAN_SPARSE_GRID_INDEX_SETS_HPP
 
-#include "tsgIOHelpers.hpp"
-#include "tsgEnumerates.hpp"
-#include <vector>
 #include <functional>
 #include <algorithm>
+
+#include "tsgIOHelpers.hpp"
 
 //! \internal
 //! \file tsgIndexSets.hpp

--- a/SparseGrids/tsgLinearSolvers.hpp
+++ b/SparseGrids/tsgLinearSolvers.hpp
@@ -32,8 +32,6 @@
 #define __TASMANIAN_LINEAR_SOLVERS_HPP
 
 #include <list>
-#include <vector>
-#include <fstream>
 #include <math.h>
 #include <complex>
 

--- a/SparseGrids/tsgOneDimensionalWrapper.hpp
+++ b/SparseGrids/tsgOneDimensionalWrapper.hpp
@@ -31,7 +31,6 @@
 #ifndef __TSG_ONE_DIMENSIONAL_WRAPPER_HPP
 #define __TSG_ONE_DIMENSIONAL_WRAPPER_HPP
 
-#include "tsgEnumerates.hpp"
 #include "tsgCoreOneDimensional.hpp"
 #include "tsgSequenceOptimizer.hpp"
 #include "tsgHardCodedTabulatedRules.hpp"

--- a/SparseGrids/tsgSequenceOptimizer.hpp
+++ b/SparseGrids/tsgSequenceOptimizer.hpp
@@ -33,6 +33,7 @@
 
 #include <vector>
 
+#include <math.h>
 #include "tsgEnumerates.hpp"
 
 namespace TasGrid{


### PR DESCRIPTION
* having redundant header includes does little to the code, but Doxygen generates spaghetti dependence graphs that make the code look worse than it is
* removed the redundant dependence in sparse grids and dream headers 