### PR TITLE
Daily fixes

### DIFF
--- a/Config/CMakeIncludes/FindTasmanianCudaMathLibs.cmake
+++ b/Config/CMakeIncludes/FindTasmanianCudaMathLibs.cmake
@@ -30,6 +30,8 @@ macro(Tasmanian_find_cuda_libraries)
     endforeach()
 endmacro()
 
+include(FindPackageHandleStandardArgs)
+
 get_filename_component(Tasmanian_nvccroot ${CMAKE_CUDA_COMPILER} DIRECTORY) # convert <path>/bin/nvcc to <path>/bin
 get_filename_component(Tasmanian_nvccroot ${Tasmanian_nvccroot} DIRECTORY)  # convert <path>/bin to <path>
 

--- a/InterfacePython/CMakeLists.txt
+++ b/InterfacePython/CMakeLists.txt
@@ -14,6 +14,19 @@ if (NOT DEFINED Tasmanian_python_install_path)
     set(Tasmanian_python_install_path "${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages" CACHE INTERNAL "install path for the Python module (version specific)")
 endif()
 
+# CMake has permissive implementation of boolean true, which includes
+# "On", "True" and "Yes" with different cases;
+# Here we convert boolen true to "ON" so it can
+# be safely passed to Python as a string and interpreted via
+# python_boolean = ("@cmake_boolean@" == "ON")
+if (Tasmanian_ENABLE_BLAS)
+    set(Tasmanian_ENABLE_BLAS "ON")
+endif()
+
+if (Tasmanian_ENABLE_CUDA)
+    set(Tasmanian_ENABLE_CUDA "ON")
+endif()
+
 
 ########################################################################
 # Stage 0: for support of simple GNU-Make


### PR DESCRIPTION
* convert all CMake booleans to ON/OFF so Python needs only to check if variable is ON
* if no other `find_package()` commands are used, then `include(FindPackageHandleStandardArgs)` is needed