### PR TITLE
begin anisotropic refinement for Fourier grids

### DIFF
--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -891,6 +891,8 @@ void TasmanianSparseGrid::estimateAnisotropicCoefficients(TypeDepth type, int ou
         }else{
             getGridGlobal()->estimateAnisotropicCoefficients(type, output, weights);
         }
+    }else if (isFourier()){
+        getGridFourier()->estimateAnisotropicCoefficients(type, output, weights);
     }else{
         throw std::runtime_error("ERROR: estimateAnisotropicCoefficients called for a grid that is neither Sequence nor Global with a sequence rule");
     }

--- a/SparseGrids/tasgridExternalTests.hpp
+++ b/SparseGrids/tasgridExternalTests.hpp
@@ -149,6 +149,7 @@ private:
     TwoOneConformalOne f21conformal;
     SixteenOneActive3 f16active3;
     Two3KExpSinCos f23Kexpsincos;
+    TwoOneC1C2Periodic f21c1c2periodic;
 };
 
 #endif

--- a/SparseGrids/tasgridTestFunctions.cpp
+++ b/SparseGrids/tasgridTestFunctions.cpp
@@ -193,4 +193,9 @@ void Two3KExpSinCos::getIntegral(double y[]) const{
     }
 }
 
+TwoOneC1C2Periodic::TwoOneC1C2Periodic(){} TwoOneC1C2Periodic::~TwoOneC1C2Periodic(){} int TwoOneC1C2Periodic::getNumInputs() const{ return 2; } int TwoOneC1C2Periodic::getNumOutputs() const { return 1; }
+const char* TwoOneC1C2Periodic::getDescription() const{ return "f(x,y) = (x^3-x) + (y^4-2y^2)"; }
+void TwoOneC1C2Periodic::eval(const double x[], double y[]) const { y[0] = x[0] * (x[0] * x[0] - 1.0) + x[1] * x[1] * (x[1] * x[1] - 2.0); } void TwoOneC1C2Periodic::getIntegral(double y[]) const{ y[0] = -28.0 / 15.0; }
+
+
 #endif

--- a/SparseGrids/tasgridTestFunctions.hpp
+++ b/SparseGrids/tasgridTestFunctions.hpp
@@ -262,4 +262,11 @@ public:
     int getNumInputs() const; int getNumOutputs() const; const char* getDescription() const; void eval(const double x[], double y[]) const; void getIntegral(double y[]) const;
 };
 
+class TwoOneC1C2Periodic: public BaseFunction{
+public:
+    TwoOneC1C2Periodic(); ~TwoOneC1C2Periodic();
+
+    int getNumInputs() const; int getNumOutputs() const; const char* getDescription() const; void eval(const double x[], double y[]) const; void getIntegral(double y[]) const;
+};
+
 #endif

--- a/SparseGrids/tsgGridFourier.cpp
+++ b/SparseGrids/tsgGridFourier.cpp
@@ -567,7 +567,7 @@ void GridFourier::estimateAnisotropicCoefficients(TypeDepth type, int output, st
     for(int c=0; c<num_points; c++){
         const int *indx = points.getIndex(c);
         if (max_fcoef[c] > tol){
-            for(int j=0; j<num_dimensions; j++) A.getStrip(j)[count] = (ishyperbolic) ? log((double) (indx[j]+1)) : ((double) indx[j]);
+            for(int j=0; j<num_dimensions; j++) A.getStrip(j)[count] = (ishyperbolic) ? log((double) ((indx[j]+1)/2 + 1)) : ((double) ((indx[j]+1)/2));
             A.getStrip(num_dimensions)[count] = 1.0;
             b[count++] = -log(max_fcoef[c]);
         }

--- a/SparseGrids/tsgGridFourier.hpp
+++ b/SparseGrids/tsgGridFourier.hpp
@@ -88,6 +88,8 @@ public:
     #endif
 
     void clearAccelerationData();
+
+    void estimateAnisotropicCoefficients(TypeDepth type, int output, std::vector<int> &weights) const;
     void clearRefinement();
     void mergeRefinement();
 


### PR DESCRIPTION
- start base functionality for `estimateAnisotropicCoefficients()` for Fourier grids
- highly similar to `tsgGridSequence.cpp` and `tsgGridGlobal.cpp`
- add tests for `estimateAnisotropicCoefficients` in Fourier case