### PR TITLE
Remove stringh

### DIFF
--- a/DREAM/dreamtest_main.cpp
+++ b/DREAM/dreamtest_main.cpp
@@ -28,44 +28,45 @@
  * IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
  */
 
-#include <iostream>
+#include "tasgridCLICommon.hpp"
 
 #include "tasdreamExternalTests.hpp"
 
 using namespace std;
 
-//enum TypeHelp{
-//    help_generic,
-//    help_benchmark
-//};
-
-//void printHelp(TypeHelp ht = help_generic);
+void printHelp();
 
 int main(int argc, const char ** argv){
+
     //cout << " Phruuuuphrrr " << endl; // this is the sound that the Tasmanian devil makes
+
+    std::deque<std::string> args = stringArgs(argc, argv);
+    if (!args.empty() && hasHelp(args.front())){
+        printHelp();
+        return 0;
+    }
 
     bool debug = false;
     TypeDREAMTest test = test_all;
 
     DreamExternalTester tester;
-    int k = 1;
-    while(k < argc){
-        if ((strcmp(argv[k],"verbose") == 0) || (strcmp(argv[k],"-verbose") == 0)){
+
+    while(!args.empty()){
+        if (hasInfo(args.front())){
             tester.showVerbose();
-            tester.showStatsValues();
-        }else if ((strcmp(argv[k],"v") == 0) || (strcmp(argv[k],"-v") == 0)){
-            tester.showVerbose();
-        }else if ((strcmp(argv[k],"random") == 0) || (strcmp(argv[k],"-random") == 0)){
-            tester.useRandomRandomSeed();
-        }else if ((strcmp(argv[k],"debug") == 0)) debug = true;
-        else if ((strcmp(argv[k],"analytic") == 0)) test = test_analytic;
-        else if ((strcmp(argv[k],"posterior") == 0)) test = test_posterior;
+            if ((args.front() == "verbose") || (args.front() == "-verbose"))
+                tester.showStatsValues();
+        }else if (hasRandom(args.front())) tester.useRandomRandomSeed();
+        else if (args.front() == "debug") debug = true;
+        else if (args.front() == "analytic") test = test_analytic;
+        else if (args.front() == "posterior") test = test_posterior;
+        else if (args.front() == "all") test = test_all;
         else{
-            cerr << "ERROR: Unknown option '" << argv[k] << "'" << endl;
-            cerr << "   to see list of available options use: ./gridtest --help" << endl;
+            cerr << "ERROR: Unknown option '" << args.front() << "'" << endl;
+            cerr << "   to see list of available options use: ./dreamtest --help" << endl;
             return 1;
         }
-        k++;
+        args.pop_front();
     }
 
     if (debug){
@@ -74,4 +75,18 @@ int main(int argc, const char ** argv){
     }
 
     return (tester.performTests(test)) ? 0 : 1;
+}
+
+void printHelp(){
+    cout << endl;
+    cout << "Usage: dreamtest <command1> <command2> ...\n\n";
+    cout << "Commands\tAction\n";
+    cout << "all\t\tRun all tests (default if no commands are given)\n";
+    cout << "analytic\tRun the tests associated with analytic probability distributions\n";
+    cout << "posterior\tRun the tests associated with Bayesian inference\n";
+    cout << "-v\t\tShow verbose test information\n";
+    cout << "verbose\t\tIn addition to -v also shows critical test values\n";
+    cout << "random\t\tDo not use the hard-coded random seed, use the time as random seed\n";
+    cout << "debug\t\tRun the code implemented in tasdreamExternalTests.cpp function testDebug()\n";
+    cout << endl;
 }

--- a/SparseGrids/tasgridCLICommon.hpp
+++ b/SparseGrids/tasgridCLICommon.hpp
@@ -42,7 +42,6 @@
  * \endinternal
  */
 
-#include <map>
 #include <random>
 #include <deque>
 #include <cctype>

--- a/SparseGrids/tasgridWrapper.cpp
+++ b/SparseGrids/tasgridWrapper.cpp
@@ -82,7 +82,7 @@ TypeCommand TasgridWrapper::hasCommand(std::string const &s){
 }
 
 TypeConformalMap TasgridWrapper::getConfromalType(const char* name){
-    if (strcmp(name, "asin") == 0){
+    if (std::string(name) == "asin"){
         return conformal_asin;
     }else{
         return conformal_none;

--- a/SparseGrids/tsgAcceleratedDataStructures.cpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.cpp
@@ -228,19 +228,20 @@ void CudaEngine::sparseMultiply(int M, int N, int K, double alpha, const CudaVec
 void CudaEngine::setDevice() const{ cudaSetDevice(gpu); }
 #endif
 
+std::map<std::string, TypeAcceleration> AccelerationMeta::getStringToAccelerationMap(){
+    return {
+        {"none",        accel_none},
+        {"cpu-blas",    accel_cpu_blas},
+        {"gpu-default", accel_gpu_default},
+        {"gpu-cublas",  accel_gpu_cublas},
+        {"gpu-cuda",    accel_gpu_cuda},
+        {"gpu-magma",   accel_gpu_magma}};
+}
 
 TypeAcceleration AccelerationMeta::getIOAccelerationString(const char * name){
-    if (strcmp(name, "cpu-blas") == 0){
-        return accel_cpu_blas;
-    }else if (strcmp(name, "gpu-default") == 0){
-        return accel_gpu_default;
-    }else if (strcmp(name, "gpu-cublas") == 0){
-        return accel_gpu_cublas;
-    }else if (strcmp(name, "gpu-cuda") == 0){
-        return accel_gpu_cuda;
-    }else if (strcmp(name, "gpu-magma") == 0){
-        return accel_gpu_magma;
-    }else{
+    try{
+        return getStringToAccelerationMap().at(name);
+    }catch(std::out_of_range &){
         return accel_none;
     }
 }

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -396,6 +396,8 @@ namespace AccelerationMeta{
     //! \brief Convert the string (coming from C or Python) into an enumerated type.
     //! \ingroup TasmanianAcceleration
     TypeAcceleration getIOAccelerationString(const char * name);
+    //! \brief Creates a map with \b std::string rule names (used by C/Python/CLI) mapped to \b TypeAcceleration enums.
+    std::map<std::string, TypeAcceleration> getStringToAccelerationMap();
     //! \internal
     //! \brief Convert the enumerated type to a string, the inverse of \b getIOAccelerationString()
     //! \ingroup TasmanianAcceleration

--- a/SparseGrids/tsgCoreOneDimensional.cpp
+++ b/SparseGrids/tsgCoreOneDimensional.cpp
@@ -592,33 +592,25 @@ int OneDimensionalMeta::getIORuleInt(TypeOneDRule rule){
     }
 }
 
+std::map<std::string, TypeDepth> OneDimensionalMeta::getStringToDepthMap(){
+    return {
+        {"level",        type_level},
+        {"curved",       type_curved},
+        {"iptotal",      type_iptotal},
+        {"ipcurved",     type_ipcurved},
+        {"qptotal",      type_qptotal},
+        {"qpcurved",     type_qpcurved},
+        {"hyperbolic",   type_hyperbolic},
+        {"iphyperbolic", type_iphyperbolic},
+        {"qphyperbolic", type_qphyperbolic},
+        {"tensor",       type_tensor},
+        {"iptensor",     type_iptensor},
+        {"qptensor",     type_qptensor}};
+}
 TypeDepth OneDimensionalMeta::getIOTypeString(const char *name){
-    if (strcmp(name, "level") == 0){
-        return type_level;
-    }else if (strcmp(name, "curved") == 0){
-        return type_curved;
-    }else if (strcmp(name, "iptotal") == 0){
-        return type_iptotal;
-    }else if (strcmp(name, "ipcurved") == 0){
-        return type_ipcurved;
-    }else if (strcmp(name, "qptotal") == 0){
-        return type_qptotal;
-    }else if (strcmp(name, "qpcurved") == 0){
-        return type_qpcurved;
-    }else if (strcmp(name, "hyperbolic") == 0){
-        return type_hyperbolic;
-    }else if (strcmp(name, "iphyperbolic") == 0){
-        return type_iphyperbolic;
-    }else if (strcmp(name, "qphyperbolic") == 0){
-        return type_qphyperbolic;
-    }else if (strcmp(name, "tensor") == 0){
-        return type_tensor;
-    }else if (strcmp(name, "iptensor") == 0){
-        return type_iptensor;
-    }else if (strcmp(name, "qptensor") == 0){
-        return type_qptensor;
-    }else{
-        //cerr << "ERROR: " << argv[k] << " is not a valid type!!!  For help see: ./tasgrid -help" << endl << endl;
+    try{
+        return getStringToDepthMap().at(name);
+    }catch(std::out_of_range &){
         return type_none;
     }
 }

--- a/SparseGrids/tsgCoreOneDimensional.cpp
+++ b/SparseGrids/tsgCoreOneDimensional.cpp
@@ -443,92 +443,55 @@ const char* OneDimensionalMeta::getIORuleString(TypeOneDRule rule){
             return "unknown";
     }
 }
+std::map<std::string, TypeOneDRule> OneDimensionalMeta::getStringToRuleMap(){
+    return {
+        {"clenshaw-curtis",      rule_clenshawcurtis},
+        {"clenshaw-curtis-zero", rule_clenshawcurtis0},
+        {"chebyshev",            rule_chebyshev},
+        {"chebyshev-odd",        rule_chebyshevodd},
+        {"gauss-legendre",       rule_gausslegendre},
+        {"gauss-legendre-odd",   rule_gausslegendreodd},
+        {"gauss-patterson",      rule_gausspatterson},
+        {"leja",                 rule_leja},
+        {"leja-odd",             rule_lejaodd},
+        {"rleja",                rule_rleja},
+        {"rleja-double2",        rule_rlejadouble2},
+        {"rleja-double4",        rule_rlejadouble4},
+        {"rleja-odd",            rule_rlejaodd},
+        {"rleja-shifted",        rule_rlejashifted},
+        {"rleja-shifted-even",   rule_rlejashiftedeven},
+        {"rleja-shifted-double", rule_rlejashifteddouble},
+        {"max-lebesgue",         rule_maxlebesgue},
+        {"max-lebesgue-odd",     rule_maxlebesgueodd},
+        {"min-lebesgue",         rule_minlebesgue},
+        {"min-lebesgue-odd",     rule_minlebesgueodd},
+        {"min-delta",            rule_mindelta},
+        {"min-delta-odd",        rule_mindeltaodd},
+        {"gauss-chebyshev1",     rule_gausschebyshev1},
+        {"gauss-chebyshev1-odd", rule_gausschebyshev1odd},
+        {"gauss-chebyshev2",     rule_gausschebyshev2},
+        {"gauss-chebyshev2-odd", rule_gausschebyshev2odd},
+        {"fejer2",               rule_fejer2},
+        {"gauss-gegenbauer",     rule_gaussgegenbauer},
+        {"gauss-gegenbauer-odd", rule_gaussgegenbauerodd},
+        {"gauss-jacobi",         rule_gaussjacobi},
+        {"gauss-jacobi-odd",     rule_gaussjacobiodd},
+        {"gauss-laguerre",       rule_gausslaguerre},
+        {"gauss-laguerre-odd",   rule_gausslaguerreodd},
+        {"gauss-hermite",        rule_gausshermite},
+        {"gauss-hermite-odd",    rule_gausshermiteodd},
+        {"custom-tabulated",     rule_customtabulated},
+        {"localp",               rule_localp},
+        {"localp-zero",          rule_localp0},
+        {"localp-boundary",      rule_localpb},
+        {"semi-localp",          rule_semilocalp},
+        {"wavelet",              rule_wavelet},
+        {"fourier",              rule_fourier}};
+}
 TypeOneDRule OneDimensionalMeta::getIORuleString(const char *name){
-    if (strcmp(name, "clenshaw-curtis") == 0){
-        return rule_clenshawcurtis;
-    }else if (strcmp(name, "clenshaw-curtis-zero") == 0){
-        return rule_clenshawcurtis0;
-    }else if (strcmp(name, "chebyshev") == 0){
-        return rule_chebyshev;
-    }else if (strcmp(name, "chebyshev-odd") == 0){
-        return rule_chebyshevodd;
-    }else if (strcmp(name, "gauss-legendre") == 0){
-        return rule_gausslegendre;
-    }else if (strcmp(name, "gauss-legendre-odd") == 0){
-        return rule_gausslegendreodd;
-    }else if (strcmp(name, "gauss-patterson") == 0){
-        return rule_gausspatterson;
-    }else if (strcmp(name, "leja") == 0){
-        return rule_leja;
-    }else if (strcmp(name, "leja-odd") == 0){
-        return rule_lejaodd;
-    }else if (strcmp(name, "rleja") == 0){
-        return rule_rleja;
-    }else if (strcmp(name, "rleja-double2") == 0){
-        return rule_rlejadouble2;
-    }else if (strcmp(name, "rleja-double4") == 0){
-        return rule_rlejadouble4;
-    }else if (strcmp(name, "rleja-odd") == 0){
-        return rule_rlejaodd;
-    }else if (strcmp(name, "rleja-shifted") == 0){
-        return rule_rlejashifted;
-    }else if (strcmp(name, "rleja-shifted-even") == 0){
-        return rule_rlejashiftedeven;
-    }else if (strcmp(name, "rleja-shifted-double") == 0){
-        return rule_rlejashifteddouble;
-    }else if (strcmp(name, "max-lebesgue") == 0){
-        return rule_maxlebesgue;
-    }else if (strcmp(name, "max-lebesgue-odd") == 0){
-        return rule_maxlebesgueodd;
-    }else if (strcmp(name, "min-lebesgue") == 0){
-        return rule_minlebesgue;
-    }else if (strcmp(name, "min-lebesgue-odd") == 0){
-        return rule_minlebesgueodd;
-    }else if (strcmp(name, "min-delta") == 0){
-        return rule_mindelta;
-    }else if (strcmp(name, "min-delta-odd") == 0){
-        return rule_mindeltaodd;
-    }else if (strcmp(name, "gauss-chebyshev1") == 0){
-        return rule_gausschebyshev1;
-    }else if (strcmp(name, "gauss-chebyshev1-odd") == 0){
-        return rule_gausschebyshev1odd;
-    }else if (strcmp(name, "gauss-chebyshev2") == 0){
-        return rule_gausschebyshev2;
-    }else if (strcmp(name, "gauss-chebyshev2-odd") == 0){
-        return rule_gausschebyshev2odd;
-    }else if (strcmp(name, "fejer2") == 0){
-        return rule_fejer2;
-    }else if (strcmp(name, "gauss-gegenbauer") == 0){
-        return rule_gaussgegenbauer;
-    }else if (strcmp(name, "gauss-gegenbauer-odd") == 0){
-        return rule_gaussgegenbauerodd;
-    }else if (strcmp(name, "gauss-jacobi") == 0){
-        return rule_gaussjacobi;
-    }else if (strcmp(name, "gauss-jacobi-odd") == 0){
-        return rule_gaussjacobiodd;
-    }else if (strcmp(name, "gauss-laguerre") == 0){
-        return rule_gausslaguerre;
-    }else if (strcmp(name, "gauss-laguerre-odd") == 0){
-        return rule_gausslaguerreodd;
-    }else if (strcmp(name, "gauss-hermite") == 0){
-        return rule_gausshermite;
-    }else if (strcmp(name, "gauss-hermite-odd") == 0){
-        return rule_gausshermiteodd;
-    }else if (strcmp(name, "custom-tabulated") == 0){
-        return rule_customtabulated;
-    }else if (strcmp(name, "localp") == 0){
-        return rule_localp;
-    }else if (strcmp(name, "localp-zero") == 0){
-        return rule_localp0;
-    }else if (strcmp(name, "localp-boundary") == 0){
-        return rule_localpb;
-    }else if (strcmp(name, "semi-localp") == 0){
-        return rule_semilocalp;
-    }else if (strcmp(name, "wavelet") == 0){
-        return rule_wavelet;
-    }else if (strcmp(name, "fourier") == 0){
-        return rule_fourier;
-    }else{
+    try{
+        return getStringToRuleMap().at(name);
+    }catch(std::out_of_range &){
         return rule_none;
     }
 }

--- a/SparseGrids/tsgCoreOneDimensional.cpp
+++ b/SparseGrids/tsgCoreOneDimensional.cpp
@@ -633,16 +633,17 @@ TypeDepth OneDimensionalMeta::getIOTypeInt(int type){
     }
 }
 
+std::map<std::string, TypeRefinement> OneDimensionalMeta::getStringToRefinementMap(){
+    return {
+        {"classic",   refine_classic},
+        {"parents",   refine_parents_first},
+        {"direction", refine_direction_selective},
+        {"fds",       refine_fds}};
+}
 TypeRefinement OneDimensionalMeta::getIOTypeRefinementString(const char *name){
-    if (strcmp(name, "classic") == 0){
-        return refine_classic;
-    }else if (strcmp(name, "parents") == 0){
-        return refine_parents_first;
-    }else if (strcmp(name, "direction") == 0){
-        return refine_direction_selective;
-    }else if (strcmp(name, "fds") == 0){
-        return refine_fds;
-    }else{
+    try{
+        return getStringToRefinementMap().at(name);
+    }catch(std::out_of_range &){
         return refine_none;
     }
 }

--- a/SparseGrids/tsgCoreOneDimensional.hpp
+++ b/SparseGrids/tsgCoreOneDimensional.hpp
@@ -128,6 +128,8 @@ namespace OneDimensionalMeta{
 
     //! \brief Map the string rule name to the enumerate, used in ASCII I/O, command line and Python.
     TypeOneDRule getIORuleString(const char *name);
+    //! \brief Creates a map with \b std::string rule names (used by C/Python/CLI) mapped to \b TypeOneDRule enums.
+    std::map<std::string, TypeOneDRule> getStringToRuleMap();
     //! \brief Map the enumerate to a string, used in ASCII I/O, command line and Python.
     const char* getIORuleString(TypeOneDRule rule);
     //! \brief Map the enumerate to a human readable string, used in \b printStats().

--- a/SparseGrids/tsgCoreOneDimensional.hpp
+++ b/SparseGrids/tsgCoreOneDimensional.hpp
@@ -188,6 +188,8 @@ namespace OneDimensionalMeta{
 
     //! \brief Map the string to the enumerate multi-index selection strategy, used in command line and Python.
     TypeDepth getIOTypeString(const char *name);
+    //! \brief Creates a map with \b std::string rule names (used by C/Python/CLI) mapped to \b TypeDepth enums.
+    std::map<std::string, TypeDepth> getStringToDepthMap();
     //! \brief Map the integer to the enumerate multi-index selection strategy, used in Fortran.
     TypeDepth getIOTypeInt(int type);
 

--- a/SparseGrids/tsgCoreOneDimensional.hpp
+++ b/SparseGrids/tsgCoreOneDimensional.hpp
@@ -195,6 +195,8 @@ namespace OneDimensionalMeta{
 
     //! \brief Map the string to the enumerate hierarchical refinement strategy, used in command line and Python.
     TypeRefinement getIOTypeRefinementString(const char *name);
+    //! \brief Creates a map with \b std::string rule names (used by C/Python/CLI) mapped to \b TypeRefinement enums.
+    std::map<std::string, TypeRefinement> getStringToRefinementMap();
     //! \brief Map the integer to the enumerate hierarchical refinement strategy, used in Fortran.
     TypeRefinement getIOTypeRefinementInt(int ref);
 }

--- a/SparseGrids/tsgEnumerates.hpp
+++ b/SparseGrids/tsgEnumerates.hpp
@@ -32,6 +32,7 @@
 #define __TASMANIAN_SPARSE_GRID_ENUMERATES_HPP
 
 // system headers used in many/many places
+#include <map>
 #include <iostream>
 #include <iomanip>
 #include <fstream>

--- a/SparseGrids/tsgEnumerates.hpp
+++ b/SparseGrids/tsgEnumerates.hpp
@@ -36,7 +36,6 @@
 #include <iostream>
 #include <iomanip>
 #include <fstream>
-#include <string.h>
 #include <string>
 #include <vector>
 #include <cmath>


### PR DESCRIPTION
* converted dream cli tests to the dequeue mechanism and switched enum to string maps to std::map
* resulting in the removal of `strcmp()` usage and the need for `string.h` header