### PR TITLE
Header cleanup

### DIFF
--- a/DREAM/tasdreamExternalTests.hpp
+++ b/DREAM/tasdreamExternalTests.hpp
@@ -31,12 +31,6 @@
 #ifndef __TASMANIAN_TASDREAM_EXTERNAL_TESTS_HPP
 #define __TASMANIAN_TASDREAM_EXTERNAL_TESTS_HPP
 
-#include <iostream>
-#include <fstream>
-#include <iomanip>
-
-#include <vector>
-#include <numeric>
 #include <random>
 
 #include "TasmanianDREAM.hpp"

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -31,9 +31,6 @@
 #ifndef __TASMANIAN_SPARSE_GRID_CPP
 #define __TASMANIAN_SPARSE_GRID_CPP
 
-#include <stdexcept>
-#include <string>
-
 #include "TasmanianSparseGrid.hpp"
 
 #include "tsgUtils.hpp"

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -42,7 +42,6 @@
 #define __TASMANIAN_SPARSE_GRID_HPP
 
 #include "tsgGridGlobal.hpp"
-#include "tsgGridSequence.hpp"
 #include "tsgGridLocalPolynomial.hpp"
 #include "tsgGridWavelet.hpp"
 #include "tsgGridFourier.hpp"

--- a/SparseGrids/tasgridCLICommon.hpp
+++ b/SparseGrids/tasgridCLICommon.hpp
@@ -42,10 +42,7 @@
  * \endinternal
  */
 
-#include <iomanip>
-#include <string>
 #include <map>
-#include <cmath>
 #include <random>
 #include <deque>
 #include <cctype>

--- a/SparseGrids/tasgridExternalTests.hpp
+++ b/SparseGrids/tasgridExternalTests.hpp
@@ -31,10 +31,6 @@
 #ifndef __TASGRID_TESTER_HPP
 #define __TASGRID_TESTER_HPP
 
-#include <cstdlib>
-#include <cstdio>
-#include <string.h>
-
 #include "tasgridCLICommon.hpp"
 
 #include "tasgridTestFunctions.hpp"

--- a/SparseGrids/tasgridUnitTests.hpp
+++ b/SparseGrids/tasgridUnitTests.hpp
@@ -31,8 +31,6 @@
 #ifndef __TASGRID_UNIT_TESTS_HPP
 #define __TASGRID_UNIT_TESTS_HPP
 
