### PR TITLE
add mpi to the docker image

### DIFF
--- a/Addons/CMakeLists.txt
+++ b/Addons/CMakeLists.txt
@@ -47,7 +47,7 @@ if (Tasmanian_ENABLE_MPI)
     add_executable(Tasmanian_mpitester testMPI.cpp testMPI.hpp)
     set_target_properties(Tasmanian_mpitester PROPERTIES OUTPUT_NAME "mpitester")
     target_link_libraries(Tasmanian_mpitester Tasmanian_addons Tasmanian_libdream)
-    add_test(MPISparseGridsIO ${MPIEXEC_EXECUTABLE} -np 3 mpitester)
+    add_test(MPISparseGridsIO ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS} mpitester ${MPIEXEC_POSTFLAGS})
 endif()
 
 # test for non-MPI capabilities

--- a/docker/Dockerfile_stack
+++ b/docker/Dockerfile_stack
@@ -10,6 +10,9 @@ RUN apt update && apt install --no-install-recommends -y \
         cmake \
         gfortran \
         git \
+        libopenmpi-dev \
+        openmpi-bin \
+        openssh-client \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/jenkins/build.sh
+++ b/docker/jenkins/build.sh
@@ -24,6 +24,8 @@ then
       -D CMAKE_CXX_FLAGS="-Wall -Wextra -Wshadow -pedantic" \
       -D CMAKE_CXX_COMPILER=g++ \
       -D Tasmanian_ENABLE_RECOMMENDED=ON \
+      -D Tasmanian_ENABLE_MPI=ON \
+      -D MPIEXEC_PREFLAGS="--allow-run-as-root" \
       -D Tasmanian_ENABLE_FORTRAN=ON \
       -D PYTHON_EXECUTABLE=/usr/bin/python2 \
       -D Tasmanian_TESTS_OMP_NUM_THREADS=4 \


### PR DESCRIPTION
* Makes sure that we add MPI to the docker image the next time we update the image. 
* MPI testing is enabled in the nightly builds, so actual updating can wait.