### PR TITLE
replace tabs with spaces for consistency

### DIFF
--- a/SparseGrids/tasgridExternalTests.cpp
+++ b/SparseGrids/tasgridExternalTests.cpp
@@ -190,26 +190,26 @@ TestResults ExternalTester::getError(const BaseFunction *f, TasGrid::TasmanianSp
         std::vector<double> result_true(num_mc * num_outputs);
         setRandomX(num_dimensions * num_mc, test_x.data());
 
-		#pragma omp parallel for // note that iterators do not work with OpenMP, direct indexing does
-		for(int i=0; i<num_mc; i++){
-			grid->evaluate(&(test_x[i * num_dimensions]), &(result_tasm[i * num_outputs]));
-			f->eval(&(test_x[i * num_dimensions]), &(result_true[i * num_outputs]));
-		}
+        #pragma omp parallel for // note that iterators do not work with OpenMP, direct indexing does
+        for(int i=0; i<num_mc; i++){
+            grid->evaluate(&(test_x[i * num_dimensions]), &(result_tasm[i * num_outputs]));
+            f->eval(&(test_x[i * num_dimensions]), &(result_true[i * num_outputs]));
+        }
 
-		for(int i=0; i<num_mc; i++){
-			for(int k=0; k<num_outputs; k++){
+        for(int i=0; i<num_mc; i++){
+            for(int k=0; k<num_outputs; k++){
                 double nrmik = std::abs(result_true[i * num_outputs + k]);
                 double errik = std::abs(result_true[i * num_outputs + k] - result_tasm[i * num_outputs + k]);
                 if (nrm[k] < nrmik) nrm[k] = nrmik;
                 if (err[k] < errik) err[k] = errik;
-			}
-		}
+            }
+        }
 
-		double rel_err = 0.0; // relative error
-		for(int k=0; k<num_outputs; k++){
+        double rel_err = 0.0; // relative error
+        for(int k=0; k<num_outputs; k++){
             double relative_errork = err[k] / nrm[k];
-			if (rel_err < relative_errork) rel_err = relative_errork;
-		}
+            if (rel_err < relative_errork) rel_err = relative_errork;
+        }
 
         R.error = rel_err;
     }

--- a/SparseGrids/tsgGridWavelet.cpp
+++ b/SparseGrids/tsgGridWavelet.cpp
@@ -183,20 +183,20 @@ void GridWavelet::getPoints(double *x) const{
 void GridWavelet::getQuadratureWeights(double *weights) const{
     const MultiIndexSet &work = (points.empty()) ? needed : points;
     int num_points = work.getNumIndexes();
-	#pragma omp parallel for
-	for(int i=0; i<num_points; i++){
-		weights[i] = evalIntegral(work.getIndex(i));
-	}
-	solveTransposed(weights);
+    #pragma omp parallel for
+    for(int i=0; i<num_points; i++){
+        weights[i] = evalIntegral(work.getIndex(i));
+    }
+    solveTransposed(weights);
 }
 void GridWavelet::getInterpolationWeights(const double x[], double *weights) const{
     const MultiIndexSet &work = (points.empty()) ? needed : points;
     int num_points = work.getNumIndexes();
-	#pragma omp parallel for
-	for(int i=0; i<num_points; i++){
+    #pragma omp parallel for
+    for(int i=0; i<num_points; i++){
         weights[i] = evalBasis(work.getIndex(i), x);
-	}
-	solveTransposed(weights);
+    }
+    solveTransposed(weights);
 }
 void GridWavelet::loadNeededPoints(const double *vals){
     #ifdef Tasmanian_ENABLE_CUDA
@@ -388,7 +388,7 @@ void GridWavelet::recomputeCoefficients(){
 
     std::vector<double> b(num_points), x(num_points);
 
-	for(int output = 0; output < num_outputs; output++){
+    for(int output = 0; output < num_outputs; output++){
         // Copy relevant portion
         std::fill(x.begin(), x.end(), 0.0);
         std::fill(b.begin(), b.end(), 0.0);

--- a/SparseGrids/tsgLinearSolvers.cpp
+++ b/SparseGrids/tsgLinearSolvers.cpp
@@ -332,12 +332,12 @@ void SparseMatrix::computeILU(){
     indxD.resize(num_rows);
     ilu.resize(pntr[num_rows]);
     for(int i=0; i<num_rows; i++){
-		int j = pntr[i];
-		while(indx[j] < i){ j++; };
-		indxD[i] = j;
-	}
+        int j = pntr[i];
+        while(indx[j] < i){ j++; };
+        indxD[i] = j;
+    }
 
-	ilu = vals;
+    ilu = vals;
 
     for(int i=0; i<num_rows-1; i++){
         double u = ilu[indxD[i]];

--- a/SparseGrids/tsgLinearSolvers.hpp
+++ b/SparseGrids/tsgLinearSolvers.hpp
@@ -130,7 +130,7 @@ public:
     int getNumRows() const;
 
     //! \brief Solve `op(A) x = b` where `op` is either identity (find the coefficients) or transpose (find the interpolation weights).
-	void solve(const double b[], double x[], bool transposed = false) const;
+    void solve(const double b[], double x[], bool transposed = false) const;
 
 protected:
     //! \brief Clear the internal data structures (maybe not needed?)


### PR DESCRIPTION
Switched tabs to spaces for consistency. Geany kept catching the tabs in `tasgridExternalTests.cpp`, so I did a find-replace job on all the files in `SparseGrids/`. Otherwise I have to go back in and manually re-add the tabs afterwards.