-#include <string.h>
-
 #include "tasgridCLICommon.hpp"
 
 enum UnitTests{

--- a/SparseGrids/tasgridWrapper.hpp
+++ b/SparseGrids/tasgridWrapper.hpp
@@ -31,8 +31,6 @@
 #ifndef __TASGRID_WRAPPER_HPP
 #define __TASGRID_WRAPPER_HPP
 
-#include <fstream>
-
 #include "tasgridCLICommon.hpp"
 
 enum TypeCommand{

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -31,9 +31,6 @@
 #ifndef __TASMANIAN_SPARSE_GRID_ACCELERATED_DATA_STRUCTURES_HPP
 #define __TASMANIAN_SPARSE_GRID_ACCELERATED_DATA_STRUCTURES_HPP
 
-#include <stdexcept>
-
-#include "tsgUtils.hpp"
 #include "tsgEnumerates.hpp"
 
 //! \internal

--- a/SparseGrids/tsgCoreOneDimensional.cpp
+++ b/SparseGrids/tsgCoreOneDimensional.cpp
@@ -31,9 +31,6 @@
 #ifndef __TSG_CORE_ONE_DIMENSIONAL_CPP
 #define __TSG_CORE_ONE_DIMENSIONAL_CPP
 
-#include <stdexcept>
-#include <string>
-
 #include "tsgCoreOneDimensional.hpp"
 
 namespace TasGrid{

--- a/SparseGrids/tsgCudaLoadStructures.hpp
+++ b/SparseGrids/tsgCudaLoadStructures.hpp
@@ -31,12 +31,7 @@
 #ifndef __TASMANIAN_SPARSE_CUDA_LOAD_STRUCTS_HPP
 #define __TASMANIAN_SPARSE_CUDA_LOAD_STRUCTS_HPP
 
-#include "TasmanianConfig.hpp"
 #include "tsgAcceleratedDataStructures.hpp"
-
-#include <iostream>
-#include <vector>
-#include <memory>
 
 namespace TasGrid{
 

--- a/SparseGrids/tsgEnumerates.hpp
+++ b/SparseGrids/tsgEnumerates.hpp
@@ -32,16 +32,18 @@
 #define __TASMANIAN_SPARSE_GRID_ENUMERATES_HPP
 
 // system headers used in many/many places
+#include <iostream>
 #include <iomanip>
-#include <stdlib.h>
-#include <ostream>
 #include <fstream>
 #include <string.h>
 #include <string>
 #include <vector>
 #include <cmath>
+#include <numeric>
+#include <stdexcept>
 
-#include "TasmanianConfig.hpp"
+#include "TasmanianConfig.hpp" // contains build options passed down from CMake
+#include "tsgUtils.hpp" // contains array wrapper and size_mult for int-to-size_t
 
 //! \file tsgEnumerates.hpp
 //! \brief Omnipresent enumerate types.

--- a/SparseGrids/tsgGridCore.hpp
+++ b/SparseGrids/tsgGridCore.hpp
@@ -31,11 +31,8 @@
 #ifndef __TSG_BASE_CLASS_HPP
 #define __TSG_BASE_CLASS_HPP
 
-#include <numeric>
-
-#include "tsgEnumerates.hpp"
-#include "tsgIndexSets.hpp"
-#include "tsgAcceleratedDataStructures.hpp"
+#include "tsgDConstructGridGlobal.hpp"
+#include "tsgCudaLoadStructures.hpp"
 
 namespace TasGrid{
 

--- a/SparseGrids/tsgGridFourier.cpp
+++ b/SparseGrids/tsgGridFourier.cpp
@@ -33,7 +33,6 @@
 
 #include "tsgGridFourier.hpp"
 #include "tsgHiddenExternals.hpp"
-#include "tsgUtils.hpp"
 
 namespace TasGrid{
 

--- a/SparseGrids/tsgGridFourier.hpp
+++ b/SparseGrids/tsgGridFourier.hpp
@@ -31,18 +31,7 @@
 #ifndef __TASMANIAN_SPARSE_GRID_FOURIER_HPP
 #define __TASMANIAN_SPARSE_GRID_FOURIER_HPP
 
-#include <cstdlib>
-#include <complex>
-
-#include "tsgEnumerates.hpp"
-#include "tsgIndexSets.hpp"
-#include "tsgCoreOneDimensional.hpp"
-#include "tsgIndexManipulator.hpp"
-#include "tsgLinearSolvers.hpp"
-#include "tsgOneDimensionalWrapper.hpp"
 #include "tsgGridCore.hpp"
-
-#include "tsgCudaLoadStructures.hpp"
 
 namespace TasGrid{
 

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -32,9 +32,7 @@
 #define __TASMANIAN_SPARSE_GRID_GLOBAL_CPP
 
 #include "tsgGridGlobal.hpp"
-
 #include "tsgHiddenExternals.hpp"
-#include "tsgUtils.hpp"
 
 namespace TasGrid{
 

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -31,22 +31,8 @@
 #ifndef __TASMANIAN_SPARSE_GRID_GLOBAL_HPP
 #define __TASMANIAN_SPARSE_GRID_GLOBAL_HPP
 
-#include <cstdlib>
-#include <memory>
-
-#include "tsgEnumerates.hpp"
-#include "tsgIndexSets.hpp"
-#include "tsgCoreOneDimensional.hpp"
-#include "tsgIndexManipulator.hpp"
-#include "tsgLinearSolvers.hpp"
-#include "tsgCacheLagrange.hpp"
-#include "tsgOneDimensionalWrapper.hpp"
-#include "tsgDConstructGridGlobal.hpp"
-#include "tsgGridCore.hpp"
-
-#include "tsgAcceleratedDataStructures.hpp"
-
 #include "tsgGridSequence.hpp"
+#include "tsgCacheLagrange.hpp"
 
 namespace TasGrid{
 

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -32,9 +32,7 @@
 #define __TASMANIAN_SPARSE_GRID_LPOLY_CPP
 
 #include "tsgGridLocalPolynomial.hpp"
-
 #include "tsgHiddenExternals.hpp"
-#include "tsgUtils.hpp"
 
 namespace TasGrid{
 

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -31,17 +31,7 @@
 #ifndef __TASMANIAN_SPARSE_GRID_LPOLY_HPP
 #define __TASMANIAN_SPARSE_GRID_LPOLY_HPP
 
-#include <vector>
-#include <memory>
-
-#include "tsgEnumerates.hpp"
-#include "tsgIndexSets.hpp"
-#include "tsgIndexManipulator.hpp"
 #include "tsgGridCore.hpp"
-#include "tsgRuleLocalPolynomial.hpp"
-#include "tsgDConstructGridGlobal.hpp"
-
-#include "tsgCudaLoadStructures.hpp"
 
 //! \internal
 //! \file tsgGridLocalPolynomial.hpp

--- a/SparseGrids/tsgGridSequence.cpp
+++ b/SparseGrids/tsgGridSequence.cpp
@@ -32,9 +32,7 @@
 #define __TASMANIAN_SPARSE_GRID_GLOBAL_NESTED_CPP
 
 #include "tsgGridSequence.hpp"
-
 #include "tsgHiddenExternals.hpp"
-#include "tsgUtils.hpp"
 
 namespace TasGrid{
 

--- a/SparseGrids/tsgGridSequence.hpp
+++ b/SparseGrids/tsgGridSequence.hpp
@@ -31,20 +31,7 @@
 #ifndef __TASMANIAN_SPARSE_GRID_GLOBAL_NESTED_HPP
 #define __TASMANIAN_SPARSE_GRID_GLOBAL_NESTED_HPP
 
-#include <cstdlib>
-#include <memory>
-
-#include "tsgEnumerates.hpp"
-#include "tsgIndexSets.hpp"
-#include "tsgCoreOneDimensional.hpp"
-#include "tsgIndexManipulator.hpp"
-#include "tsgLinearSolvers.hpp"
-#include "tsgCacheLagrange.hpp"
-#include "tsgOneDimensionalWrapper.hpp"
 #include "tsgGridCore.hpp"
-#include "tsgDConstructGridGlobal.hpp"
-
-#include "tsgCudaLoadStructures.hpp"
 
 namespace TasGrid{
 

--- a/SparseGrids/tsgGridWavelet.cpp
+++ b/SparseGrids/tsgGridWavelet.cpp
@@ -31,10 +31,8 @@
 #ifndef __TASMANIAN_SPARSE_GRID_WAVELET_CPP
 #define __TASMANIAN_SPARSE_GRID_WAVELET_CPP
 
-#include "tsgHiddenExternals.hpp"
 #include "tsgGridWavelet.hpp"
-
-#include "tsgUtils.hpp"
+#include "tsgHiddenExternals.hpp"
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/SparseGrids/tsgGridWavelet.hpp
+++ b/SparseGrids/tsgGridWavelet.hpp
@@ -31,15 +31,8 @@
 #ifndef __TASMANIAN_SPARSE_GRID_WAVELET_HPP
 #define __TASMANIAN_SPARSE_GRID_WAVELET_HPP
 
-#include "tsgIOHelpers.hpp"
-#include "tsgEnumerates.hpp"
-#include "tsgIndexSets.hpp"
-#include "tsgIndexManipulator.hpp"
-#include "tsgRuleWavelet.hpp"
-#include "tsgLinearSolvers.hpp"
 #include "tsgGridCore.hpp"
-
-#include "tsgCudaLoadStructures.hpp"
+#include "tsgRuleWavelet.hpp"
 
 namespace TasGrid{
 

--- a/SparseGrids/tsgIOHelpers.hpp
+++ b/SparseGrids/tsgIOHelpers.hpp
@@ -31,8 +31,6 @@
 #ifndef __TASMANIAN_IOHELPERS_HPP
 #define __TASMANIAN_IOHELPERS_HPP
 
-#include <tuple>
-
 #include "tsgCoreOneDimensional.hpp"
 
 /*!

--- a/SparseGrids/tsgIndexManipulator.hpp
+++ b/SparseGrids/tsgIndexManipulator.hpp
@@ -31,8 +31,7 @@
 #ifndef __TSG_INDEX_MANIPULATOR_HPP
 #define __TSG_INDEX_MANIPULATOR_HPP
 
-#include <numeric>
-#include <iostream>
+#include <functional>
 
 #include "tsgIndexSets.hpp"
 #include "tsgOneDimensionalWrapper.hpp"

--- a/SparseGrids/tsgIndexSets.hpp
+++ b/SparseGrids/tsgIndexSets.hpp
@@ -31,11 +31,9 @@
 #ifndef __TASMANIAN_SPARSE_GRID_INDEX_SETS_HPP
 #define __TASMANIAN_SPARSE_GRID_INDEX_SETS_HPP
 
-#include <functional>
 #include <algorithm>
 
 #include "tsgIOHelpers.hpp"
-#include "tsgUtils.hpp"
 
 /*!
  * \internal

--- a/SparseGrids/tsgLinearSolvers.cpp
+++ b/SparseGrids/tsgLinearSolvers.cpp
@@ -33,10 +33,6 @@
 
 #include "tsgLinearSolvers.hpp"
 
-#ifdef TASMANIAN_CHOLMOD
-#include <cholmod.h>
-#endif // TASMANIAN_CHOLMOD
-
 namespace TasGrid{
 
 void TasmanianDenseSolver::solveLeastSquares(int n, int m, const double A[], const double b[], double reg, double *x){

--- a/SparseGrids/tsgLinearSolvers.hpp
+++ b/SparseGrids/tsgLinearSolvers.hpp
@@ -31,7 +31,6 @@
 #ifndef __TASMANIAN_LINEAR_SOLVERS_HPP
 #define __TASMANIAN_LINEAR_SOLVERS_HPP
 
-#include <list>
 #include <complex>
 
 #include "tsgEnumerates.hpp"

--- a/SparseGrids/tsgOneDimensionalWrapper.cpp
+++ b/SparseGrids/tsgOneDimensionalWrapper.cpp
@@ -31,9 +31,6 @@
 #ifndef __TSG_ONE_DIMENSIONAL_WRAPPER_CPP
 #define __TSG_ONE_DIMENSIONAL_WRAPPER_CPP
 
-#include <stdexcept>
-#include <string>
-
 #include "tsgOneDimensionalWrapper.hpp"
 
 namespace TasGrid{

--- a/SparseGrids/tsgOneDimensionalWrapper.hpp
+++ b/SparseGrids/tsgOneDimensionalWrapper.hpp
@@ -31,7 +31,6 @@
 #ifndef __TSG_ONE_DIMENSIONAL_WRAPPER_HPP
 #define __TSG_ONE_DIMENSIONAL_WRAPPER_HPP
 
-#include "tsgCoreOneDimensional.hpp"
 #include "tsgSequenceOptimizer.hpp"
 #include "tsgHardCodedTabulatedRules.hpp"
 

--- a/SparseGrids/tsgRuleWavelet.cpp
+++ b/SparseGrids/tsgRuleWavelet.cpp
@@ -28,7 +28,6 @@
  * IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
  */
 
-#include <iostream>
 #include "tsgRuleWavelet.hpp"
 
 #define ACCESS_FINE(I, LEVEL, DEPTH) ((1 << ((DEPTH)-(LEVEL)-1)) * (2 * (I) + 1))

--- a/SparseGrids/tsgRuleWavelet.hpp
+++ b/SparseGrids/tsgRuleWavelet.hpp
@@ -31,9 +31,6 @@
 #ifndef __TASMANIAN_SPARSE_GRID_WAVELET_RULE_HPP
 #define __TASMANIAN_SPARSE_GRID_WAVELET_RULE_HPP
 
-#include <vector>
-
-#include "tsgEnumerates.hpp"
 #include "tsgRuleLocalPolynomial.hpp"
 
 namespace TasGrid{


### PR DESCRIPTION
* removed redundant header inclusions, both direct and transitive, used to create a mess with Doxygen