### PR TITLE
Improved build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,50 +206,5 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianENVsetup.sh"
 # Setup Message
 ########################################################################
 if (NOT USE_XSDK_DEFAULTS)
-    message(STATUS "")
-    message(STATUS "Tasmanian ${Tasmanian_VERSION_MAJOR}.${Tasmanian_VERSION_MINOR} (development version): summary of build options")
-    message(STATUS " -D CMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}")
-    message(STATUS " -D CMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}")
-    message(STATUS " -D CMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}")
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-        message(STATUS " -D CMAKE_CXX_FLAGS_DEBUG:STRING=${CMAKE_CXX_FLAGS_DEBUG}") # useful for Windows debugging
-        message(STATUS " -D CMAKE_CXX_FLAGS_RELEASE:STRING=${CMAKE_CXX_FLAGS_RELEASE}")
-    endif()
-    if (Tasmanian_ENABLE_CUDA)
-        message(STATUS " -D CMAKE_CUDA_FLAGS:STRING=${CMAKE_CUDA_FLAGS}")
-    endif()
-    if (DEFINED BUILD_SHARED_LIBS)
-        message(STATUS " -D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}")
-    else()
-        message(STATUS " -D BUILD_SHARED_LIBS=Undefined")
-    endif()
-    foreach(Tasmanian_option Tasmanian_ENABLE_OPENMP  Tasmanian_ENABLE_BLAS
-                             Tasmanian_ENABLE_MPI     Tasmanian_ENABLE_PYTHON
-                             Tasmanian_ENABLE_CUDA    Tasmanian_ENABLE_MAGMA
-                             Tasmanian_ENABLE_FORTRAN Tasmanian_ENABLE_DOXYGEN)
-        if (${Tasmanian_option})
-            message(STATUS " -D ${Tasmanian_option}:BOOL=ON")
-        else()
-            message(STATUS " -D ${Tasmanian_option}:BOOL=OFF")
-        endif()
-    endforeach()
-    if (Tasmanian_MAGMA AND Tasmanian_MAGMA_ROOT)
-        message(STATUS " -D Tasmanian_MAGMA_ROOT:PATH=${Tasmanian_MAGMA_ROOT}")
-    endif()
-    if (NOT "${Tasmanian_MATLAB_WORK_FOLDER}" STREQUAL "")
-        message(STATUS " -D Tasmanian_MATLAB_WORK_FOLDER:PATH=${Tasmanian_MATLAB_WORK_FOLDER}")
-        message(STATUS " pre-install MATLAB folder: addpath('${CMAKE_CURRENT_BINARY_DIR}/MATLAB/matlab/')")
-    endif()
-    message(STATUS "")
-endif()
-
-
-########################################################################
-# Print final message (a bit of a hack)
-# The message is written in the CMakeLists.txt, as the subdir is added last
-# this ensures that the message will appear last in the install process
-# do not print if USE_XSDK or Tasmanian has been imported with addsubdir
-########################################################################
-if (NOT USE_XSDK_DEFAULTS AND (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME}))
-    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/Config/CMakeIncludes/")
+    include("${CMAKE_CURRENT_SOURCE_DIR}/Config/CMakeIncludes/setup_message.cmake")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,55 +151,12 @@ endif()
 
 
 ########################################################################
-# Skip test post-install, exports and package config,
-# in the case when Tasmanian is merged into an external master project.
-# The master should be responsible for such testing and exporting
+# Tasmanian is merged into an external master project then skip the exports
+# The master should be responsible for post-install testing and exporting
 ########################################################################
 if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
-########################################################################
-# Testing: post install, make test_install
-# checks if the executables run and if the examples compile and run
-########################################################################
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Testing/test_post_install.in.sh" "${CMAKE_CURRENT_BINARY_DIR}/test_post_install.sh")
-    if (Tasmanian_ENABLE_FORTRAN)
-        add_custom_target(test_install COMMAND "${CMAKE_CURRENT_BINARY_DIR}/test_post_install.sh"
-                                               "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}")
-    else()
-        add_custom_target(test_install COMMAND "${CMAKE_CURRENT_BINARY_DIR}/test_post_install.sh"
-                                               "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
-    endif()
-
-########################################################################
-# Install exports, package-config files, and examples cmake file
-########################################################################
-    install(EXPORT "${Tasmanian_export_name}" DESTINATION "lib/${CMAKE_PROJECT_NAME}" FILE "${CMAKE_PROJECT_NAME}.cmake")
-
-    configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/Config/TasmanianConfig.in.cmake"
-                                  "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianConfig.cmake"
-                                  INSTALL_DESTINATION "lib/Tasmanian/")
-    write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianConfigVersion.cmake"
-                                     COMPATIBILITY AnyNewerVersion)
-    # not sure why it is necessary to explicitly install TasmanianConfig.cmake, INSTALL_DESTINATION above doesn't work
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianConfig.cmake"
-            DESTINATION "lib/Tasmanian/"
-            PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianConfigVersion.cmake"
-            DESTINATION "lib/Tasmanian/"
-            PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
-
-    # cmake file for the examples, to be used post-install
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Config/CMakeLists.examples.txt" "${CMAKE_CURRENT_BINARY_DIR}/configured/CMakeLists.txt" @ONLY)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/CMakeLists.txt"
-            DESTINATION "share/Tasmanian/examples/"
-            PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
+    include("${CMAKE_CURRENT_SOURCE_DIR}/Config/CMakeIncludes/exports.cmake")
 endif()
