### PR TITLE
Improved move semantics

### DIFF
--- a/SparseGrids/tsgDConstructGridGlobal.cpp
+++ b/SparseGrids/tsgDConstructGridGlobal.cpp
@@ -79,8 +79,7 @@ int DynamicConstructorDataGlobal::getMaxTensor() const{
 
 void DynamicConstructorDataGlobal::reloadPoints(std::function<int(int)> getNumPoints){
     for(auto &t : tensors){
-        std::vector<int> v = t.tensor;
-        MultiIndexSet dummy_set(num_dimensions, v);
+        MultiIndexSet dummy_set(num_dimensions, std::vector<int>(t.tensor));
         t.points = MultiIndexManipulations::generateNestedPoints(dummy_set, getNumPoints);
         t.loaded = std::vector<bool>((size_t) t.points.getNumIndexes(), false);
     }
@@ -115,9 +114,8 @@ MultiIndexSet DynamicConstructorDataGlobal::getInitialTensors() const{
 
 void DynamicConstructorDataGlobal::addTensor(const int *tensor, std::function<int(int)> getNumPoints, double weight){
     TensorData t;
-    std::vector<int> v(tensor, tensor + num_dimensions);
-    t.tensor = v;
-    MultiIndexSet dummy_set(num_dimensions, v);
+    t.tensor = std::vector<int>(tensor, tensor + num_dimensions);
+    MultiIndexSet dummy_set(num_dimensions, std::vector<int>(tensor, tensor + num_dimensions));
     t.points = MultiIndexManipulations::generateNestedPoints(dummy_set, getNumPoints);
     t.loaded = std::vector<bool>((size_t) t.points.getNumIndexes(), false);
     for(auto const &p : data){

--- a/SparseGrids/tsgDConstructGridGlobal.hpp
+++ b/SparseGrids/tsgDConstructGridGlobal.hpp
@@ -152,14 +152,16 @@ template<bool useAscii>
 std::forward_list<NodeData> readNodeDataList(size_t num_dimensions, size_t num_outputs, std::istream &is){
     std::forward_list<NodeData> data;
     int num_nodes = IO::readNumber<useAscii, int>(is);
+
     for(int i=0; i<num_nodes; i++){
-        NodeData nd;
-        nd.point.resize(num_dimensions);
-        IO::readVector<useAscii>(is, nd.point);
-        nd.value.resize(num_outputs);
-        IO::readVector<useAscii>(is, nd.value);
-        data.push_front(std::move(nd));
+        data.emplace_front(NodeData{
+                            std::vector<int>(num_dimensions), // point
+                            std::vector<double>(num_outputs)  // value
+                           });
+        IO::readVector<useAscii>(is, data.front().point);
+        IO::readVector<useAscii>(is, data.front().value);
     }
+
     return data;
 }
 

--- a/SparseGrids/tsgGridCore.cpp
+++ b/SparseGrids/tsgGridCore.cpp
@@ -75,11 +75,10 @@ SplitDirections::SplitDirections(const MultiIndexSet &points){
             // new job, get reference index
             const int *p = points.getIndex(*imap);
             job_directions.push_back((int) d);
-            std::vector<int> pnts = {*imap++};
+            job_pnts.emplace_back(std::vector<int>(1, *imap++));
             // while the points are in the same direction as the reference, add to the same job
             while((imap != map.end()) && doesBelongSameLine(p, points.getIndex(*imap), d))
-                pnts.push_back(*imap++);
-            job_pnts.push_back(std::move(pnts));
+                job_pnts.back().push_back(*imap++);
         }
     }
 }

--- a/SparseGrids/tsgGridFourier.cpp
+++ b/SparseGrids/tsgGridFourier.cpp
@@ -115,30 +115,27 @@ void GridFourier::reset(){
 }
 
 void GridFourier::makeGrid(int cnum_dimensions, int cnum_outputs, int depth, TypeDepth type, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits){
-
-    MultiIndexSet tset = (OneDimensionalMeta::isExactLevel(type)) ?
+    setTensors( (OneDimensionalMeta::isExactLevel(type)) ?
         MultiIndexManipulations::selectTensors((size_t) cnum_dimensions, depth, type,
                                                [&](int i) -> int{ return i; }, anisotropic_weights, level_limits) :
         MultiIndexManipulations::selectTensors((size_t) cnum_dimensions, depth, type,
-                                               [&](int i) -> int{ return OneDimensionalMeta::getIExact(i, rule_fourier); }, anisotropic_weights, level_limits);
-
-    setTensors(tset, cnum_outputs);
+                                               [&](int i) -> int{ return OneDimensionalMeta::getIExact(i, rule_fourier); }, anisotropic_weights, level_limits),
+    cnum_outputs);
 }
 
 void GridFourier::copyGrid(const GridFourier *fourier){
-    MultiIndexSet tset = fourier->tensors;
-    setTensors(tset, fourier->num_outputs);
+    setTensors(MultiIndexSet(fourier->tensors), fourier->num_outputs);
     if ((num_outputs > 0) && (!fourier->points.empty())){ // if there are values inside the source object
         loadNeededPoints(fourier->values.getValues(0));
     }
 }
 
-void GridFourier::setTensors(MultiIndexSet &tset, int cnum_outputs){
+void GridFourier::setTensors(MultiIndexSet &&tset, int cnum_outputs){
     reset();
-    num_dimensions = (int) tset.getNumDimensions();
-    num_outputs = cnum_outputs;
-
     tensors = std::move(tset);
+
+    num_dimensions = (int) tensors.getNumDimensions();
+    num_outputs = cnum_outputs;
 
     max_levels = MultiIndexManipulations::getMaxIndexes(tensors);
 

--- a/SparseGrids/tsgGridFourier.hpp
+++ b/SparseGrids/tsgGridFourier.hpp
@@ -60,7 +60,7 @@ public:
     void makeGrid(int cnum_dimensions, int cnum_outputs, int depth, TypeDepth type, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits);
     void copyGrid(const GridFourier *fourier);
 
-    void setTensors(MultiIndexSet &tset, int cnum_outputs);
+    void setTensors(MultiIndexSet &&tset, int cnum_outputs);
 
     TypeOneDRule getRule() const{ return rule_fourier; }
 

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -183,16 +183,14 @@ void GridGlobal::makeGrid(int cnum_dimensions, int cnum_outputs, int depth, Type
         custom.read(custom_filename);
     }
 
-    MultiIndexSet tset = selectTensors((size_t) cnum_dimensions, depth, type, anisotropic_weights, crule, level_limits);
-
-    setTensors(tset, cnum_outputs, crule, calpha, cbeta);
+    setTensors(selectTensors((size_t) cnum_dimensions, depth, type, anisotropic_weights, crule, level_limits),
+               cnum_outputs, crule, calpha, cbeta);
 }
 void GridGlobal::copyGrid(const GridGlobal *global){
     custom = CustomTabulated();
     if (global->rule == rule_customtabulated) custom = global->custom;
 
-    MultiIndexSet tset = global->tensors;
-    setTensors(tset, global->num_outputs, global->rule, global->alpha, global->beta);
+    setTensors(MultiIndexSet(global->tensors), global->num_outputs, global->rule, global->alpha, global->beta);
 
     if ((num_outputs > 0) && (!(global->points.empty()))){ // if there are values inside the source object
         loadNeededPoints(global->values.getValues(0));
@@ -210,14 +208,14 @@ void GridGlobal::copyGrid(const GridGlobal *global){
     }
 }
 
-void GridGlobal::setTensors(MultiIndexSet &tset, int cnum_outputs, TypeOneDRule crule, double calpha, double cbeta){
+void GridGlobal::setTensors(MultiIndexSet &&tset, int cnum_outputs, TypeOneDRule crule, double calpha, double cbeta){
     reset(false);
-    num_dimensions = (int) tset.getNumDimensions();
+    tensors = std::move(tset);
+
+    num_dimensions = (int) tensors.getNumDimensions();
     num_outputs = cnum_outputs;
     rule = crule;
     alpha = calpha;  beta = cbeta;
-
-    tensors = std::move(tset);
 
     max_levels = MultiIndexManipulations::getMaxIndexes(tensors);
 
@@ -693,7 +691,7 @@ std::vector<double> GridGlobal::computeSurpluses(int output, bool normalize) con
 
         GridGlobal QuadGrid;
         if (getMaxQuadLevel < TableGaussPatterson::getNumLevels()-1){
-            QuadGrid.setTensors(quadrature_tensors, 0, rule_gausspatterson, 0.0, 0.0);
+            QuadGrid.setTensors(std::move(quadrature_tensors), 0, rule_gausspatterson, 0.0, 0.0);
         }else{
             quadrature_tensors =
                 MultiIndexManipulations::generateLowerMultiIndexSet((size_t) num_dimensions, [&](const std::vector<int> &index) ->
@@ -702,7 +700,7 @@ std::vector<double> GridGlobal::computeSurpluses(int output, bool normalize) con
                         for(auto &i : qindex) i = (i > 0) ? 1 + OneDimensionalMeta::getQExact(i - 1, rule_clenshawcurtis) : 0;
                         return polynomial_set.missing(qindex);
                     });
-            QuadGrid.setTensors(quadrature_tensors, 0, rule_clenshawcurtis, 0.0, 0.0);
+            QuadGrid.setTensors(std::move(quadrature_tensors), 0, rule_clenshawcurtis, 0.0, 0.0);
         }
 
         size_t qn = (size_t) QuadGrid.getNumPoints();

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -384,8 +384,7 @@ void GridGlobal::loadNeededPoints(const double *vals){
 void GridGlobal::mergeRefinement(){
     if (needed.empty()) return; // nothing to do
     int num_all_points = getNumLoaded() + getNumNeeded();
-    std::vector<double> vals(((size_t) num_all_points) * ((size_t) num_outputs), 0.0);
-    values.setValues(vals);
+    values.setValues(std::vector<double>(Utils::size_mult(num_outputs, num_all_points), 0.0));
     acceptUpdatedTensors();
 }
 
@@ -548,7 +547,7 @@ void GridGlobal::loadConstructedTensors(){
     bool added_any = false;
     while(dynamic_values->ejectCompleteTensor(tensors, tensor, new_points, new_values)){
         if (points.empty()){
-            values.setValues(new_values);
+            values.setValues(std::move(new_values));
             points = std::move(new_points);
         }else{
             values.addValues(points, new_points, new_values.data());

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -556,7 +556,7 @@ void GridGlobal::loadConstructedTensors(){
         }
 
         if (tensors.empty()){
-            tensors = MultiIndexSet((size_t) num_dimensions, tensor);
+            tensors = MultiIndexSet((size_t) num_dimensions, std::move(tensor));
         }else{
             tensors.addSortedIndexes(tensor);
         }

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -63,7 +63,7 @@ public:
     void makeGrid(int cnum_dimensions, int cnum_outputs, int depth, TypeDepth type, TypeOneDRule crule, const std::vector<int> &anisotropic_weights, double calpha, double cbeta, const char* custom_filename, const std::vector<int> &level_limits);
     void copyGrid(const GridGlobal *global);
 
-    void setTensors(MultiIndexSet &tset, int cnum_outputs, TypeOneDRule crule, double calpha, double cbeta);
+    void setTensors(MultiIndexSet &&tset, int cnum_outputs, TypeOneDRule crule, double calpha, double cbeta);
 
     void updateGrid(int depth, TypeDepth type, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits);
 

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -211,7 +211,7 @@ GridLocalPolynomial::GridLocalPolynomial(int cnum_dimensions, int cnum_outputs, 
     points = MultiIndexSet(num_dimensions, pnts);
     values.resize(num_outputs, points.getNumIndexes());
     values.setValues(vals);
-    surpluses = Data2D<double>(num_outputs, points.getNumIndexes(), surps);
+    surpluses = Data2D<double>(num_outputs, points.getNumIndexes(), std::move(surps));
 
     buildTree();
 }
@@ -347,7 +347,7 @@ void GridLocalPolynomial::loadNeededPointsCuda(CudaEngine *engine, const double 
         cumulative_poitns.addMultiIndexSet(level_points);
     }
 
-    surpluses = Data2D<double>(num_outputs, points.getNumIndexes(), cumulative_surpluses.getVector());
+    surpluses = Data2D<double>(num_outputs, points.getNumIndexes(), std::move(cumulative_surpluses.getVector()));
 }
 void GridLocalPolynomial::evaluateCudaMixed(CudaEngine *engine, const double x[], int num_x, double y[]) const{
     loadCudaSurpluses();

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -210,7 +210,7 @@ GridLocalPolynomial::GridLocalPolynomial(int cnum_dimensions, int cnum_outputs, 
 
     points = MultiIndexSet(num_dimensions, std::move(pnts));
     values.resize(num_outputs, points.getNumIndexes());
-    values.setValues(vals);
+    values.setValues(std::move(vals));
     surpluses = Data2D<double>(num_outputs, points.getNumIndexes(), std::move(surps));
 
     buildTree();
@@ -316,7 +316,7 @@ void GridLocalPolynomial::loadNeededPointsCuda(CudaEngine *engine, const double 
 
     StorageSet cumulative_surpluses;
     cumulative_surpluses.resize(num_outputs, cumulative_poitns.getNumIndexes());
-    cumulative_surpluses.setValues(lvals[0].getVector());
+    cumulative_surpluses.setValues(std::move(lvals[0].getVector()));
 
     for(size_t l = 1; l < lpnts.size(); l++){ // loop over the levels
         // note that level_points.getNumIndexes() == lx[l].getNumStrips() == lvals[l].getNumStrips()
@@ -426,8 +426,7 @@ void GridLocalPolynomial::mergeRefinement(){
     #endif
     int num_all_points = getNumLoaded() + getNumNeeded();
     size_t num_vals = ((size_t) num_all_points) * ((size_t) num_outputs);
-    std::vector<double> vals(num_vals, 0.0);
-    values.setValues(vals);
+    values.setValues(std::vector<double>(num_vals, 0.0));
     if (points.empty()){
         points = std::move(needed);
         needed = MultiIndexSet();
@@ -558,8 +557,7 @@ void GridLocalPolynomial::expandGrid(const std::vector<int> &point, const std::v
     if (points.empty()){ // only one point
         points = MultiIndexSet((size_t) num_dimensions, std::vector<int>(point));
         values.resize(num_outputs, 1);
-        auto v = value; // create new to allow move
-        values.setValues(v);
+        values.setValues(std::vector<double>(value));
         surpluses.resize(num_outputs, 1);
         surpluses.getVector() = value; // the surplus of one point is the value itself
     }else{ // merge with existing points

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -138,7 +138,7 @@ protected:
     void reset(bool clear_rule = true);
 
     //! \brief Create a new grid with given parameters and moving the data out of the vectors and sets.
-    GridLocalPolynomial(int cnum_dimensions, int cnum_outputs, int corder, TypeOneDRule crule, std::vector<int> &pnts, std::vector<double> &vals, std::vector<double> &surps);
+    GridLocalPolynomial(int cnum_dimensions, int cnum_outputs, int corder, TypeOneDRule crule, std::vector<int> &&pnts, std::vector<double> &&vals, std::vector<double> &&surps);
 
     //! \brief Used as part of the loadNeededPoints() algorithm, updates the values and cuda cache, but does not touch the surpluses.
     void updateValues(double const *vals);

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -743,8 +743,7 @@ std::vector<int> GridSequence::getPolynomialSpace(bool interpolation) const{
         MultiIndexSet polynomial_set = MultiIndexManipulations::createPolynomialSpace(
             (points.empty()) ? needed : points,
             [&](int l) -> int{ return OneDimensionalMeta::getQExact(l, rule); });
-        std::vector<int> poly_space = std::move(polynomial_set.getVector());
-        return poly_space;
+        return std::move(polynomial_set.getVector());
     }
 }
 const double* GridSequence::getSurpluses() const{

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -232,8 +232,7 @@ void GridSequence::mergeRefinement(){
     #endif
     int num_all_points = getNumLoaded() + getNumNeeded();
     size_t num_vals = ((size_t) num_all_points) * ((size_t) num_outputs);
-    std::vector<double> vals(num_vals, 0.0);
-    values.setValues(vals);
+    values.setValues(std::vector<double>(num_vals, 0.0));
     if (points.empty()){ // relabel needed as points (loaded)
         points = std::move(needed);
         needed = MultiIndexSet();
@@ -409,8 +408,7 @@ void GridSequence::expandGrid(const std::vector<int> &point, const std::vector<d
     if (points.empty()){ // only one point
         points = MultiIndexSet((size_t) num_dimensions, std::vector<int>(point));
         values.resize(num_outputs, 1);
-        auto v = value; // create new to allow copy move
-        values.setValues(v);
+        values.setValues(std::vector<double>(value));
         surpluses.resize(num_outputs, 1);
         surpluses.getVector() = value; // the surplus of one point is the value itself
     }else{ // merge with existing points

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -407,16 +407,14 @@ void GridSequence::loadConstructedPoint(const double x[], const std::vector<doub
 }
 void GridSequence::expandGrid(const std::vector<int> &point, const std::vector<double> &value, const std::vector<double> &surplus){
     if (points.empty()){ // only one point
-        auto p = point; // create new so it can be moved
-        points = MultiIndexSet((size_t) num_dimensions, p);
+        points = MultiIndexSet((size_t) num_dimensions, std::vector<int>(point));
         values.resize(num_outputs, 1);
         auto v = value; // create new to allow copy move
         values.setValues(v);
         surpluses.resize(num_outputs, 1);
         surpluses.getVector() = value; // the surplus of one point is the value itself
     }else{ // merge with existing points
-        auto p = point;
-        MultiIndexSet temp(num_dimensions, p);
+        MultiIndexSet temp(num_dimensions, std::vector<int>(point));
         values.addValues(points, temp, value.data());
 
         points.addSortedIndexes(point);

--- a/SparseGrids/tsgGridWavelet.cpp
+++ b/SparseGrids/tsgGridWavelet.cpp
@@ -233,8 +233,7 @@ void GridWavelet::mergeRefinement(){
     #endif
     int num_all_points = getNumLoaded() + getNumNeeded();
     size_t size_vals = ((size_t) num_all_points) * ((size_t) num_outputs);
-    std::vector<double> vals(size_vals, 0.0);
-    values.setValues(vals);
+    values.setValues(std::vector<double>(size_vals, 0.0));
     if (points.empty()){
         points = std::move(needed);
     }else{

--- a/SparseGrids/tsgGridWavelet.cpp
+++ b/SparseGrids/tsgGridWavelet.cpp
@@ -500,7 +500,7 @@ Data2D<int> GridWavelet::buildUpdateMap(double tolerance, TypeRefinement criteri
                 std::copy(p, p + num_dimensions, indexes.getStrip(i));
             }
 
-            MultiIndexSet pointset(num_dimensions, indexes.getVector());
+            MultiIndexSet pointset(num_dimensions, std::move(indexes.getVector()));
 
             GridWavelet direction_grid;
             direction_grid.setNodes(pointset, active_outputs, order);

--- a/SparseGrids/tsgIndexManipulator.cpp
+++ b/SparseGrids/tsgIndexManipulator.cpp
@@ -59,7 +59,7 @@ inline MultiIndexSet generateFullTensorSet(std::vector<int> const &num_entries){
             t /= *l++;
         }
     }
-    return MultiIndexSet(num_dimensions, indexes);
+    return MultiIndexSet(num_dimensions, std::move(indexes));
 }
 
 /*!
@@ -148,8 +148,7 @@ void completeSetToLower(MultiIndexSet &set){
  * \endinternal
  */
 inline MultiIndexSet generateGeneralMultiIndexSet(size_t num_dimensions, std::function<bool(const std::vector<int> &index)> criteria){
-    std::vector<int> root(num_dimensions, 0);
-    std::vector<MultiIndexSet> level_sets = { MultiIndexSet(num_dimensions, root) };
+    std::vector<MultiIndexSet> level_sets = { MultiIndexSet(num_dimensions, std::vector<int>(num_dimensions, 0)) };
 
     repeatAddIndexes<false>(criteria, level_sets);
 

--- a/SparseGrids/tsgIndexManipulator.hpp
+++ b/SparseGrids/tsgIndexManipulator.hpp
@@ -95,7 +95,7 @@ inline MultiIndexSet generateLowerMultiIndexSet(size_t num_dimensions, std::func
         }
         is_in = inside(root);
     }
-    return MultiIndexSet(num_dimensions, indexes);
+    return MultiIndexSet(num_dimensions, std::move(indexes));
 }
 
 /*!
@@ -434,7 +434,7 @@ inline MultiIndexSet createActiveTensors(const MultiIndexSet &mset, const std::v
         std::advance(iset, num_dimensions);
     }
 
-    return MultiIndexSet(num_dimensions, indexes);
+    return MultiIndexSet(num_dimensions, std::move(indexes));
 }
 
 /*!

--- a/SparseGrids/tsgIndexSets.cpp
+++ b/SparseGrids/tsgIndexSets.cpp
@@ -212,7 +212,7 @@ MultiIndexSet MultiIndexSet::diffSets(const MultiIndexSet &substract){
             std::copy_n(i, num_dimensions, inew);
             std::advance(inew, num_dimensions);
         }
-        return MultiIndexSet(num_dimensions, new_indexes);
+        return MultiIndexSet(num_dimensions, std::move(new_indexes));
     }
 
     return MultiIndexSet();

--- a/SparseGrids/tsgIndexSets.cpp
+++ b/SparseGrids/tsgIndexSets.cpp
@@ -264,9 +264,9 @@ void StorageSet::setValues(const double vals[]){
     values.resize(num_outputs * num_values);
     std::copy_n(vals, num_values * num_outputs, values.data());
 }
-void StorageSet::setValues(std::vector<double> &vals){
+void StorageSet::setValues(std::vector<double> &&vals){
     num_values = vals.size() / num_outputs;
-    values = std::move(vals); // move assignment
+    values = std::vector<double>(vals); // move assignment
 }
 
 void StorageSet::addValues(const MultiIndexSet &old_set, const MultiIndexSet &new_set, const double new_vals[]){

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -286,8 +286,8 @@ public:
 
     //! \brief Replace the existing values with a copy of **vals**, the size must be at least **num_outputs** times **num_values**
     void setValues(const double vals[]);
-    //! \brief Replace the existing values with **vals** using `std::move()`, the size of **vals** must be **num_outputs** times **num_values**
-    void setValues(std::vector<double> &vals);
+    //! \brief Replace the existing values with \b vals using move semantics, the size of \b vals must be \b num_outputs times \b num_values
+    void setValues(std::vector<double> &&vals);
 
     /*!
      * \brief Add more values to the set, the \b old_set and \b new_set are the associated multi-index sets required to maintain order.

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -88,8 +88,8 @@ public:
     Data2D(size_t new_stride, int new_num_strips) : stride(new_stride), num_strips((size_t) new_num_strips), vec(stride * num_strips){}
     //! \brief Create data-structure with given \b stride and number of \b strips and initializes with \b val.
     Data2D(int new_stride, int new_num_strips, T val) : stride((size_t) new_stride), num_strips((size_t) new_num_strips), vec(stride * num_strips, val){}
-    //! \brief Create data-structure with given \b stride and number of \b strips and \b std::move \b data into the internal vector.
-    Data2D(int new_stride, int new_num_strips, std::vector<T> &data) : stride((size_t) new_stride), num_strips((size_t) new_num_strips), vec(std::move(data)){}
+    //! \brief Create data-structure with given \b stride and number of \b strips and moves \b data into the internal vector.
+    Data2D(int new_stride, int new_num_strips, std::vector<T> &&data) : stride((size_t) new_stride), num_strips((size_t) new_num_strips), vec(data){}
     //! \brief Default destructor.
     ~Data2D(){}
 

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -168,8 +168,8 @@ public:
     //! \brief Default constructor, makes an empty set.
     MultiIndexSet() : num_dimensions(0), cache_num_indexes(0){}
     //! \brief Constructor, makes a set by \b moving out of the vector, the vector must be already sorted.
-    MultiIndexSet(size_t cnum_dimensions, std::vector<int> &new_indexes) :
-        num_dimensions(cnum_dimensions), cache_num_indexes((int)(new_indexes.size() / cnum_dimensions)), indexes(std::move(new_indexes)){}
+    MultiIndexSet(size_t cnum_dimensions, std::vector<int> &&new_indexes) :
+        num_dimensions(cnum_dimensions), cache_num_indexes((int)(new_indexes.size() / cnum_dimensions)), indexes(new_indexes){}
     //! \brief Copy a collection of unsorted indexes into a sorted multi-index set, sorts during the copy.
     MultiIndexSet(Data2D<int> &data) : num_dimensions((size_t) data.getStride()), cache_num_indexes(0){ setData2D(data); }
     //! \brief Default destructor.


### PR DESCRIPTION
* no functions move out of simple vector references, but use `&&` instead
* every call is now explicit move or copy (visible without referring to the api docs)
* using `emplace` instead of creating local variables and explicitly calling `push(move(foo))`