### PR TITLE
Update container api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog for version 6.1 (may rename this to 7.0 later)
 * modernized C++ compatibility
     * see the updated DREAM api notes
     * TasmanianSparseGrid has move and copy constructors and `operator=` overloads
+    * Tasmanian C++ API no-longer returns raw-pointers, only STL containers
+    * **broke backward api** affects mostly get points and weights
+    * externally allocated raw-pointers are still accepted and used by C/Python/Fortran APIs
 
 * improved the `add_subdirectory()` capability
     * can specify the export name used by the Tasmanian install commands

--- a/InterfaceFortran/tsgC2Fortran.cpp
+++ b/InterfaceFortran/tsgC2Fortran.cpp
@@ -248,11 +248,10 @@ void tsgsar_(int *id, int *type, int *min_growth, int *output, int *opt_flags, c
     _tsg_grid_list[*id]->setAnisotropicRefinement(OneDimensionalMeta::getIOTypeInt(*type), *min_growth, *output, ll);
 }
 void tsgeac_(int *id, int *type, int *output, int *result){
-    int *coeff = _tsg_grid_list[*id]->estimateAnisotropicCoefficients(OneDimensionalMeta::getIOTypeInt(*type), *output);
+    auto coeff = _tsg_grid_list[*id]->estimateAnisotropicCoefficients(OneDimensionalMeta::getIOTypeInt(*type), *output);
     int num_coeff = _tsg_grid_list[*id]->getNumDimensions();
     if ((*type == 2) || (*type == 4) || (*type == 6)) num_coeff *= 2;
     for(int i=0; i<num_coeff; i++) result[i] = coeff[i];
-    delete[] coeff;
 }
 void tsgssr_(int *id, double *tol, int *output, int *opt_flags, const int *llimits){
     const int *ll;

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -380,42 +380,19 @@ int TasmanianSparseGrid::getNumLoaded() const{ return (empty()) ? 0 : base->getN
 int TasmanianSparseGrid::getNumNeeded() const{ return (empty()) ? 0 : base->getNumNeeded(); }
 int TasmanianSparseGrid::getNumPoints() const{ return (empty()) ? 0 : base->getNumPoints(); }
 
-double* TasmanianSparseGrid::getLoadedPoints() const{
-    if (base->getNumLoaded() == 0) return 0;
-    size_t nump = (size_t) base->getNumLoaded();
-    size_t numd = (size_t) base->getNumDimensions();
-    double *x = new double[nump * numd];
-    getLoadedPoints(x);
-    return x;
-}
 void TasmanianSparseGrid::getLoadedPoints(double *x) const{
     base->getLoadedPoints(x);
     formTransformedPoints(base->getNumLoaded(), x);
-}
-double* TasmanianSparseGrid::getNeededPoints() const{
-    if (base->getNumNeeded() == 0) return 0;
-    size_t nump = (size_t) base->getNumNeeded();
-    size_t numd = (size_t) base->getNumDimensions();
-    double *x = new double[nump * numd];
-    getNeededPoints(x);
-    return x;
 }
 void TasmanianSparseGrid::getNeededPoints(double *x) const{
     base->getNeededPoints(x);
     formTransformedPoints(base->getNumNeeded(), x);
 }
-double* TasmanianSparseGrid::getPoints() const{
-    if (base->getNumPoints() == 0) return 0;
-    size_t nump = (size_t) base->getNumPoints();
-    size_t numd = (size_t) base->getNumDimensions();
-    double *x = new double[nump * numd];
-    getPoints(x);
-    return x;
-}
 void TasmanianSparseGrid::getPoints(double *x) const{
     base->getPoints(x);
     formTransformedPoints(base->getNumPoints(), x);
 }
+
 void TasmanianSparseGrid::getLoadedPoints(std::vector<double> &x) const{
     x.resize(((size_t) base->getNumLoaded()) * ((size_t) base->getNumDimensions()));
     getLoadedPoints(x.data());

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -361,16 +361,6 @@ void TasmanianSparseGrid::updateSequenceGrid(int depth, TypeDepth type, const st
     }
 }
 
-double TasmanianSparseGrid::getAlpha() const{
-    return (isGlobal()) ? getGridGlobal()->getAlpha() : 0.0;
-}
-double TasmanianSparseGrid::getBeta() const{
-    return (isGlobal()) ? getGridGlobal()->getBeta() : 0.0;
-}
-int TasmanianSparseGrid::getOrder() const{
-    return (isLocalPolynomial()) ? getGridLocalPolynomial()->getOrder() : ((isWavelet()) ? getGridWavelet()->getOrder() : -1);
-}
-
 TypeOneDRule TasmanianSparseGrid::getRule() const{ return (base) ? base->getRule() : rule_none; }
 const char* TasmanianSparseGrid::getCustomRuleDescription() const{ return (isGlobal()) ? getGridGlobal()->getCustomRuleDescription() : ""; }
 

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -374,10 +374,6 @@ int TasmanianSparseGrid::getOrder() const{
 TypeOneDRule TasmanianSparseGrid::getRule() const{ return (base) ? base->getRule() : rule_none; }
 const char* TasmanianSparseGrid::getCustomRuleDescription() const{ return (isGlobal()) ? getGridGlobal()->getCustomRuleDescription() : ""; }
 
-int TasmanianSparseGrid::getNumLoaded() const{ return (empty()) ? 0 : base->getNumLoaded(); }
-int TasmanianSparseGrid::getNumNeeded() const{ return (empty()) ? 0 : base->getNumNeeded(); }
-int TasmanianSparseGrid::getNumPoints() const{ return (empty()) ? 0 : base->getNumPoints(); }
-
 void TasmanianSparseGrid::getLoadedPoints(double *x) const{
     base->getLoadedPoints(x);
     formTransformedPoints(base->getNumLoaded(), x);
@@ -507,12 +503,6 @@ void TasmanianSparseGrid::integrate(std::vector<double> &q) const{
     q.resize(num_outputs);
     integrate(q.data());
 }
-
-bool TasmanianSparseGrid::isGlobal() const{          return (empty()) ? false : base->isGlobal(); }
-bool TasmanianSparseGrid::isSequence() const{        return (empty()) ? false : base->isSequence(); }
-bool TasmanianSparseGrid::isLocalPolynomial() const{ return (empty()) ? false : base->isLocalPolynomial(); }
-bool TasmanianSparseGrid::isWavelet() const{         return (empty()) ? false : base->isWavelet(); }
-bool TasmanianSparseGrid::isFourier() const{         return (empty()) ? false : base->isFourier(); }
 
 void TasmanianSparseGrid::setDomainTransform(const double a[], const double b[]){
     if (empty() || (base->getNumDimensions() == 0)){

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -1245,13 +1245,12 @@ void TasmanianSparseGrid::setHierarchicalCoefficients(const double c[]){
 }
 void TasmanianSparseGrid::setHierarchicalCoefficients(const std::vector<double> &c){ setHierarchicalCoefficients(c.data()); }
 
-void TasmanianSparseGrid::getGlobalPolynomialSpace(bool interpolation, int &num_indexes, int* &poly) const{
+std::vector<int> TasmanianSparseGrid::getGlobalPolynomialSpace(bool interpolation) const{
     if (isGlobal()){
-        getGridGlobal()->getPolynomialSpace(interpolation, num_indexes, poly);
+        return getGridGlobal()->getPolynomialSpace(interpolation);
     }else if (isSequence()){
-        getGridSequence()->getPolynomialSpace(interpolation, num_indexes, poly);
+        return getGridSequence()->getPolynomialSpace(interpolation);
     }else{
-        num_indexes = 0;
         throw std::runtime_error("ERROR: getGlobalPolynomialSpace() called for a grid that is neither Global nor Sequence");
     }
 }

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -391,12 +391,6 @@ void TasmanianSparseGrid::getPoints(double *x) const{
     formTransformedPoints(base->getNumPoints(), x);
 }
 
-double* TasmanianSparseGrid::getQuadratureWeights() const{
-    if (getNumPoints() == 0) return 0;
-    double *w = new double[getNumPoints()];
-    getQuadratureWeights(w);
-    return w;
-}
 void TasmanianSparseGrid::getQuadratureWeights(double *weights) const{
     base->getQuadratureWeights(weights);
     mapConformalWeights(base->getNumDimensions(), base->getNumPoints(), weights);
@@ -406,24 +400,20 @@ void TasmanianSparseGrid::getQuadratureWeights(double *weights) const{
         for(int i=0; i<getNumPoints(); i++) weights[i] *= scale;
     }
 }
-double* TasmanianSparseGrid::getInterpolationWeights(const double x[]) const{
-    if (getNumPoints() == 0) return 0;
-    double *w = new double[getNumPoints()];
-    getInterpolationWeights(x, w);
-    return w;
-}
 void TasmanianSparseGrid::getInterpolationWeights(const double x[], double *weights) const{
     Data2D<double> x_tmp;
     base->getInterpolationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
-}
-void TasmanianSparseGrid::getQuadratureWeights(std::vector<double> &weights) const{
-    weights.resize(base->getNumPoints());
-    getQuadratureWeights(weights.data());
 }
 void TasmanianSparseGrid::getInterpolationWeights(const std::vector<double> &x, std::vector<double> &weights) const{
     if (x.size() != (size_t) base->getNumDimensions()) throw std::runtime_error("ERROR: getInterpolationWeights() incorrect size of x, must be same as getNumDimensions()");
     weights.resize(base->getNumPoints());
     getInterpolationWeights(x.data(), weights.data());
+}
+double* TasmanianSparseGrid::getInterpolationWeights(const double x[]) const{
+    if (getNumPoints() == 0) return 0;
+    double *w = new double[getNumPoints()];
+    getInterpolationWeights(x, w);
+    return w;
 }
 
 void TasmanianSparseGrid::loadNeededPoints(const double *vals){

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -994,7 +994,7 @@ void TasmanianSparseGrid::beginConstruction(){
         base->beginConstruction();
     }
 }
-void TasmanianSparseGrid::getCandidateConstructionPoints(TypeDepth type, std::vector<double> &x, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits){
+std::vector<double> TasmanianSparseGrid::getCandidateConstructionPoints(TypeDepth type, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits){
     if (!usingDynamicConstruction) throw std::runtime_error("ERROR: getCandidateConstructionPoints() called before beginConstruction()");
     if (isLocalPolynomial()) throw std::runtime_error("ERROR: getCandidateConstructionPoints() anisotropic version called for local polynomial grid");
     size_t dims = (size_t) base->getNumDimensions();
@@ -1007,12 +1007,12 @@ void TasmanianSparseGrid::getCandidateConstructionPoints(TypeDepth type, std::ve
 
     if (!level_limits.empty()) llimits = level_limits;
     if (isGlobal()){
-        getGridGlobal()->getCandidateConstructionPoints(type, anisotropic_weights, x, llimits);
+        return getGridGlobal()->getCandidateConstructionPoints(type, anisotropic_weights, llimits);
     }else{
-        getGridSequence()->getCandidateConstructionPoints(type, anisotropic_weights, x, llimits);
+        return getGridSequence()->getCandidateConstructionPoints(type, anisotropic_weights, llimits);
     }
 }
-void TasmanianSparseGrid::getCandidateConstructionPoints(TypeDepth type, int output, std::vector<double> &x, const std::vector<int> &level_limits){
+std::vector<double> TasmanianSparseGrid::getCandidateConstructionPoints(TypeDepth type, int output, const std::vector<int> &level_limits){
     if (!usingDynamicConstruction) throw std::runtime_error("ERROR: getCandidateConstructionPoints() called before beginConstruction()");
     if (isLocalPolynomial()) throw std::runtime_error("ERROR: getCandidateConstructionPoints() anisotropic version called for local polynomial grid");
     size_t dims = (size_t) base->getNumDimensions();
@@ -1023,13 +1023,13 @@ void TasmanianSparseGrid::getCandidateConstructionPoints(TypeDepth type, int out
 
     if (!level_limits.empty()) llimits = level_limits;
     if (isGlobal()){
-        getGridGlobal()->getCandidateConstructionPoints(type, output, x, llimits);
+        return getGridGlobal()->getCandidateConstructionPoints(type, output, llimits);
     }else{
-        getGridSequence()->getCandidateConstructionPoints(type, output, x, llimits);
+        return getGridSequence()->getCandidateConstructionPoints(type, output, llimits);
     }
 }
-void TasmanianSparseGrid::getCandidateConstructionPoints(double tolerance, TypeRefinement criteria, std::vector<double> &x,
-                                                         int output, const std::vector<int> &level_limits, const std::vector<double> &scale_correction){
+std::vector<double> TasmanianSparseGrid::getCandidateConstructionPoints(double tolerance, TypeRefinement criteria,
+                                                                        int output, const std::vector<int> &level_limits, const std::vector<double> &scale_correction){
     if (!usingDynamicConstruction) throw std::runtime_error("ERROR: getCandidateConstructionPoints() called before beginConstruction()");
     if (!isLocalPolynomial()) throw std::runtime_error("ERROR: getCandidateConstructionPoints() anisotropic version called for local polynomial grid");
     size_t dims = (size_t) base->getNumDimensions();
@@ -1039,7 +1039,7 @@ void TasmanianSparseGrid::getCandidateConstructionPoints(double tolerance, TypeR
     if ((output < -1) || (output >= outs)) throw std::invalid_argument("ERROR: calling getCandidateConstructionPoints() with invalid output");
 
     if (!level_limits.empty()) llimits = level_limits;
-    getGridLocalPolynomial()->getCandidateConstructionPoints(tolerance, criteria, output, llimits, ((scale_correction.empty()) ? nullptr : scale_correction.data()), x);
+    return getGridLocalPolynomial()->getCandidateConstructionPoints(tolerance, criteria, output, llimits, ((scale_correction.empty()) ? nullptr : scale_correction.data()));
 }
 void TasmanianSparseGrid::loadConstructedPoint(const std::vector<double> &x, const std::vector<double> &y){
     if (!usingDynamicConstruction) throw std::runtime_error("ERROR: loadConstructedPoint() called before beginConstruction()");

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -400,20 +400,19 @@ void TasmanianSparseGrid::getQuadratureWeights(double *weights) const{
         for(int i=0; i<getNumPoints(); i++) weights[i] *= scale;
     }
 }
-void TasmanianSparseGrid::getInterpolationWeights(const double x[], double *weights) const{
-    Data2D<double> x_tmp;
-    base->getInterpolationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
+std::vector<double> TasmanianSparseGrid::getInterpolationWeights(std::vector<double> const &x) const{
+    std::vector<double> w;
+    getInterpolationWeights(x, w);
+    return w;
 }
 void TasmanianSparseGrid::getInterpolationWeights(const std::vector<double> &x, std::vector<double> &weights) const{
     if (x.size() != (size_t) base->getNumDimensions()) throw std::runtime_error("ERROR: getInterpolationWeights() incorrect size of x, must be same as getNumDimensions()");
-    weights.resize(base->getNumPoints());
+    weights.resize((size_t) getNumPoints());
     getInterpolationWeights(x.data(), weights.data());
 }
-double* TasmanianSparseGrid::getInterpolationWeights(const double x[]) const{
-    if (getNumPoints() == 0) return 0;
-    double *w = new double[getNumPoints()];
-    getInterpolationWeights(x, w);
-    return w;
+void TasmanianSparseGrid::getInterpolationWeights(const double x[], double weights[]) const{
+    Data2D<double> x_tmp;
+    base->getInterpolationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
 }
 
 void TasmanianSparseGrid::loadNeededPoints(const double *vals){

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -1721,16 +1721,12 @@ int TasmanianSparseGrid::getGPUMemory(int gpu){
     if ((gpu < 0) || (gpu >= AccelerationMeta::getNumCudaDevices())) return 0;
     return (int) (AccelerationMeta::getTotalGPUMemory(gpu) / 1048576);
 }
-char* TasmanianSparseGrid::getGPUName(int gpu){
+std::string TasmanianSparseGrid::getGPUName(int gpu){
     return AccelerationMeta::getCudaDeviceName(gpu);
 }
 #else
 int TasmanianSparseGrid::getGPUMemory(int){ return 0; }
-char* TasmanianSparseGrid::getGPUName(int){
-    char *name = new char[1];
-    name[0] = '\0';
-    return name;
-}
+std::string TasmanianSparseGrid::getGPUName(int){ return std::string(); }
 #endif // Tasmanian_ENABLE_CUDA
 
 }

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -393,19 +393,6 @@ void TasmanianSparseGrid::getPoints(double *x) const{
     formTransformedPoints(base->getNumPoints(), x);
 }
 
-void TasmanianSparseGrid::getLoadedPoints(std::vector<double> &x) const{
-    x.resize(((size_t) base->getNumLoaded()) * ((size_t) base->getNumDimensions()));
-    getLoadedPoints(x.data());
-}
-void TasmanianSparseGrid::getNeededPoints(std::vector<double> &x) const{
-    x.resize(((size_t) base->getNumNeeded()) * ((size_t) base->getNumDimensions()));
-    getNeededPoints(x.data());
-}
-void TasmanianSparseGrid::getPoints(std::vector<double> &x) const{
-    x.resize(((size_t) base->getNumPoints()) * ((size_t) base->getNumDimensions()));
-    getPoints(x.data());
-}
-
 double* TasmanianSparseGrid::getQuadratureWeights() const{
     if (getNumPoints() == 0) return 0;
     double *w = new double[getNumPoints()];

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -124,14 +124,14 @@ void TasmanianSparseGrid::read(const char *filename){
     ifs.close();
 }
 
-void TasmanianSparseGrid::write(std::ofstream &ofs, bool binary) const{
+void TasmanianSparseGrid::write(std::ostream &ofs, bool binary) const{
     if (binary){
         writeBinary(ofs);
     }else{
         writeAscii(ofs);
     }
 }
-void TasmanianSparseGrid::read(std::ifstream &ifs, bool binary){
+void TasmanianSparseGrid::read(std::istream &ifs, bool binary){
     if (binary){
         readBinary(ifs);
     }else{
@@ -1349,7 +1349,7 @@ void TasmanianSparseGrid::printStats(std::ostream &os) const{
     os << endl;
 }
 
-void TasmanianSparseGrid::writeAscii(std::ofstream &ofs) const{
+void TasmanianSparseGrid::writeAscii(std::ostream &ofs) const{
     using std::endl;
 
     ofs << "TASMANIAN SG " << getVersion() << endl;
@@ -1407,7 +1407,7 @@ void TasmanianSparseGrid::writeAscii(std::ofstream &ofs) const{
     }
     ofs << "TASMANIAN SG end" << endl;
 }
-void TasmanianSparseGrid::writeBinary(std::ofstream &ofs) const{
+void TasmanianSparseGrid::writeBinary(std::ostream &ofs) const{
     const char *TSG = "TSG5"; // last char indicates version (update only if necessary, no need to sync with getVersionMajor())
     ofs.write(TSG, 4 * sizeof(char)); // mark Tasmanian files
     char flag;
@@ -1459,7 +1459,7 @@ void TasmanianSparseGrid::writeBinary(std::ofstream &ofs) const{
     }
     flag = 'e'; ofs.write(&flag, sizeof(char)); // E stands for END
 }
-void TasmanianSparseGrid::readAscii(std::ifstream &ifs){
+void TasmanianSparseGrid::readAscii(std::istream &ifs){
     std::string T;
     std::string message = ""; // used in case there is an exception
     ifs >> T;  if (!(T.compare("TASMANIAN") == 0)){ throw std::runtime_error("ERROR: wrong file format, first word in not 'TASMANIAN'"); }
@@ -1566,7 +1566,7 @@ void TasmanianSparseGrid::readAscii(std::ifstream &ifs){
         }
     }
 }
-void TasmanianSparseGrid::readBinary(std::ifstream &ifs){
+void TasmanianSparseGrid::readBinary(std::istream &ifs){
     std::vector<char>  TSG(4);
     ifs.read(TSG.data(), 4*sizeof(char));
     if ((TSG[0] != 'T') || (TSG[1] != 'S') || (TSG[2] != 'G')){

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -886,14 +886,7 @@ void TasmanianSparseGrid::setAnisotropicRefinement(TypeDepth type, int min_growt
     }
 }
 
-int* TasmanianSparseGrid::estimateAnisotropicCoefficients(TypeDepth type, int output){
-    std::vector<int> weights;
-    estimateAnisotropicCoefficients(type, output, weights);
-    int *w = new int[weights.size()];
-    std::copy(weights.begin(), weights.end(), w);
-    return w;
-}
-void TasmanianSparseGrid::estimateAnisotropicCoefficients(TypeDepth type, int output, std::vector<int> &weights){
+void TasmanianSparseGrid::estimateAnisotropicCoefficients(TypeDepth type, int output, std::vector<int> &weights) const{
     if (empty()) throw std::runtime_error("ERROR: calling estimateAnisotropicCoefficients() for a grid that has not been initialized");
     int outs = base->getNumOutputs();
     if (outs == 0) throw std::runtime_error("ERROR: calling estimateAnisotropicCoefficients() for a grid that has no outputs");

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -371,9 +371,7 @@ int TasmanianSparseGrid::getOrder() const{
     return (isLocalPolynomial()) ? getGridLocalPolynomial()->getOrder() : ((isWavelet()) ? getGridWavelet()->getOrder() : -1);
 }
 
-int TasmanianSparseGrid::getNumDimensions() const{ return (empty()) ? 0 : base->getNumDimensions(); }
-int TasmanianSparseGrid::getNumOutputs() const{ return (empty()) ? 0 : base->getNumOutputs(); }
-TypeOneDRule TasmanianSparseGrid::getRule() const{ return (empty()) ? rule_none :base->getRule(); }
+TypeOneDRule TasmanianSparseGrid::getRule() const{ return (base) ? base->getRule() : rule_none; }
 const char* TasmanianSparseGrid::getCustomRuleDescription() const{ return (isGlobal()) ? getGridGlobal()->getCustomRuleDescription() : ""; }
 
 int TasmanianSparseGrid::getNumLoaded() const{ return (empty()) ? 0 : base->getNumLoaded(); }

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -250,7 +250,7 @@ public:
     int getGPUID() const;
     static int getNumGPUs();
     static int getGPUMemory(int gpu); // returns the MB of a given GPU
-    static char* getGPUName(int gpu); // returns a null-terminated char array
+    static std::string getGPUName(int gpu); // returns a null-terminated char array
 
     // functions assuming vectors are pre-allocated on the GPU (stable for the implemented cases)
     void evaluateHierarchicalFunctionsGPU(const double gpu_x[], int cpu_num_x, double gpu_y[]) const; // does not work for Global or LocalPolynomial with order > 2

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -125,13 +125,13 @@ public:
     std::vector<double> getNeededPoints() const{ std::vector<double> x; getNeededPoints(x); return x; }
     std::vector<double> getPoints() const{ std::vector<double> x; getPoints(x); return x; }
 
+    void getLoadedPoints(std::vector<double> &x) const{ x.resize((size_t) getNumDimensions() * (size_t) getNumLoaded()); getLoadedPoints(x.data()); }
+    void getNeededPoints(std::vector<double> &x) const{ x.resize((size_t) getNumDimensions() * (size_t) getNumNeeded()); getNeededPoints(x.data()); }
+    void getPoints(std::vector<double> &x) const{ x.resize((size_t) getNumDimensions() * (size_t) getNumPoints()); getPoints(x.data()); }
+
     void getLoadedPoints(double *x) const; // using static memory, assuming x has size num_dimensions X get***Points()
     void getNeededPoints(double *x) const;
     void getPoints(double *x) const; // returns the loaded points unless no points are loaded, then returns the needed points
-
-    void getLoadedPoints(std::vector<double> &x) const; // dynamic memory, resizes x
-    void getNeededPoints(std::vector<double> &x) const;
-    void getPoints(std::vector<double> &x) const; // returns the loaded points unless no points are loaded, then returns the needed points
 
     double* getQuadratureWeights() const;
     double* getInterpolationWeights(const double x[]) const;

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -108,9 +108,9 @@ public:
     void updateSequenceGrid(int depth, TypeDepth type, const int *anisotropic_weights = 0, const int *level_limits = 0);
     void updateSequenceGrid(int depth, TypeDepth type, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits = std::vector<int>());
 
-    double getAlpha() const;
-    double getBeta() const;
-    int getOrder() const;
+    double getAlpha() const{ return (isGlobal()) ? getGridGlobal()->getAlpha() : 0.0; }
+    double getBeta() const{ return (isGlobal()) ? getGridGlobal()->getBeta() : 0.0; }
+    int getOrder() const{ return (isLocalPolynomial()) ? getGridLocalPolynomial()->getOrder() : ((isWavelet()) ? getGridWavelet()->getOrder() : -1); }
 
     int getNumDimensions() const{ return (base) ? base->getNumDimensions() : 0; }
     int getNumOutputs() const{ return (base) ? base->getNumOutputs() : 0; }

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -179,12 +179,13 @@ public:
     void clearLevelLimits(); // level limits will be set anew if non-null vector is given to refine command
     void getLevelLimits(int *limits) const; // static, assume limits is already allocated with length num_dimensions
     void getLevelLimits(std::vector<int> &limits) const; // allocates the vector
+    std::vector<int> getLevelLimits() const{ std::vector<int> ll; getLevelLimits(ll); return ll; }
 
     void setAnisotropicRefinement(TypeDepth type, int min_growth, int output, const int *level_limits = 0);
     void setAnisotropicRefinement(TypeDepth type, int min_growth, int output, const std::vector<int> &level_limits);
 
-    int* estimateAnisotropicCoefficients(TypeDepth type, int output);
-    void estimateAnisotropicCoefficients(TypeDepth type, int output, std::vector<int> &weights);
+    void estimateAnisotropicCoefficients(TypeDepth type, int output, std::vector<int> &weights) const;
+    std::vector<int> estimateAnisotropicCoefficients(TypeDepth type, int output) const{ std::vector<int> w; estimateAnisotropicCoefficients(type, output, w); return w; }
 
     void setSurplusRefinement(double tolerance, int output, const int *level_limits = 0);
     void setSurplusRefinement(double tolerance, int output, const std::vector<int> &level_limits);

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -133,13 +133,12 @@ public:
     void getNeededPoints(double *x) const;
     void getPoints(double *x) const; // returns the loaded points unless no points are loaded, then returns the needed points
 
-    double* getQuadratureWeights() const;
-    double* getInterpolationWeights(const double x[]) const;
-
+    std::vector<double> getQuadratureWeights() const{ std::vector<double> w; getQuadratureWeights(w); return w; }
+    void getQuadratureWeights(std::vector<double> &weights) const{ weights.resize((size_t) getNumPoints()); getQuadratureWeights(weights.data()); }
     void getQuadratureWeights(double weights[]) const; // static memory, assumes that weights has size getNumPoints()
-    void getInterpolationWeights(const double x[], double weights[]) const; // static memory, assumes that weights has size getNumPoints()
 
-    void getQuadratureWeights(std::vector<double> &weights) const; // dynamic memory, resizes weights
+    double* getInterpolationWeights(double const x[]) const;
+    void getInterpolationWeights(const double x[], double weights[]) const; // static memory, assumes that weights has size getNumPoints()
     void getInterpolationWeights(const std::vector<double> &x, std::vector<double> &weights) const; // dynamic memory, resizes weights
 
     void loadNeededPoints(const double *vals); // no error checking

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -137,9 +137,10 @@ public:
     void getQuadratureWeights(std::vector<double> &weights) const{ weights.resize((size_t) getNumPoints()); getQuadratureWeights(weights.data()); }
     void getQuadratureWeights(double weights[]) const; // static memory, assumes that weights has size getNumPoints()
 
-    double* getInterpolationWeights(double const x[]) const;
-    void getInterpolationWeights(const double x[], double weights[]) const; // static memory, assumes that weights has size getNumPoints()
-    void getInterpolationWeights(const std::vector<double> &x, std::vector<double> &weights) const; // dynamic memory, resizes weights
+    std::vector<double> getInterpolationWeights(std::vector<double> const &x) const;
+    std::vector<double> getInterpolationWeights(double const x[]) const{ std::vector<double> w((size_t) getNumPoints()); getInterpolationWeights(x, w.data()); return w; }
+    void getInterpolationWeights(const std::vector<double> &x, std::vector<double> &weights) const;
+    void getInterpolationWeights(const double x[], double weights[]) const;
 
     void loadNeededPoints(const double *vals); // no error checking
     void loadNeededPoints(const std::vector<double> &vals); // checks if vals has size num_outputs X getNumNeeded()

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -117,9 +117,9 @@ public:
     TypeOneDRule getRule() const;
     const char* getCustomRuleDescription() const; // used only for Global Grids with rule_customtabulated
 
-    int getNumLoaded() const;
-    int getNumNeeded() const;
-    int getNumPoints() const; // returns the number of loaded points unless no points are loaded, then returns the number of needed points
+    int getNumLoaded() const{ return (base) ? base->getNumLoaded() : 0; }
+    int getNumNeeded() const{ return (base) ? base->getNumNeeded() : 0; }
+    int getNumPoints() const{ return (base) ? base->getNumPoints() : 0; }
 
     std::vector<double> getLoadedPoints() const{ std::vector<double> x; getLoadedPoints(x); return x; }
     std::vector<double> getNeededPoints() const{ std::vector<double> x; getNeededPoints(x); return x; }
@@ -157,12 +157,12 @@ public:
     void evaluateBatch(const std::vector<double> &x, std::vector<double> &y) const;
     void integrate(std::vector<double> &q) const;
 
-    bool isGlobal() const;
-    bool isSequence() const;
-    bool isLocalPolynomial() const;
-    bool isWavelet() const;
-    bool isFourier() const;
-    inline bool empty() const{ return (base.get() == nullptr); }
+    bool isGlobal() const{ return base && base->isGlobal(); }
+    bool isSequence() const{ return base && base->isSequence(); }
+    bool isLocalPolynomial() const{ return base && base->isLocalPolynomial(); }
+    bool isWavelet() const{ return base && base->isWavelet(); }
+    bool isFourier() const{ return base && base->isFourier(); }
+    bool empty() const{ return !base; }
 
     void setDomainTransform(const double a[], const double b[]); // set the ranges of the box, a[] and b[] must have size num_dimensions
     bool isSetDomainTransfrom() const;

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -82,8 +82,8 @@ public:
     void write(const char *filename, bool binary = false) const;
     void read(const char *filename); // auto-check if format is binary or ascii
 
-    void write(std::ofstream &ofs, bool binary = false) const;
-    void read(std::ifstream &ifs, bool binary = false);
+    void write(std::ostream &ofs, bool binary = false) const;
+    void read(std::istream &ifs, bool binary = false);
 
     void makeGlobalGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const int *anisotropic_weights = 0, double alpha = 0.0, double beta = 0.0, const char* custom_filename = 0, const int *level_limits = 0);
     void makeGlobalGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule, const std::vector<int> &anisotropic_weights, double alpha = 0.0, double beta = 0.0, const char* custom_filename = 0, const std::vector<int> &level_limits = std::vector<int>());
@@ -301,11 +301,11 @@ protected:
     #endif
     void formTransformedPoints(int num_points, double x[]) const; // when calling get***Points()
 
-    void writeAscii(std::ofstream &ofs) const;
-    void readAscii(std::ifstream &ifs);
+    void writeAscii(std::ostream &ofs) const;
+    void readAscii(std::istream &ifs);
 
-    void writeBinary(std::ofstream &ofs) const;
-    void readBinary(std::ifstream &ifs);
+    void writeBinary(std::ostream &ofs) const;
+    void readBinary(std::istream &ifs);
 
 private:
     std::unique_ptr<BaseCanonicalGrid> base;

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -112,8 +112,8 @@ public:
     double getBeta() const;
     int getOrder() const;
 
-    int getNumDimensions() const;
-    int getNumOutputs() const;
+    int getNumDimensions() const{ return (base) ? base->getNumDimensions() : 0; }
+    int getNumOutputs() const{ return (base) ? base->getNumOutputs() : 0; }
     TypeOneDRule getRule() const;
     const char* getCustomRuleDescription() const; // used only for Global Grids with rule_customtabulated
 

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -206,12 +206,12 @@ public:
     //! \brief Generate a sorted list of points weighted by descending importance using the \b type and provided anisotropic_weights (expensive call, roughly equivalent to set-refinement)
 
     //! If no weights are provided, isotropic weights will be imposed. Tensor types fall-back to \b type_level (not recommended to use here).
-    void getCandidateConstructionPoints(TypeDepth type, std::vector<double> &x, const std::vector<int> &anisotropic_weights = std::vector<int>(), const std::vector<int> &level_limits = std::vector<int>());
+    std::vector<double> getCandidateConstructionPoints(TypeDepth type, const std::vector<int> &anisotropic_weights = std::vector<int>(), const std::vector<int> &level_limits = std::vector<int>());
     //! \brief Same as \b getCandidateConstructionPoints() but the weights are obtained from a call to \b estimateAnisotropicCoefficients().
 
     //! Unlike \b estimateAnisotropicCoefficients(), this function will not throw if the grid is empty; instead, isotropic coefficient will be used
     //! until enough points are loaded so that coefficients can be estimated.
-    void getCandidateConstructionPoints(TypeDepth type, int output, std::vector<double> &x, const std::vector<int> &level_limits = std::vector<int>());
+    std::vector<double> getCandidateConstructionPoints(TypeDepth type, int output, const std::vector<int> &level_limits = std::vector<int>());
 
     /*!
      * \brief Returns a sorted list of points weighted by descending importance using the hierarchical surpluses.
@@ -219,7 +219,7 @@ public:
      * Used by the local polynomial grids, performs a refinement similar to \b setSurplusRefinement(\b double, \b TypeRefinement),
      * but in a construction context and the returned points are sorted by magnitude of the hierarchical surplus.
      */
-    void getCandidateConstructionPoints(double tolerance, TypeRefinement criteria, std::vector<double> &x, int output = -1, const std::vector<int> &level_limits = std::vector<int>(), const std::vector<double> &scale_correction = std::vector<double>());
+    std::vector<double> getCandidateConstructionPoints(double tolerance, TypeRefinement criteria, int output = -1, const std::vector<int> &level_limits = std::vector<int>(), const std::vector<double> &scale_correction = std::vector<double>());
     //! \brief Add the value of a single point (if the tensor of the point is not complete, the grid will not be updated but the value will be stored)
     void loadConstructedPoint(const std::vector<double> &x, const std::vector<double> &y);
     //! \brief Same as \b loadConstructedPoint() but using arrays in place of vectors (array size is not checked)

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -236,7 +236,7 @@ public:
     void evaluateHierarchicalFunctions(const std::vector<double> &x, std::vector<double> &y) const;
     void setHierarchicalCoefficients(const std::vector<double> &c);
 
-    void getGlobalPolynomialSpace(bool interpolation, int &num_indexes, int* &poly) const;
+    std::vector<int> getGlobalPolynomialSpace(bool interpolation) const;
 
     void printStats(std::ostream &os = std::cout) const;
 

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -121,9 +121,9 @@ public:
     int getNumNeeded() const;
     int getNumPoints() const; // returns the number of loaded points unless no points are loaded, then returns the number of needed points
 
-    double* getLoadedPoints() const;
-    double* getNeededPoints() const;
-    double* getPoints() const; // returns the loaded points unless no points are loaded, then returns the needed points
+    std::vector<double> getLoadedPoints() const{ std::vector<double> x; getLoadedPoints(x); return x; }
+    std::vector<double> getNeededPoints() const{ std::vector<double> x; getNeededPoints(x); return x; }
+    std::vector<double> getPoints() const{ std::vector<double> x; getPoints(x); return x; }
 
     void getLoadedPoints(double *x) const; // using static memory, assuming x has size num_dimensions X get***Points()
     void getNeededPoints(double *x) const;

--- a/SparseGrids/TasmanianSparseGridWrapC.cpp
+++ b/SparseGrids/TasmanianSparseGridWrapC.cpp
@@ -234,10 +234,9 @@ int* tsgEstimateAnisotropicCoefficients(void *grid, const char * sType, int outp
     if ((depth_type == type_curved) || (depth_type == type_ipcurved) || (depth_type == type_qpcurved)){
         *num_coefficients *= 2;
     }
-    int *coeff = ((TasmanianSparseGrid*) grid)->estimateAnisotropicCoefficients(depth_type, output);
+    auto coeff = ((TasmanianSparseGrid*) grid)->estimateAnisotropicCoefficients(depth_type, output);
     int *result = (int*) malloc((*num_coefficients) * sizeof(int));
     for(int i=0; i<*num_coefficients; i++) result[i] = coeff[i];
-    delete[] coeff;
     return result;
 }
 void tsgEstimateAnisotropicCoefficientsStatic(void *grid, const char * sType, int output, int *coefficients){
@@ -250,9 +249,8 @@ void tsgEstimateAnisotropicCoefficientsStatic(void *grid, const char * sType, in
     if ((depth_type == type_curved) || (depth_type == type_ipcurved) || (depth_type == type_qpcurved)){
         num_coefficients *= 2;
     }
-    int *coeff = ((TasmanianSparseGrid*) grid)->estimateAnisotropicCoefficients(depth_type, output);
+    auto coeff = ((TasmanianSparseGrid*) grid)->estimateAnisotropicCoefficients(depth_type, output);
     for(int i=0; i<num_coefficients; i++) coefficients[i] = coeff[i];
-    delete[] coeff;
 }
 void tsgSetGlobalSurplusRefinement(void *grid, double tolerance, int output, const int *level_limits){
     ((TasmanianSparseGrid*) grid)->setSurplusRefinement(tolerance, output, level_limits);

--- a/SparseGrids/TasmanianSparseGridWrapC.cpp
+++ b/SparseGrids/TasmanianSparseGridWrapC.cpp
@@ -411,15 +411,14 @@ int tsgGetGPUMemory(int gpu){ return TasmanianSparseGrid::getGPUMemory(gpu); }
 int tsgIsAccelerationAvailable(const char *accel){ return (TasmanianSparseGrid::isAccelerationAvailable(AccelerationMeta::getIOAccelerationString(accel))) ? 1 : 0; }
 void tsgGetGPUName(int gpu, int num_buffer, char *buffer, int *num_actual){
     // gpu is the gpuID, num_buffer is the size of *buffer, num_actual returns the actual number of chars
-    char* name = TasmanianSparseGrid::getGPUName(gpu);
-    int c = 0;
-    while ((name[c] != '\0') && (c < num_buffer-1)){
-        buffer[c] = name[c];
-        c++;
-    }
-    buffer[c] = '\0';
-    num_actual[0] = c;
-    delete[] name;
+    if (num_buffer == 0) return;
+    std::string name = TasmanianSparseGrid::getGPUName(gpu);
+
+    size_t chars = std::min((size_t) (num_buffer - 1), name.size());
+    std::copy(name.begin(), name.begin() + chars, buffer);
+    buffer[chars] = '\0';
+
+    *num_actual = (int) chars;
 }
 
 void tsgDeleteInts(int *p){ delete[] p; }

--- a/SparseGrids/TasmanianSparseGridWrapC.cpp
+++ b/SparseGrids/TasmanianSparseGridWrapC.cpp
@@ -382,19 +382,19 @@ void tsgSetHierarchicalCoefficients(void *grid, const double *c){
 
 // to be called from Python only, must later call delete[] on the pointer
 int* tsgPythonGetGlobalPolynomialSpace(void *grid, int interpolation, int *num_indexes){
-    int *indx = 0;;
-    ((TasmanianSparseGrid*) grid)->getGlobalPolynomialSpace((interpolation != 0), *num_indexes, indx);
+    std::vector<int> space = ((TasmanianSparseGrid*) grid)->getGlobalPolynomialSpace((interpolation != 0));
+    int *indx = new int[space.size()];
+    std::copy(space.begin(), space.end(), indx);
+    *num_indexes = (int) space.size() / ((TasmanianSparseGrid*) grid)->getNumDimensions();
     return indx;
 }
 // to be used in C, creates a C pointer (requires internal copy of data)
 void tsgGetGlobalPolynomialSpace(void *grid, int interpolation, int *num_indexes, int **indexes){
-    int *indx = 0, num_ind, num_dims = ((TasmanianSparseGrid*) grid)->getNumDimensions();
-    ((TasmanianSparseGrid*) grid)->getGlobalPolynomialSpace((interpolation != 0), num_ind, indx);
-    *num_indexes = num_ind;
-    if (indx != 0){
-        *indexes = (int*) malloc(((*num_indexes) * num_dims) * sizeof(int));
-        for(int i=0; i<((*num_indexes) * num_dims); i++) (*indexes)[i] = indx[i];
-        delete[] indx;
+    std::vector<int> space = ((TasmanianSparseGrid*) grid)->getGlobalPolynomialSpace((interpolation != 0));
+    *num_indexes = (int) space.size() / ((TasmanianSparseGrid*) grid)->getNumDimensions();
+    if (!space.empty()){
+        *indexes = (int*) malloc(space.size() * sizeof(int));
+        std::copy(space.begin(), space.end(), *indexes);
     }
 }
 

--- a/SparseGrids/TasmanianSparseGridWrapC.cpp
+++ b/SparseGrids/TasmanianSparseGridWrapC.cpp
@@ -286,7 +286,7 @@ void* tsgGetCandidateConstructionPointsVoidPntr(void *grid, const char *sType, i
     std::vector<int> veclimits;
     if (limit_levels != nullptr) veclimits = std::vector<int>(limit_levels, limit_levels + dims);
     if (anisotropic_weights == nullptr){
-        ((TasmanianSparseGrid*) grid)->getCandidateConstructionPoints(depth_type, output, *vecx, veclimits);
+        *vecx = ((TasmanianSparseGrid*) grid)->getCandidateConstructionPoints(depth_type, output, veclimits);
     }else{
         int num_weights = ((TasmanianSparseGrid*) grid)->getNumDimensions();
         if ((depth_type == type_curved) || (depth_type == type_ipcurved) || (depth_type == type_qpcurved)){
@@ -294,7 +294,7 @@ void* tsgGetCandidateConstructionPointsVoidPntr(void *grid, const char *sType, i
         }
         std::vector<int> vecweights(anisotropic_weights, anisotropic_weights +
                                     (((depth_type == type_curved) || (depth_type == type_ipcurved) || (depth_type == type_qpcurved)) ? 2*dims : dims));
-        ((TasmanianSparseGrid*) grid)->getCandidateConstructionPoints(depth_type, *vecx, vecweights, veclimits);
+        *vecx = ((TasmanianSparseGrid*) grid)->getCandidateConstructionPoints(depth_type, vecweights, veclimits);
     }
     return (void*) vecx;
 }
@@ -314,7 +314,7 @@ void* tsgGetCandidateConstructionPointsSurplusVoidPntr(void *grid, double tolera
         size_t active_outputs = (size_t) (output == -1) ? ((TasmanianSparseGrid*) grid)->getNumOutputs() : 1;
         vecscale = std::vector<double>(scale_correction, scale_correction + ((size_t) ((TasmanianSparseGrid*) grid)->getNumLoaded() * active_outputs));
     }
-    ((TasmanianSparseGrid*) grid)->getCandidateConstructionPoints(tolerance, ref_type, *vecx, output, veclimits, vecscale);
+    *vecx = ((TasmanianSparseGrid*) grid)->getCandidateConstructionPoints(tolerance, ref_type, output, veclimits, vecscale);
     return (void*) vecx;
 }
 void tsgGetCandidateConstructionPoints(void *grid, const char *sType, int output, const int *anisotropic_weights, const int *limit_levels, int *num_points, double **x){

--- a/SparseGrids/tasgridExternalTests.cpp
+++ b/SparseGrids/tasgridExternalTests.cpp
@@ -2187,9 +2187,7 @@ void ExternalTester::benchmark(int argc, const char **argv){
         int width = 15;
         cout << setw(24) << "CPU";
         if (gpu > -1){
-            char *name = grid->getGPUName(gpu);
-            cout << setw(2*width + width/2) << name;
-            delete[] name;
+            cout << setw(2*width + width/2) << grid->getGPUName(gpu);
         }else{
             cout << setw(width + width/2) << "CPU";
         }

--- a/SparseGrids/tasgridExternalTests.cpp
+++ b/SparseGrids/tasgridExternalTests.cpp
@@ -538,7 +538,7 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
         grid.makeGlobalGrid(1, 1, 6, type_level, oned);
         double transa = 4.0, transb = 7.0;
         grid.setDomainTransform(&transa, &transb);
-        double *w = grid.getQuadratureWeights();
+        auto w = grid.getQuadratureWeights();
         auto p = grid.getNeededPoints();
         int num_p = grid.getNumNeeded();
         double sum = 0.0; for(int i=0; i<num_p; i++) sum += w[i];
@@ -553,7 +553,6 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
             cout << "ERROR: disrepancy in transformed gauss-chebyshev-1 rule is: " << fabs(sum - M_PI * sqrt(7.0) / 14.0) << endl;
             cout << setw(wfirst) << "Rule" << setw(wsecond) << TasGrid::OneDimensionalMeta::getIORuleString(oned) << setw(wthird) << "FAIL" << endl;  pass = false;
         }
-        delete[] w;
     }else if ((oned == TasGrid::rule_gausschebyshev2) || (oned == TasGrid::rule_gausschebyshev2odd)){
         // Gauss-Chebyshev-2 translated to [4, 7], area = 9.0 * M_PI / 2.0, integral of f(x) = (7 - x)^0.5 (x - 4)^0.5 is 9.0 / 2.0
         TasGrid::TasmanianSparseGrid grid;
@@ -582,7 +581,7 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
         grid.makeGlobalGrid(1, 1, 10, type_level, oned, 0, 2.0);
         double transa = 4.0, transb = 7.0;
         grid.setDomainTransform(&transa, &transb);
-        double *w = grid.getQuadratureWeights();
+        auto w = grid.getQuadratureWeights();
         auto p = grid.getNeededPoints();
         int num_p = grid.getNumNeeded();
         double sum = 0.0; for(int i=0; i<num_p; i++) sum += w[i];
@@ -596,14 +595,13 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
             cout << "ERROR: disrepancy in transformed gauss-gegenbauer rule is: " << fabs(sum - 389367.0 / 280.0) << endl;
             cout << setw(wfirst) << "Rule" << setw(wsecond) << TasGrid::OneDimensionalMeta::getIORuleString(oned) << setw(wthird) << "FAIL" << endl;  pass = false;
         }
-        delete[] w;
     }else if ((oned == TasGrid::rule_gaussjacobi) || (oned == TasGrid::rule_gaussjacobiodd)){
         // Gauss-Jacobi translated to [4, 7], area = 12.15, integral of f(x) = x^3 is 389367.0 / 280.0
         TasGrid::TasmanianSparseGrid grid;
         grid.makeGlobalGrid(1, 1, 10, type_level, oned, 0, 3.0, 2.0);
         double transa = 4.0, transb = 7.0;
         grid.setDomainTransform(&transa, &transb);
-        double *w = grid.getQuadratureWeights();
+        auto w = grid.getQuadratureWeights();
         auto p = grid.getNeededPoints();
         int num_p = grid.getNumNeeded();
         double sum = 0.0; for(int i=0; i<num_p; i++) sum += w[i];
@@ -617,14 +615,13 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
             cout << "ERROR: disrepancy in transformed gauss-jacobi rule is: " << fabs(sum + 18.0 * (3.0 * M_PI * M_PI - 4.0) / pow(M_PI, 5.0)) << endl;
             cout << setw(wfirst) << "Rule" << setw(wsecond) << TasGrid::OneDimensionalMeta::getIORuleString(oned) << setw(wthird) << "FAIL" << endl;  pass = false;
         }
-        delete[] w;
     }else if ((oned == TasGrid::rule_gausslaguerre) || (oned == TasGrid::rule_gausslaguerreodd)){
         // Gauss-Laguerre, unbounded domain
         TasGrid::TasmanianSparseGrid grid;
         grid.makeGlobalGrid(2, 1, 6, type_level, oned, 0, 3.0);
         double transa[2] = {4.0, 3.0}, transb[2] = {0.5, 0.75};
         grid.setDomainTransform(transa, transb);
-        double *w = grid.getQuadratureWeights();
+        auto w = grid.getQuadratureWeights();
         auto p = grid.getNeededPoints();
         int num_p = grid.getNumNeeded();
         double sum = 0.0; for(int i=0; i<num_p; i++) sum += w[i];
@@ -645,7 +642,6 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
             cout << "ERROR: nodal interpolation using gauss-laguerre: " << fabs(sum - test_x[0] * test_x[0] * test_x[1] * test_x[1] * test_x[1]) << endl;
             cout << setw(wfirst) << "Rule" << setw(wsecond) << TasGrid::OneDimensionalMeta::getIORuleString(oned) << setw(wthird) << "FAIL" << endl;  pass = false;
         }
-        delete[] w;
         delete[] iw;
     }else if ((oned == TasGrid::rule_gausshermite) || (oned == TasGrid::rule_gausshermiteodd)){
         // Gauss-Hermite, unbounded domain
@@ -653,7 +649,7 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
         grid.makeGlobalGrid(2, 1, 6, type_level, oned, 0, 4.0);
         double transa[2] = {4.0, 3.0}, transb[2] = {0.5, 0.75};
         grid.setDomainTransform(transa, transb);
-        double *w = grid.getQuadratureWeights();
+        auto w = grid.getQuadratureWeights();
         auto p = grid.getNeededPoints();
         int num_p = grid.getNumNeeded();
         double sum = 0.0; for(int i=0; i<num_p; i++) sum += w[i];
@@ -674,7 +670,6 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
             cout << "ERROR: nodal interpolation using gauss-hermite: " << fabs(sum - test_x[0] * test_x[0] * test_x[1] * test_x[1] * test_x[1]) << endl;
             cout << setw(wfirst) << "Rule" << setw(wsecond) << TasGrid::OneDimensionalMeta::getIORuleString(oned) << setw(wthird) << "FAIL" << endl;  pass = false;
         }
-        delete[] w;
         delete[] iw;
     }
     return pass;

--- a/SparseGrids/tasgridExternalTests.cpp
+++ b/SparseGrids/tasgridExternalTests.cpp
@@ -539,7 +539,7 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
         double transa = 4.0, transb = 7.0;
         grid.setDomainTransform(&transa, &transb);
         double *w = grid.getQuadratureWeights();
-        double *p = grid.getNeededPoints();
+        auto p = grid.getNeededPoints();
         int num_p = grid.getNumNeeded();
         double sum = 0.0; for(int i=0; i<num_p; i++) sum += w[i];
         if (fabs(sum - M_PI) > TSG_NUM_TOL){
@@ -554,7 +554,6 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
             cout << setw(wfirst) << "Rule" << setw(wsecond) << TasGrid::OneDimensionalMeta::getIORuleString(oned) << setw(wthird) << "FAIL" << endl;  pass = false;
         }
         delete[] w;
-        delete[] p;
     }else if ((oned == TasGrid::rule_gausschebyshev2) || (oned == TasGrid::rule_gausschebyshev2odd)){
         // Gauss-Chebyshev-2 translated to [4, 7], area = 9.0 * M_PI / 2.0, integral of f(x) = (7 - x)^0.5 (x - 4)^0.5 is 9.0 / 2.0
         TasGrid::TasmanianSparseGrid grid;
@@ -563,8 +562,7 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
         grid.setDomainTransform(&transa, &transb);
         std::vector<double> w;
         grid.getQuadratureWeights(w);
-        std::vector<double> p;
-        grid.getNeededPoints(p);
+        std::vector<double> p = grid.getNeededPoints();
         int num_p = grid.getNumNeeded();
         double sum = 0.0; for(int i=0; i<num_p; i++) sum += w[i];
         if (fabs(sum - 9.0 * M_PI / 8.0) > TSG_NUM_TOL){
@@ -585,7 +583,7 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
         double transa = 4.0, transb = 7.0;
         grid.setDomainTransform(&transa, &transb);
         double *w = grid.getQuadratureWeights();
-        double *p = grid.getNeededPoints();
+        auto p = grid.getNeededPoints();
         int num_p = grid.getNumNeeded();
         double sum = 0.0; for(int i=0; i<num_p; i++) sum += w[i];
         if (fabs(sum - 8.1) > TSG_NUM_TOL){
@@ -599,7 +597,6 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
             cout << setw(wfirst) << "Rule" << setw(wsecond) << TasGrid::OneDimensionalMeta::getIORuleString(oned) << setw(wthird) << "FAIL" << endl;  pass = false;
         }
         delete[] w;
-        delete[] p;
     }else if ((oned == TasGrid::rule_gaussjacobi) || (oned == TasGrid::rule_gaussjacobiodd)){
         // Gauss-Jacobi translated to [4, 7], area = 12.15, integral of f(x) = x^3 is 389367.0 / 280.0
         TasGrid::TasmanianSparseGrid grid;
@@ -607,7 +604,7 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
         double transa = 4.0, transb = 7.0;
         grid.setDomainTransform(&transa, &transb);
         double *w = grid.getQuadratureWeights();
-        double *p = grid.getNeededPoints();
+        auto p = grid.getNeededPoints();
         int num_p = grid.getNumNeeded();
         double sum = 0.0; for(int i=0; i<num_p; i++) sum += w[i];
         if (fabs(sum - 12.15) > TSG_NUM_TOL){
@@ -621,7 +618,6 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
             cout << setw(wfirst) << "Rule" << setw(wsecond) << TasGrid::OneDimensionalMeta::getIORuleString(oned) << setw(wthird) << "FAIL" << endl;  pass = false;
         }
         delete[] w;
-        delete[] p;
     }else if ((oned == TasGrid::rule_gausslaguerre) || (oned == TasGrid::rule_gausslaguerreodd)){
         // Gauss-Laguerre, unbounded domain
         TasGrid::TasmanianSparseGrid grid;
@@ -629,7 +625,7 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
         double transa[2] = {4.0, 3.0}, transb[2] = {0.5, 0.75};
         grid.setDomainTransform(transa, transb);
         double *w = grid.getQuadratureWeights();
-        double *p = grid.getNeededPoints();
+        auto p = grid.getNeededPoints();
         int num_p = grid.getNumNeeded();
         double sum = 0.0; for(int i=0; i<num_p; i++) sum += w[i];
         if (fabs(sum - 96.0 * 512.0 / 27.0) > TSG_NUM_TOL){
@@ -649,7 +645,6 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
             cout << "ERROR: nodal interpolation using gauss-laguerre: " << fabs(sum - test_x[0] * test_x[0] * test_x[1] * test_x[1] * test_x[1]) << endl;
             cout << setw(wfirst) << "Rule" << setw(wsecond) << TasGrid::OneDimensionalMeta::getIORuleString(oned) << setw(wthird) << "FAIL" << endl;  pass = false;
         }
-        delete[] p;
         delete[] w;
         delete[] iw;
     }else if ((oned == TasGrid::rule_gausshermite) || (oned == TasGrid::rule_gausshermiteodd)){
@@ -659,7 +654,7 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
         double transa[2] = {4.0, 3.0}, transb[2] = {0.5, 0.75};
         grid.setDomainTransform(transa, transb);
         double *w = grid.getQuadratureWeights();
-        double *p = grid.getNeededPoints();
+        auto p = grid.getNeededPoints();
         int num_p = grid.getNumNeeded();
         double sum = 0.0; for(int i=0; i<num_p; i++) sum += w[i];
         if (fabs(sum - (8.0 * M_PI / 3.0) * sqrt(6.0)) > TSG_NUM_TOL){
@@ -679,7 +674,6 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
             cout << "ERROR: nodal interpolation using gauss-hermite: " << fabs(sum - test_x[0] * test_x[0] * test_x[1] * test_x[1] * test_x[1]) << endl;
             cout << setw(wfirst) << "Rule" << setw(wsecond) << TasGrid::OneDimensionalMeta::getIORuleString(oned) << setw(wthird) << "FAIL" << endl;  pass = false;
         }
-        delete[] p;
         delete[] w;
         delete[] iw;
     }
@@ -1467,7 +1461,7 @@ bool ExternalTester::testAllDomain() const{
         for(int i=0; i<5; i++){
             grid.makeSequenceGrid(f->getNumInputs(), f->getNumOutputs(), i+5, TasGrid::type_level, TasGrid::rule_leja);
             grid.setDomainTransform(transform_a, transform_b);
-            double *needed_points = grid.getNeededPoints();
+            auto needed_points = grid.getNeededPoints();
             int num_needed = grid.getNumNeeded();
             TestResults R = getError(f, &grid, type_integration);
             if (R.error > errs[i]){
@@ -1488,15 +1482,13 @@ bool ExternalTester::testAllDomain() const{
                 cout << "Failed domain transform test interpolation for " << f->getDescription() << "   error = " << R.error << "  expected: " << errs[i] << endl;
                      pass2 = false;
             }
-            double *loaded_points = grid.getLoadedPoints();
+            auto loaded_points = grid.getLoadedPoints();
             for(int j=0; j<num_needed * f->getNumInputs(); j++){
                 if (fabs(needed_points[j] - loaded_points[j]) > TSG_NUM_TOL){
                     cout << "Mismatch between needed and loaded points" << endl;
                     pass2 = false;
                 }
             }
-            delete[] loaded_points;
-            delete[] needed_points;
         }
     }{
         const BaseFunction *f = &f21expDomain;
@@ -1572,7 +1564,7 @@ bool ExternalTester::testAllDomain() const{
             grid.makeGlobalGrid(f->getNumInputs(), f->getNumOutputs(), l+2, TasGrid::type_level, TasGrid::rule_clenshawcurtis);
             gridc.makeGlobalGrid(f->getNumInputs(), f->getNumOutputs(), l+2, TasGrid::type_level, TasGrid::rule_clenshawcurtis);
             gridc.setConformalTransformASIN(asin_conformal);
-            double *needed_points = grid.getNeededPoints();
+            auto needed_points = grid.getNeededPoints();
             int num_needed = grid.getNumNeeded();
             TestResults R1 = getError(f, &grid, type_internal_interpolation);
             TestResults R2 = getError(f, &gridc, type_internal_interpolation);
@@ -1596,15 +1588,13 @@ bool ExternalTester::testAllDomain() const{
                 cout << " conformal error = " << fabs(y2 - y_true) << endl;
                 pass3 = false;
             }
-            double *loaded_points = grid.getLoadedPoints();
+            auto loaded_points = grid.getLoadedPoints();
             for(int j=0; j<num_needed * f->getNumInputs(); j++){
                 if (fabs(needed_points[j] - loaded_points[j]) > TSG_NUM_TOL){
                     cout << "Mismatch between needed and loaded points" << endl;
                     pass2 = false;
                 }
             }
-            delete[] loaded_points;
-            delete[] needed_points;
         }
     }{
         TasmanianSparseGrid gridc;
@@ -2147,7 +2137,7 @@ void loadGridValues(TasmanianSparseGrid *grid){ // for benchmark
     int dims = grid->getNumDimensions(), num_outputs = grid->getNumOutputs();
     int num_points = grid->getNumNeeded();
     if (num_points == 0) return;
-    double *x = grid->getNeededPoints();
+    auto x = grid->getNeededPoints();
     double *v = new double[num_outputs * num_points];
     double s = 1.0 / ((double) (dims*dims));
     for(int i=0; i<num_points; i++){

--- a/SparseGrids/tasgridExternalTests.cpp
+++ b/SparseGrids/tasgridExternalTests.cpp
@@ -636,13 +636,12 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
             cout << setw(wfirst) << "Rule" << setw(wsecond) << TasGrid::OneDimensionalMeta::getIORuleString(oned) << setw(wthird) << "FAIL" << endl;  pass = false;
         }
         double test_x[2] = {3.0 + sqrt(2.0), 2.0 + sqrt(2.0)};
-        double *iw = grid.getInterpolationWeights(test_x);
+        auto iw = grid.getInterpolationWeights(test_x);
         sum = 0.0; for(int i=0; i<num_p; i++) sum += iw[i] * (p[2*i]*p[2*i] * p[2*i+1]*p[2*i+1]*p[2*i+1]);
         if (fabs(sum - test_x[0] * test_x[0] * test_x[1] * test_x[1] * test_x[1]) > 2.E-9){
             cout << "ERROR: nodal interpolation using gauss-laguerre: " << fabs(sum - test_x[0] * test_x[0] * test_x[1] * test_x[1] * test_x[1]) << endl;
             cout << setw(wfirst) << "Rule" << setw(wsecond) << TasGrid::OneDimensionalMeta::getIORuleString(oned) << setw(wthird) << "FAIL" << endl;  pass = false;
         }
-        delete[] iw;
     }else if ((oned == TasGrid::rule_gausshermite) || (oned == TasGrid::rule_gausshermiteodd)){
         // Gauss-Hermite, unbounded domain
         TasGrid::TasmanianSparseGrid grid;
@@ -664,13 +663,12 @@ bool ExternalTester::performGaussTransfromTest(TasGrid::TypeOneDRule oned) const
             cout << setw(wfirst) << "Rule" << setw(wsecond) << TasGrid::OneDimensionalMeta::getIORuleString(oned) << setw(wthird) << "FAIL" << endl;  pass = false;
         }
         double test_x[2] = {3.0 + sqrt(2.0), 2.0 + sqrt(2.0)};
-        double *iw = grid.getInterpolationWeights(test_x);
+        auto iw = grid.getInterpolationWeights(test_x);
         sum = 0.0; for(int i=0; i<num_p; i++) sum += iw[i] * (p[2*i]*p[2*i] * p[2*i+1]*p[2*i+1]*p[2*i+1]*p[2*i+1]);
         if (fabs(sum - test_x[0] * test_x[0] * test_x[1] * test_x[1] * test_x[1] * test_x[1]) > 1.E-9){
             cout << "ERROR: nodal interpolation using gauss-hermite: " << fabs(sum - test_x[0] * test_x[0] * test_x[1] * test_x[1] * test_x[1]) << endl;
             cout << setw(wfirst) << "Rule" << setw(wsecond) << TasGrid::OneDimensionalMeta::getIORuleString(oned) << setw(wthird) << "FAIL" << endl;  pass = false;
         }
-        delete[] iw;
     }
     return pass;
 }

--- a/SparseGrids/tasgridExternalTests.cpp
+++ b/SparseGrids/tasgridExternalTests.cpp
@@ -833,12 +833,12 @@ bool ExternalTester::testDynamicRefinement(const BaseFunction *f, TasmanianSpars
             if (itr == 1){
                 std::vector<int> weights;
                 grid->estimateAnisotropicCoefficients(type, 0, weights);
-                grid->getCandidateConstructionPoints(type, points, weights);
+                points = grid->getCandidateConstructionPoints(type, weights);
             }else{
-                grid->getCandidateConstructionPoints(type, 0, points);
+                points = grid->getCandidateConstructionPoints(type, 0);
             }
         }else{
-            grid->getCandidateConstructionPoints(tolerance, reftype, points);
+            points = grid->getCandidateConstructionPoints(tolerance, reftype);
         }
         size_t num_points = points.size() / dims;
         size_t max_points = (grid->isLocalPolynomial()) ? 123 : 32;

--- a/SparseGrids/tasgridUnitTests.cpp
+++ b/SparseGrids/tasgridUnitTests.cpp
@@ -309,31 +309,12 @@ bool GridUnitTester::testAPIconsistency(){
 
     // test array and vector consistency between the two versions of the API
     bool pass = true;
-    double *apoints;
     std::vector<double> vpoints;
 
     TasmanianSparseGrid grid;
     grid.makeGlobalGrid(2, 1, 4, type_iptotal, rule_clenshawcurtis);
     gridLoadEN2(&grid);
     grid.setAnisotropicRefinement(type_iptotal, 10, 0);
-
-    apoints = grid.getPoints();
-    grid.getPoints(vpoints);
-    pass = pass && doesMatch(vpoints, apoints);
-    delete[] apoints;
-    vpoints.clear();
-
-    apoints = grid.getLoadedPoints();
-    grid.getLoadedPoints(vpoints);
-    pass = pass && doesMatch(vpoints, apoints);
-    delete[] apoints;
-    vpoints.clear();
-
-    apoints = grid.getNeededPoints();
-    grid.getNeededPoints(vpoints);
-    pass = pass && doesMatch(vpoints, apoints);
-    delete[] apoints;
-    vpoints.clear();
 
     if (verbose) cout << setw(wfirst) << "API variation" << setw(wsecond) << "getPoints()" << setw(wthird) << ((pass) ? "Pass" : "FAIL") << endl;
     passAll = pass && passAll;

--- a/SparseGrids/tasgridWrapper.cpp
+++ b/SparseGrids/tasgridWrapper.cpp
@@ -612,7 +612,7 @@ bool TasgridWrapper::getAnisoCoeff(){
         cerr << "ERROR: cannot estimate coefficients for a grid with no loaded values!" << endl;
         return false;
     }
-    int *ab;
+    std::vector<int> ab;
     if (grid.isSequence()){
         ab = grid.estimateAnisotropicCoefficients(depth_type, ref_output);
     }else{
@@ -643,7 +643,6 @@ bool TasgridWrapper::getAnisoCoeff(){
         printMatrix(num_coeff, 1, coeff);
     }
     delete[] coeff;
-    delete[] ab;
 
     return true;
 }

--- a/SparseGrids/tasgridWrapper.cpp
+++ b/SparseGrids/tasgridWrapper.cpp
@@ -402,7 +402,7 @@ bool TasgridWrapper::readGrid(){
 }
 void TasgridWrapper::outputPoints(bool useNeeded) const{
     int num_p, num_d = grid.getNumDimensions();
-    double *points;
+    std::vector<double> points;
     if ((outfilename == 0) && (!printCout)) return;
     if (useNeeded){
         num_p = grid.getNumNeeded();
@@ -411,17 +411,16 @@ void TasgridWrapper::outputPoints(bool useNeeded) const{
         num_p = grid.getNumPoints();
         points = grid.getPoints();
     }
-    if (outfilename != 0) writeMatrix(outfilename, num_p, num_d, points, useASCII);
-    if (printCout) printMatrix(num_p, num_d, points);
-    delete[] points;
+    if (outfilename != 0) writeMatrix(outfilename, num_p, num_d, points.data(), useASCII);
+    if (printCout) printMatrix(num_p, num_d, points.data());
 }
 void TasgridWrapper::outputQuadrature() const{
-    double *points, *weights, *combined;
+    double *weights, *combined;
     if ((outfilename == 0) && (!printCout)) return;
     int num_p = grid.getNumPoints();
     int num_d = grid.getNumDimensions();
     int offset = num_d + 1;
-    points  = grid.getPoints();
+    auto points  = grid.getPoints();
     weights = grid.getQuadratureWeights();
     combined = new double[num_p * offset];
     for(int i=0; i<num_p; i++){
@@ -436,7 +435,6 @@ void TasgridWrapper::outputQuadrature() const{
     }
     delete[] combined;
     delete[] weights;
-    delete[] points;
 }
 void TasgridWrapper::outputHierarchicalCoefficients() const{
     const double *coeff = grid.getHierarchicalCoefficients();

--- a/SparseGrids/tasgridWrapper.cpp
+++ b/SparseGrids/tasgridWrapper.cpp
@@ -755,18 +755,15 @@ bool TasgridWrapper::getPoly(){
     if ((grid.isGlobal()) || (grid.isSequence())){
         int num_d = grid.getNumDimensions();
         bool integrate = ((depth_type == type_iptotal) || (depth_type == type_ipcurved) || (depth_type == type_iptensor) || (depth_type == type_iphyperbolic));
-        int n, *poly = 0;
-        grid.getGlobalPolynomialSpace(integrate, n, poly);
-        double *double_poly = new double[n * num_d];
-        for(int i=0; i<num_d * n; i++) double_poly[i] = (double) poly[i];
+        std::vector<int> poly = grid.getGlobalPolynomialSpace(integrate);
+        std::vector<double> double_poly(poly.size());
+        std::transform(poly.begin(), poly.end(), double_poly.begin(), [](int x)->double{ return static_cast<double>(x); });
         if (outfilename != 0){
-            writeMatrix(outfilename, n, num_d, double_poly, useASCII);
+            writeMatrix(outfilename, (int) double_poly.size() / num_d, num_d, double_poly.data(), useASCII);
         }
         if (printCout){
-            printMatrix(n, num_d, double_poly);
+            printMatrix((int) double_poly.size() / num_d, num_d, double_poly.data());
         }
-        delete[] poly;
-        delete[] double_poly;
     }else{
         cerr << "ERROR: cannot call -getpoly for a grid that is neither Global nor Sequence" << endl;
         return false;

--- a/SparseGrids/tasgridWrapper.cpp
+++ b/SparseGrids/tasgridWrapper.cpp
@@ -415,13 +415,13 @@ void TasgridWrapper::outputPoints(bool useNeeded) const{
     if (printCout) printMatrix(num_p, num_d, points.data());
 }
 void TasgridWrapper::outputQuadrature() const{
-    double *weights, *combined;
+    double *combined;
     if ((outfilename == 0) && (!printCout)) return;
     int num_p = grid.getNumPoints();
     int num_d = grid.getNumDimensions();
     int offset = num_d + 1;
     auto points  = grid.getPoints();
-    weights = grid.getQuadratureWeights();
+    auto weights = grid.getQuadratureWeights();
     combined = new double[num_p * offset];
     for(int i=0; i<num_p; i++){
         combined[i * offset] = weights[i];
@@ -434,7 +434,6 @@ void TasgridWrapper::outputQuadrature() const{
         printMatrix(num_p, offset, combined);
     }
     delete[] combined;
-    delete[] weights;
 }
 void TasgridWrapper::outputHierarchicalCoefficients() const{
     const double *coeff = grid.getHierarchicalCoefficients();

--- a/SparseGrids/tasgridWrapper.cpp
+++ b/SparseGrids/tasgridWrapper.cpp
@@ -525,9 +525,8 @@ bool TasgridWrapper::getInterWeights(){
     res = new double[((size_t) num_p) * rows];
     #pragma omp parallel for
     for(int i=0; i<(int) rows; i++){ // in windows OpenMP loop counters must be signed ??
-        double *r = grid.getInterpolationWeights(&(x[i*cols]));
-        std::copy(r, r + num_p, &(res[i * ((size_t) num_p)]));
-        delete[] r;
+        auto r = grid.getInterpolationWeights(&(x[i*cols]));
+        std::copy_n(r.begin(), num_p, &(res[i * ((size_t) num_p)]));
     }
     if (outfilename != 0){
         writeMatrix(outfilename, (int) rows, (int) num_p, res, useASCII);

--- a/SparseGrids/tasgrid_main.cpp
+++ b/SparseGrids/tasgrid_main.cpp
@@ -111,10 +111,9 @@ int main(int argc, const char ** argv){
             if (numGPUs > 0){
                 cout << "                 Available GPUs:" << endl;
                 for(int i=0; i<numGPUs; i++){
-                    char *name = TasmanianSparseGrid::getGPUName(i);
+                    std::string name = TasmanianSparseGrid::getGPUName(i);
                     int memory = TasmanianSparseGrid::getGPUMemory(i);
                     cout << setw(11) << i << ":" << setw(20) << name << " with" << setw(7) << memory << "MB of RAM" << endl;
-                    delete[] name;
                 }
             }else{
                 cout << "        Available GPUs: none" << endl;

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -416,20 +416,13 @@ unsigned long long AccelerationMeta::getTotalGPUMemory(int deviceID){
     cudaGetDeviceProperties(&prop, deviceID);
     return prop.totalGlobalMem;
 }
-char* AccelerationMeta::getCudaDeviceName(int deviceID){
-    char *name = new char[1];
-    name[0] = '\0';
-    if ((deviceID < 0) || (deviceID >= getNumCudaDevices())) return name;
+std::string AccelerationMeta::getCudaDeviceName(int deviceID){
+    if ((deviceID < 0) || (deviceID >= getNumCudaDevices())) return std::string();
+
     cudaDeviceProp prop;
     cudaGetDeviceProperties(&prop, deviceID);
 
-    int c = 0; while(prop.name[c] != '\0'){ c++; }
-    delete[] name;
-    name = new char[c+1];
-    for(int i=0; i<c; i++){ name[i] = prop.name[i]; }
-    name[c] = '\0';
-
-    return name;
+    return std::string(prop.name);
 }
 template<typename T> void AccelerationMeta::recvCudaArray(size_t num_entries, const T *gpu_data, std::vector<T> &cpu_data){
     cpu_data.resize(num_entries);

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -452,7 +452,7 @@ namespace AccelerationMeta{
     //! The character array has to be manually deleted to avoid memory leaks.
     //! This causes issues between different versions of CUDA, Nvidia uses fixed length character arrays and Tasmanian makes a copy;
     //! sometimes different versions of CUDA use different name length which causes unexpected crashes on the CUDA side.
-    char* getCudaDeviceName(int deviceID);
+    std::string getCudaDeviceName(int deviceID);
 
     //! \internal
     //! \brief Copy a device array to the main memory, used for testing only, always favor using \b CudaVector (if possible).

--- a/SparseGrids/tsgDConstructGridGlobal.hpp
+++ b/SparseGrids/tsgDConstructGridGlobal.hpp
@@ -249,10 +249,10 @@ struct SimpleConstructData{
  * \endinternal
  */
 template<bool useAscii>
-std::unique_ptr<SimpleConstructData> readSimpleConstructionData(size_t num_dimensions, size_t num_outputs, std::ifstream &ifs){
+std::unique_ptr<SimpleConstructData> readSimpleConstructionData(size_t num_dimensions, size_t num_outputs, std::istream &is){
     std::unique_ptr<SimpleConstructData> dynamic_values = std::unique_ptr<SimpleConstructData>(new SimpleConstructData);
-    dynamic_values->initial_points.read<useAscii>(ifs);
-    dynamic_values->data = readNodeDataList<useAscii>(num_dimensions, num_outputs, ifs);
+    dynamic_values->initial_points.read<useAscii>(is);
+    dynamic_values->data = readNodeDataList<useAscii>(num_dimensions, num_outputs, is);
     return dynamic_values;
 }
 

--- a/SparseGrids/tsgGridCore.hpp
+++ b/SparseGrids/tsgGridCore.hpp
@@ -87,10 +87,10 @@ public:
     virtual void mergeRefinement() = 0;
 
     virtual void beginConstruction(){}
-    virtual void writeConstructionDataBinary(std::ofstream&) const{}
-    virtual void writeConstructionData(std::ofstream&) const{}
-    virtual void readConstructionDataBinary(std::ifstream&){}
-    virtual void readConstructionData(std::ifstream&){}
+    virtual void writeConstructionDataBinary(std::ostream&) const{}
+    virtual void writeConstructionData(std::ostream&) const{}
+    virtual void readConstructionDataBinary(std::istream&){}
+    virtual void readConstructionData(std::istream&){}
     virtual void loadConstructedPoint(const double[], const std::vector<double> &){}
     virtual void finishConstruction(){}
 

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -680,7 +680,7 @@ std::vector<double> GridGlobal::computeSurpluses(int output, bool normalize) con
 
         if (normalize) for(auto &s : surp) s /= max_surp;
     }else{
-        MultiIndexSet polynomial_set = getPolynomialSpace(true);
+        MultiIndexSet polynomial_set = getPolynomialSpaceSet(true);
 
         MultiIndexSet quadrature_tensors =
             MultiIndexManipulations::generateLowerMultiIndexSet((size_t) num_dimensions, [&](const std::vector<int> &index) ->
@@ -877,7 +877,7 @@ void GridGlobal::clearAccelerationData(){
     #endif
 }
 
-MultiIndexSet GridGlobal::getPolynomialSpace(bool interpolation) const{
+MultiIndexSet GridGlobal::getPolynomialSpaceSet(bool interpolation) const{
     if (interpolation){
         if (rule == rule_customtabulated){
             return MultiIndexManipulations::createPolynomialSpace(active_tensors, [&](int l)-> int{ return custom.getIExact(l); });
@@ -893,12 +893,8 @@ MultiIndexSet GridGlobal::getPolynomialSpace(bool interpolation) const{
     }
 }
 
-void GridGlobal::getPolynomialSpace(bool interpolation, int &n, int* &poly) const{
-    MultiIndexSet polynomial_set = getPolynomialSpace(interpolation);
-
-    n = polynomial_set.getNumIndexes();
-    poly = new int[polynomial_set.getVector().size()];
-    std::copy(polynomial_set.getVector().begin(), polynomial_set.getVector().end(), poly);
+std::vector<int> GridGlobal::getPolynomialSpace(bool interpolation) const{
+    return std::move(getPolynomialSpaceSet(interpolation).getVector());
 }
 const int* GridGlobal::getPointIndexes() const{
     return ((points.empty()) ? needed.getIndex(0) : points.getIndex(0));

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -71,7 +71,7 @@ template<bool useAscii> void GridGlobal::write(std::ostream &os) const{
     }
 }
 
-template<bool useAscii> void GridGlobal::read(std::ifstream &is){
+template<bool useAscii> void GridGlobal::read(std::istream &is){
     reset(true); // true deletes any custom rule
     num_dimensions = IO::readNumber<useAscii, int>(is);
     num_outputs = IO::readNumber<useAscii, int>(is);
@@ -112,8 +112,8 @@ template<bool useAscii> void GridGlobal::read(std::ifstream &is){
 
 template void GridGlobal::write<true>(std::ostream &) const;
 template void GridGlobal::write<false>(std::ostream &) const;
-template void GridGlobal::read<true>(std::ifstream &);
-template void GridGlobal::read<false>(std::ifstream &);
+template void GridGlobal::read<true>(std::istream &);
+template void GridGlobal::read<false>(std::istream &);
 
 void GridGlobal::reset(bool includeCustom){
     clearAccelerationData();
@@ -404,23 +404,23 @@ void GridGlobal::beginConstruction(){
         values.resize(num_outputs, 0);
     }
 }
-void GridGlobal::writeConstructionDataBinary(std::ofstream &ofs) const{
-    dynamic_values->write<false>(ofs);
+void GridGlobal::writeConstructionDataBinary(std::ostream &os) const{
+    dynamic_values->write<false>(os);
 }
-void GridGlobal::writeConstructionData(std::ofstream &ofs) const{
-    dynamic_values->write<true>(ofs);
+void GridGlobal::writeConstructionData(std::ostream &os) const{
+    dynamic_values->write<true>(os);
 }
-void GridGlobal::readConstructionDataBinary(std::ifstream &ifs){
+void GridGlobal::readConstructionDataBinary(std::istream &is){
     dynamic_values = std::unique_ptr<DynamicConstructorDataGlobal>(new DynamicConstructorDataGlobal((size_t) num_dimensions, (size_t) num_outputs));
-    dynamic_values->read<false>(ifs);
+    dynamic_values->read<false>(is);
     int max_level = dynamic_values->getMaxTensor();
     if (max_level + 1 > wrapper.getNumLevels())
         wrapper.load(custom, max_level, rule, alpha, beta);
     dynamic_values->reloadPoints([&](int l)->int{ return wrapper.getNumPoints(l); });
 }
-void GridGlobal::readConstructionData(std::ifstream &ifs){
+void GridGlobal::readConstructionData(std::istream &is){
     dynamic_values = std::unique_ptr<DynamicConstructorDataGlobal>(new DynamicConstructorDataGlobal((size_t) num_dimensions, (size_t) num_outputs));
-    dynamic_values->read<true>(ifs);
+    dynamic_values->read<true>(is);
     int max_level = dynamic_values->getMaxTensor();
     if (max_level + 1 > wrapper.getNumLevels())
         wrapper.load(custom, max_level, rule, alpha, beta);

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -122,7 +122,7 @@ public:
 
     void clearAccelerationData();
 
-    void getPolynomialSpace(bool interpolation, int &n, int* &poly) const;
+    std::vector<int> getPolynomialSpace(bool interpolation) const;
 
     const int* getPointIndexes() const;
 
@@ -140,7 +140,7 @@ protected:
     void recomputeTensorRefs(const MultiIndexSet &work);
     void proposeUpdatedTensors();
     void acceptUpdatedTensors();
-    MultiIndexSet getPolynomialSpace(bool interpolation) const;
+    MultiIndexSet getPolynomialSpaceSet(bool interpolation) const;
 
     void mapIndexesToNodes(const std::vector<int> &indexes, double *x) const;
     void loadConstructedTensors();

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -111,9 +111,9 @@ public:
     void writeConstructionData(std::ofstream &ofs) const;
     void readConstructionDataBinary(std::ifstream &ifs);
     void readConstructionData(std::ifstream &ifs);
-    void getCandidateConstructionPoints(TypeDepth type, const std::vector<int> &weights, std::vector<double> &x, const std::vector<int> &level_limits);
-    void getCandidateConstructionPoints(TypeDepth type, int output, std::vector<double> &x, const std::vector<int> &level_limits);
-    void getCandidateConstructionPoints(std::function<double(const int *)> getTensorWeight, std::vector<double> &x, const std::vector<int> &level_limits);
+    std::vector<double> getCandidateConstructionPoints(TypeDepth type, const std::vector<int> &weights, const std::vector<int> &level_limits);
+    std::vector<double> getCandidateConstructionPoints(TypeDepth type, int output, const std::vector<int> &level_limits);
+    std::vector<double> getCandidateConstructionPoints(std::function<double(const int *)> getTensorWeight, const std::vector<int> &level_limits);
     void loadConstructedPoint(const double x[], const std::vector<double> &y);
     void finishConstruction();
 

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -58,7 +58,7 @@ public:
     bool isGlobal() const{ return true; }
 
     template<bool useAscii> void write(std::ostream &os) const;
-    template<bool useAscii> void read(std::ifstream &is);
+    template<bool useAscii> void read(std::istream &is);
 
     void makeGrid(int cnum_dimensions, int cnum_outputs, int depth, TypeDepth type, TypeOneDRule crule, const std::vector<int> &anisotropic_weights, double calpha, double cbeta, const char* custom_filename, const std::vector<int> &level_limits);
     void copyGrid(const GridGlobal *global);
@@ -107,10 +107,10 @@ public:
     void mergeRefinement();
 
     void beginConstruction();
-    void writeConstructionDataBinary(std::ofstream &ofs) const;
-    void writeConstructionData(std::ofstream &ofs) const;
-    void readConstructionDataBinary(std::ifstream &ifs);
-    void readConstructionData(std::ifstream &ifs);
+    void writeConstructionDataBinary(std::ostream &os) const;
+    void writeConstructionData(std::ostream &os) const;
+    void readConstructionDataBinary(std::istream &is);
+    void readConstructionData(std::istream &is);
     std::vector<double> getCandidateConstructionPoints(TypeDepth type, const std::vector<int> &weights, const std::vector<int> &level_limits);
     std::vector<double> getCandidateConstructionPoints(TypeDepth type, int output, const std::vector<int> &level_limits);
     std::vector<double> getCandidateConstructionPoints(std::function<double(const int *)> getTensorWeight, const std::vector<int> &level_limits);

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -450,17 +450,17 @@ void GridLocalPolynomial::beginConstruction(){
         indx.clear();
     }
 }
-void GridLocalPolynomial::writeConstructionDataBinary(std::ofstream &ofs) const{
-    dynamic_values->write<false>(ofs);
+void GridLocalPolynomial::writeConstructionDataBinary(std::ostream &os) const{
+    dynamic_values->write<false>(os);
 }
-void GridLocalPolynomial::writeConstructionData(std::ofstream &ofs) const{
-    dynamic_values->write<true>(ofs);
+void GridLocalPolynomial::writeConstructionData(std::ostream &os) const{
+    dynamic_values->write<true>(os);
 }
-void GridLocalPolynomial::readConstructionDataBinary(std::ifstream &ifs){
-    dynamic_values = readSimpleConstructionData<false>(num_dimensions, num_outputs, ifs);
+void GridLocalPolynomial::readConstructionDataBinary(std::istream &is){
+    dynamic_values = readSimpleConstructionData<false>(num_dimensions, num_outputs, is);
 }
-void GridLocalPolynomial::readConstructionData(std::ifstream &ifs){
-    dynamic_values = readSimpleConstructionData<true>(num_dimensions, num_outputs, ifs);
+void GridLocalPolynomial::readConstructionData(std::istream &is){
+    dynamic_values = readSimpleConstructionData<true>(num_dimensions, num_outputs, is);
 }
 std::vector<double> GridLocalPolynomial::getCandidateConstructionPoints(double tolerance, TypeRefinement criteria, int output,
                                                                         std::vector<int> const &level_limits, double const *scale_correction){

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -462,8 +462,8 @@ void GridLocalPolynomial::readConstructionDataBinary(std::ifstream &ifs){
 void GridLocalPolynomial::readConstructionData(std::ifstream &ifs){
     dynamic_values = readSimpleConstructionData<true>(num_dimensions, num_outputs, ifs);
 }
-void GridLocalPolynomial::getCandidateConstructionPoints(double tolerance, TypeRefinement criteria, int output,
-                                                         std::vector<int> const &level_limits, double const *scale_correction, std::vector<double> &x){
+std::vector<double> GridLocalPolynomial::getCandidateConstructionPoints(double tolerance, TypeRefinement criteria, int output,
+                                                                        std::vector<int> const &level_limits, double const *scale_correction){
     // combine the initial points with negative weights and the refinement candidates with surplus weights (no need to normalize, the sort uses relative values)
     MultiIndexSet refine_candidates = getRefinementCanidates(tolerance, criteria, output, level_limits, scale_correction);
     MultiIndexSet new_points = (dynamic_values->initial_points.empty()) ? std::move(refine_candidates) : refine_candidates.diffSets(dynamic_values->initial_points);
@@ -519,7 +519,7 @@ void GridLocalPolynomial::getCandidateConstructionPoints(double tolerance, TypeR
     // sort and return the sorted list
     weighted_points.sort([&](const NodeData &a, const NodeData &b)->bool{ return (a.value[0] < b.value[0]); });
 
-    x.resize(dynamic_values->initial_points.getVector().size() + new_points.getVector().size());
+    std::vector<double> x(dynamic_values->initial_points.getVector().size() + new_points.getVector().size());
     auto t = weighted_points.begin();
     auto ix = x.begin();
     while(t != weighted_points.end()){
@@ -527,6 +527,7 @@ void GridLocalPolynomial::getCandidateConstructionPoints(double tolerance, TypeR
         std::advance(ix, num_dimensions);
         t++;
     }
+    return x;
 }
 void GridLocalPolynomial::loadConstructedPoint(const double x[], const std::vector<double> &y){
     std::vector<int> p(num_dimensions); // convert x to p, maybe expensive

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -107,10 +107,10 @@ public:
     int removePointsByHierarchicalCoefficient(double tolerance, int output, const double *scale_correction); // returns the number of points kept
 
     void beginConstruction();
-    void writeConstructionDataBinary(std::ofstream &ofs) const;
-    void writeConstructionData(std::ofstream &ofs) const;
-    void readConstructionDataBinary(std::ifstream &ifs);
-    void readConstructionData(std::ifstream &ifs);
+    void writeConstructionDataBinary(std::ostream &os) const;
+    void writeConstructionData(std::ostream &os) const;
+    void readConstructionDataBinary(std::istream &is);
+    void readConstructionData(std::istream &is);
     std::vector<double> getCandidateConstructionPoints(double tolerance, TypeRefinement criteria, int output, std::vector<int> const &level_limits, double const *scale_correction);
     void loadConstructedPoint(const double x[], const std::vector<double> &y);
     void finishConstruction();

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -111,7 +111,7 @@ public:
     void writeConstructionData(std::ofstream &ofs) const;
     void readConstructionDataBinary(std::ifstream &ifs);
     void readConstructionData(std::ifstream &ifs);
-    void getCandidateConstructionPoints(double tolerance, TypeRefinement criteria, int output, std::vector<int> const &level_limits, double const *scale_correction, std::vector<double> &x);
+    std::vector<double> getCandidateConstructionPoints(double tolerance, TypeRefinement criteria, int output, std::vector<int> const &level_limits, double const *scale_correction);
     void loadConstructedPoint(const double x[], const std::vector<double> &y);
     void finishConstruction();
 

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -57,7 +57,7 @@ template<bool useAscii> void GridSequence::write(std::ostream &os) const{
     if (num_outputs > 0) values.write<useAscii>(os);
 }
 
-template<bool useAscii> void GridSequence::read(std::ifstream &is){
+template<bool useAscii> void GridSequence::read(std::istream &is){
     reset();
     num_dimensions = IO::readNumber<useAscii, int>(is);
     num_outputs = IO::readNumber<useAscii, int>(is);
@@ -78,8 +78,8 @@ template<bool useAscii> void GridSequence::read(std::ifstream &is){
 
 template void GridSequence::write<true>(std::ostream &) const;
 template void GridSequence::write<false>(std::ostream &) const;
-template void GridSequence::read<true>(std::ifstream &);
-template void GridSequence::read<false>(std::ifstream &);
+template void GridSequence::read<true>(std::istream &);
+template void GridSequence::read<false>(std::istream &);
 
 void GridSequence::reset(){
     clearAccelerationData();
@@ -256,17 +256,17 @@ void GridSequence::beginConstruction(){
         needed = MultiIndexSet();
     }
 }
-void GridSequence::writeConstructionDataBinary(std::ofstream &ofs) const{
-    dynamic_values->write<false>(ofs);
+void GridSequence::writeConstructionDataBinary(std::ostream &os) const{
+    dynamic_values->write<false>(os);
 }
-void GridSequence::writeConstructionData(std::ofstream &ofs) const{
-    dynamic_values->write<true>(ofs);
+void GridSequence::writeConstructionData(std::ostream &os) const{
+    dynamic_values->write<true>(os);
 }
-void GridSequence::readConstructionDataBinary(std::ifstream &ifs){
-    dynamic_values = readSimpleConstructionData<false>(num_dimensions, num_outputs, ifs);
+void GridSequence::readConstructionDataBinary(std::istream &is){
+    dynamic_values = readSimpleConstructionData<false>(num_dimensions, num_outputs, is);
 }
-void GridSequence::readConstructionData(std::ifstream &ifs){
-    dynamic_values = readSimpleConstructionData<true>(num_dimensions, num_outputs, ifs);
+void GridSequence::readConstructionData(std::istream &is){
+    dynamic_values = readSimpleConstructionData<true>(num_dimensions, num_outputs, is);
 }
 std::vector<double> GridSequence::getCandidateConstructionPoints(TypeDepth type, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits){
     MultiIndexManipulations::ProperWeights weights((size_t) num_dimensions, type, anisotropic_weights);

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -740,17 +740,16 @@ void GridSequence::setSurplusRefinement(double tolerance, int output, const std:
     }
 }
 
-void GridSequence::getPolynomialSpace(bool interpolation, int &n, int* &poly) const{
-    MultiIndexSet space; // used only when interpolation is false
-    const MultiIndexSet &work = (points.empty()) ? needed : points;
-    if (!interpolation){ // when using interpolation, the polynomial space coincides with points/needed
-        space = MultiIndexManipulations::createPolynomialSpace(work, [&](int l) -> int{ return OneDimensionalMeta::getQExact(l, rule); });
+std::vector<int> GridSequence::getPolynomialSpace(bool interpolation) const{
+    if (interpolation){
+        return (points.empty()) ? needed.getVector() : points.getVector(); // copy
+    }else{
+        MultiIndexSet polynomial_set = MultiIndexManipulations::createPolynomialSpace(
+            (points.empty()) ? needed : points,
+            [&](int l) -> int{ return OneDimensionalMeta::getQExact(l, rule); });
+        std::vector<int> poly_space = std::move(polynomial_set.getVector());
+        return poly_space;
     }
-    const MultiIndexSet &result = (interpolation) ? work : space;
-
-    n = result.getNumIndexes();
-    poly = new int[result.getVector().size()];
-    std::copy(result.getVector().begin(), result.getVector().end(), poly);
 }
 const double* GridSequence::getSurpluses() const{
     return surpluses.getVector().data();

--- a/SparseGrids/tsgGridSequence.hpp
+++ b/SparseGrids/tsgGridSequence.hpp
@@ -116,7 +116,7 @@ public:
 
     void setHierarchicalCoefficients(const double c[], TypeAcceleration acc);
 
-    void getPolynomialSpace(bool interpolation, int &n, int* &poly) const;
+    std::vector<int> getPolynomialSpace(bool interpolation) const;
 
     const double* getSurpluses() const;
     const int* getPointIndexes() const;

--- a/SparseGrids/tsgGridSequence.hpp
+++ b/SparseGrids/tsgGridSequence.hpp
@@ -56,7 +56,7 @@ public:
     bool isSequence() const{ return true; }
 
     template<bool useAscii> void write(std::ostream &os) const;
-    template<bool useAscii> void read(std::ifstream &is);
+    template<bool useAscii> void read(std::istream &is);
 
     void makeGrid(int cnum_dimensions, int cnum_outputs, int depth, TypeDepth type, TypeOneDRule crule, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits);
     void copyGrid(const GridSequence *seq);
@@ -104,10 +104,10 @@ public:
     void mergeRefinement();
 
     void beginConstruction();
-    void writeConstructionDataBinary(std::ofstream &ofs) const;
-    void writeConstructionData(std::ofstream &ofs) const;
-    void readConstructionDataBinary(std::ifstream &ifs);
-    void readConstructionData(std::ifstream &ifs);
+    void writeConstructionDataBinary(std::ostream &ofs) const;
+    void writeConstructionData(std::ostream &ofs) const;
+    void readConstructionDataBinary(std::istream &ifs);
+    void readConstructionData(std::istream &ifs);
     std::vector<double> getCandidateConstructionPoints(TypeDepth type, const std::vector<int> &weights, const std::vector<int> &level_limits);
     std::vector<double> getCandidateConstructionPoints(TypeDepth type, int output, const std::vector<int> &level_limits);
     std::vector<double> getCandidateConstructionPoints(std::function<double(const int *)> getTensorWeight, const std::vector<int> &level_limits);

--- a/SparseGrids/tsgGridSequence.hpp
+++ b/SparseGrids/tsgGridSequence.hpp
@@ -108,9 +108,9 @@ public:
     void writeConstructionData(std::ofstream &ofs) const;
     void readConstructionDataBinary(std::ifstream &ifs);
     void readConstructionData(std::ifstream &ifs);
-    void getCandidateConstructionPoints(TypeDepth type, const std::vector<int> &weights, std::vector<double> &x, const std::vector<int> &level_limits);
-    void getCandidateConstructionPoints(TypeDepth type, int output, std::vector<double> &x, const std::vector<int> &level_limits);
-    void getCandidateConstructionPoints(std::function<double(const int *)> getTensorWeight, std::vector<double> &x, const std::vector<int> &level_limits);
+    std::vector<double> getCandidateConstructionPoints(TypeDepth type, const std::vector<int> &weights, const std::vector<int> &level_limits);
+    std::vector<double> getCandidateConstructionPoints(TypeDepth type, int output, const std::vector<int> &level_limits);
+    std::vector<double> getCandidateConstructionPoints(std::function<double(const int *)> getTensorWeight, const std::vector<int> &level_limits);
     void loadConstructedPoint(const double x[], const std::vector<double> &y);
     void finishConstruction();
 


### PR DESCRIPTION
* broken backwards API for some funcitons
* Tasmanian C++ API no longer returns raw-pointers that need to be deleted
    * proper C++ containers are returned instead, i.e., std::vector and std::string
    * externally allocated raw-pointers are still accepted (used by the C/Python/Fortran APIs)
    * mostly affects the points and weights, but also level limits and GPU name
    * vectors can still be passed in by reference
* moved on-liner function from the .cpp file to the header (for blobbing reduction more than speed)
* the read/write commands operate on basic streams, this change is backwards compatible
* the C and Fortran interfaces still return raw-pointers as they did before (no change here)