-
-
-# configure environment shell script that can be sourced to set path and lib path
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Config/TasmanianENVsetup.in.sh" "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianENVsetup.sh" @ONLY)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianENVsetup.sh"
-        DESTINATION "share/Tasmanian/"
-        PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 
 
 ########################################################################

--- a/Config/CMakeIncludes/exports.cmake
+++ b/Config/CMakeIncludes/exports.cmake
@@ -29,6 +29,16 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianConfigVersion.cma
         DESTINATION "lib/Tasmanian/"
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 
+# TasmanianMake.in for GNU Make include/link
+get_target_property(Tasmanian_list Tasmanian_libsparsegrid INTERFACE_LINK_LIBRARIES)
+foreach(Tasmanian_lib_ ${Tasmanian_list})
+    set(Tasmanian_libs "${Tasmanian_libs} ${Tasmanian_lib_}")
+endforeach()
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Config/TasmanianMakefile.in" "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianMakefile.in" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianMakefile.in"
+        DESTINATION "share/Tasmanian/"
+        PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
+
 # cmake file for the examples, to be used post-install
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Config/CMakeLists.examples.txt" "${CMAKE_CURRENT_BINARY_DIR}/configured/CMakeLists.txt" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/CMakeLists.txt"

--- a/Config/CMakeIncludes/exports.cmake
+++ b/Config/CMakeIncludes/exports.cmake
@@ -1,0 +1,43 @@
+########################################################################
+# Testing: post install, make test_install
+# checks if the executables run and if the examples compile and run
+########################################################################
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Testing/test_post_install.in.sh" "${CMAKE_CURRENT_BINARY_DIR}/test_post_install.sh")
+if (Tasmanian_ENABLE_FORTRAN)
+    add_custom_target(test_install COMMAND "${CMAKE_CURRENT_BINARY_DIR}/test_post_install.sh"
+                                           "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}")
+else()
+    add_custom_target(test_install COMMAND "${CMAKE_CURRENT_BINARY_DIR}/test_post_install.sh"
+                                           "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
+endif()
+
+########################################################################
+# Install exports, package-config files, and examples cmake file
+########################################################################
+install(EXPORT "${Tasmanian_export_name}" DESTINATION "lib/${CMAKE_PROJECT_NAME}" FILE "${CMAKE_PROJECT_NAME}.cmake")
+
+configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/Config/TasmanianConfig.in.cmake"
+                              "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianConfig.cmake"
+                              INSTALL_DESTINATION "lib/Tasmanian/")
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianConfigVersion.cmake"
+                                 COMPATIBILITY AnyNewerVersion)
+# not sure why it is necessary to explicitly install TasmanianConfig.cmake, INSTALL_DESTINATION above doesn't work
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianConfig.cmake"
+        DESTINATION "lib/Tasmanian/"
+        PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianConfigVersion.cmake"
+        DESTINATION "lib/Tasmanian/"
+        PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
+
+# cmake file for the examples, to be used post-install
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Config/CMakeLists.examples.txt" "${CMAKE_CURRENT_BINARY_DIR}/configured/CMakeLists.txt" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/CMakeLists.txt"
+        DESTINATION "share/Tasmanian/examples/"
+        PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
+
+
+# configure environment shell script that can be sourced to set path and lib path
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Config/TasmanianENVsetup.in.sh" "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianENVsetup.sh" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianENVsetup.sh"
+        DESTINATION "share/Tasmanian/"
+        PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)

--- a/Config/CMakeIncludes/setup_message.cmake
+++ b/Config/CMakeIncludes/setup_message.cmake
@@ -1,0 +1,48 @@
+########################################################################
+# Print the configuration options
+########################################################################
+message(STATUS "")
+message(STATUS "Tasmanian ${Tasmanian_VERSION_MAJOR}.${Tasmanian_VERSION_MINOR} (development version): summary of build options")
+message(STATUS " -D CMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}")
+message(STATUS " -D CMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}")
+message(STATUS " -D CMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}")
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    message(STATUS " -D CMAKE_CXX_FLAGS_DEBUG:STRING=${CMAKE_CXX_FLAGS_DEBUG}") # useful for Windows debugging
+    message(STATUS " -D CMAKE_CXX_FLAGS_RELEASE:STRING=${CMAKE_CXX_FLAGS_RELEASE}")
+endif()
+if (Tasmanian_ENABLE_CUDA)
+    message(STATUS " -D CMAKE_CUDA_FLAGS:STRING=${CMAKE_CUDA_FLAGS}")
+endif()
+if (DEFINED BUILD_SHARED_LIBS)
+    message(STATUS " -D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}")
+else()
+    message(STATUS " -D BUILD_SHARED_LIBS=Undefined")
+endif()
+foreach(Tasmanian_option Tasmanian_ENABLE_OPENMP  Tasmanian_ENABLE_BLAS
+                         Tasmanian_ENABLE_MPI     Tasmanian_ENABLE_PYTHON
+                         Tasmanian_ENABLE_CUDA    Tasmanian_ENABLE_MAGMA
+                         Tasmanian_ENABLE_FORTRAN Tasmanian_ENABLE_DOXYGEN)
+    if (${Tasmanian_option})
+        message(STATUS " -D ${Tasmanian_option}:BOOL=ON")
+    else()
+        message(STATUS " -D ${Tasmanian_option}:BOOL=OFF")
+    endif()
+endforeach()
+if (Tasmanian_MAGMA AND Tasmanian_MAGMA_ROOT)
+    message(STATUS " -D Tasmanian_MAGMA_ROOT:PATH=${Tasmanian_MAGMA_ROOT}")
+endif()
+if (NOT "${Tasmanian_MATLAB_WORK_FOLDER}" STREQUAL "")
+    message(STATUS " -D Tasmanian_MATLAB_WORK_FOLDER:PATH=${Tasmanian_MATLAB_WORK_FOLDER}")
+    message(STATUS " pre-install MATLAB folder: addpath('${CMAKE_CURRENT_BINARY_DIR}/MATLAB/matlab/')")
+endif()
+message(STATUS "")
+
+########################################################################
+# Print final message (a bit of a hack)
+# The message is written in the CMakeLists.txt, as the subdir is added last
+# this ensures that the message will appear last in the install process
+# do not print if USE_XSDK or Tasmanian has been imported with addsubdir
+########################################################################
+if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
+    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/Config/CMakeIncludes/")
+endif()

--- a/Config/TasmanianMakefile.in
+++ b/Config/TasmanianMakefile.in
@@ -1,0 +1,4 @@
+Tasmanian_include = -I@CMAKE_INSTALL_PREFIX@/include/
+Tasmanian_link = -L@CMAKE_INSTALL_PREFIX@/lib/
+Tasmanian_libs = -ltasmaniandream -ltasmaniansparsegrid @Tasmanian_libs@
+Tarmanian_fortran_libs = -ltasmanianfortran90 $(Tasmanian_libs) -lstdc++

--- a/InterfacePython/CMakeLists.txt
+++ b/InterfacePython/CMakeLists.txt
@@ -134,7 +134,12 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianSG.py"
         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ)
 
 # Create symlink for backward compatibility
-install(CODE "execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink ${Tasmanian_python_install_path} ${Tasmanian_PYTHONPATH} )" )
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    # Windows does not support sym-link, but it is still beneficial to have a version independent python module
+    install(CODE "execute_process( COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/configured/TasmanianSG.py ${Tasmanian_PYTHONPATH}/TasmanianSG.py )" )
+else()
+    install(CODE "execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink ${Tasmanian_python_install_path} ${Tasmanian_PYTHONPATH} )" )
+endif()
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/example_sparse_grids.py"
         DESTINATION "share/Tasmanian/examples/"
         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ)

--- a/Testing/test_post_install.in.sh
+++ b/Testing/test_post_install.in.sh
@@ -38,7 +38,7 @@ echo "--------------------------------------------------------------------------
 echo " Test 2: compile and run the C++ examples"
 echo "--------------------------------------------------------------------------------"
 echo 'Building  "cmake @CMAKE_INSTALL_PREFIX@/share/Tasmanian/examples"'
-cmake $1 @CMAKE_INSTALL_PREFIX@/share/Tasmanian/examples || { echo "ERROR: Could not cmake the C++ examples"; exit 1; }
+@CMAKE_COMMAND@ $1 @CMAKE_INSTALL_PREFIX@/share/Tasmanian/examples || { echo "ERROR: Could not cmake the C++ examples"; exit 1; }
 echo 'Compiling "make"'
 make || { echo "ERROR: Could not compile the C++ examples"; exit 1; }
 echo 'Executing "./example_sparse_grids" SKIP WILL FIX THE EXAMPLES LATER'


### PR DESCRIPTION
* split CMake configure exports and config message to separate files
* added export file for GNU Make build system that is using Tasmanian + CMake
* copy the Python version independent module under Windows (Linux uses sym-link)