### PR TITLE
Small adjustments

### DIFF
--- a/Addons/testConstructSurrogate.hpp
+++ b/Addons/testConstructSurrogate.hpp
@@ -153,13 +153,13 @@ bool testConstructSurrogate(bool verbose){
 
     // Basic test, run until grid points are exhausted, number of points can still vary
     // due to child surplus being computed before or after the parent point has completed
-    TasGrid::constructSurrogate<true>(model_exp, -1, 2, 1, grid, 1.E-4, TasGrid::refine_classic); // parallel
+    TasGrid::constructSurrogate<TasGrid::mode_parallel>(model_exp, -1, 2, 1, grid, 1.E-4, TasGrid::refine_classic); // parallel
     simpleSequentialConstruction(model_exp, 300, 2, reference_grid, 1.E-4, TasGrid::refine_classic);
     compareGrids(5.E-4, grid, reference_grid, false);
     if (verbose) cout << std::setw(40) << "parallel localp unlimited budget" << std::setw(10) << "Pass" << endl;
 
     grid = TasGrid::makeLocalPolynomialGrid(2, 1, 3, 2);
-    TasGrid::constructSurrogate<true>(model_exp2, -1, 2, 2, grid, 1.E-4, TasGrid::refine_classic); // parallel, batch 2
+    TasGrid::constructSurrogate<TasGrid::mode_parallel>(model_exp2, -1, 2, 2, grid, 1.E-4, TasGrid::refine_classic); // parallel, batch 2
     compareGrids(5.E-4, grid, reference_grid, false);
     if (verbose) cout << std::setw(40) << "parallel localp batch" << std::setw(10) << "Pass" << endl;
 
@@ -167,7 +167,7 @@ bool testConstructSurrogate(bool verbose){
     // compare the grids by how similar they are to each other
     grid = TasGrid::makeLocalPolynomialGrid(2, 1, 3, 1);
     reference_grid = grid;
-    TasGrid::constructSurrogate<true>(model_exp, 500, 8, 1, grid, 1.E-4, TasGrid::refine_classic); // parallel, limit points
+    TasGrid::constructSurrogate<TasGrid::mode_parallel>(model_exp, 500, 8, 1, grid, 1.E-4, TasGrid::refine_classic); // parallel, limit points
     simpleSequentialConstruction(model_exp, 500, 2, reference_grid, 1.E-4, TasGrid::refine_classic);
     compareGrids(5.E-4, grid, reference_grid, true);
     if (verbose) cout << std::setw(40) << "parallel localp limited budget" << std::setw(10) << "Pass" << endl;
@@ -175,7 +175,7 @@ bool testConstructSurrogate(bool verbose){
     // Sequential test, checks the simpler algorithm, this should be deterministic
     grid = TasGrid::makeLocalPolynomialGrid(2, 1, 3, 2);
     reference_grid = grid;
-    TasGrid::constructSurrogate<false>(model_exp, -1, 2, 1, grid, 1.E-4, TasGrid::refine_classic); // sequential
+    TasGrid::constructSurrogate<TasGrid::mode_sequential>(model_exp, -1, 2, 1, grid, 1.E-4, TasGrid::refine_classic); // sequential
     simpleSequentialConstruction(model_exp, 300, 2, reference_grid, 1.E-4, TasGrid::refine_classic);
     compareGrids(1.E-9, grid, reference_grid, true);
     if (verbose) cout << std::setw(40) << "sequential localp limited budget" << std::setw(10) << "Pass" << endl;
@@ -184,7 +184,7 @@ bool testConstructSurrogate(bool verbose){
     auto model_aniso = [&](std::vector<double> const &x, std::vector<double> &y, size_t)->void{ y = {std::exp(x[0] + 0.1 * x[1])}; };
     grid = TasGrid::makeGlobalGrid(2, 1, 3, TasGrid::type_level, TasGrid::rule_rleja);
     reference_grid = grid;
-    TasGrid::constructSurrogate<true>(model_aniso, 200, 3, 1, grid, TasGrid::type_iptotal, 0); // parallel
+    TasGrid::constructSurrogate<TasGrid::mode_parallel>(model_aniso, 200, 3, 1, grid, TasGrid::type_iptotal, 0); // parallel
     simpleSequentialConstruction(model_aniso, 200, 2, reference_grid, TasGrid::type_iptotal, 0);
     compareGrids(1.E-9, grid, reference_grid, true);
     if (verbose) cout << std::setw(40) << "parallel anisotropic rleja" << std::setw(10) << "Pass" << endl;
@@ -193,7 +193,7 @@ bool testConstructSurrogate(bool verbose){
     // nevertheless the grid accuracy should match
     grid = TasGrid::makeGlobalGrid(2, 1, 3, TasGrid::type_level, TasGrid::rule_clenshawcurtis);
     reference_grid = grid;
-    TasGrid::constructSurrogate<true>(model_aniso, 200, 3, 1, grid, TasGrid::type_iptotal, 0); // parallel
+    TasGrid::constructSurrogate<TasGrid::mode_parallel>(model_aniso, 200, 3, 1, grid, TasGrid::type_iptotal, 0); // parallel
     simpleSequentialConstruction(model_aniso, 200, 2, reference_grid, TasGrid::type_iptotal, 0);
     compareGrids(1.E-9, grid, reference_grid, false);
     if (verbose) cout << std::setw(40) << "parallel anisotropic global" << std::setw(10) << "Pass" << endl;
@@ -212,7 +212,7 @@ bool testConstructSurrogate(bool verbose){
     reference_grid.loadNeededPoints(vals);
 
     grid = TasGrid::makeSequenceGrid(2, 1, 1, TasGrid::type_level, TasGrid::rule_leja);
-    TasGrid::constructSurrogate<true>(model_aniso, reference_grid.getNumLoaded(), 4, 1, grid, TasGrid::type_iptotal, aweights); // parallel
+    TasGrid::constructSurrogate<TasGrid::mode_parallel>(model_aniso, reference_grid.getNumLoaded(), 4, 1, grid, TasGrid::type_iptotal, aweights); // parallel
     compareGrids(1.E-9, grid, reference_grid, true);
     if (verbose) cout << std::setw(40) << "parallel weighted sequence" << std::setw(10) << "Pass" << endl;
 

--- a/Addons/testMPI.cpp
+++ b/Addons/testMPI.cpp
@@ -40,9 +40,6 @@ inline int fail(){
 
 int main(int argc, char ** argv){
 
-    constexpr bool binary = true;
-    constexpr bool ascii = false;
-
     MPI_Init(&argc, &argv);
 
     int me;
@@ -50,37 +47,37 @@ int main(int argc, char ** argv){
     if (me == 0) cout << "\n";
 
     // --------------- Send/Recv <ascii> ----------------- //
-    if (!testSendReceive<ascii>()) return fail();
+    if (!testSendReceive<TasGrid::mode_ascii>()) return fail();
     MPI_Barrier(MPI_COMM_WORLD);
     if (me == 0)
         cout << "    MPI Send/Recv     <ascii>    Pass\n";
 
     // --------------- Send/Recv <binary> ----------------- //
-    if (!testSendReceive<binary>()) return fail();
+    if (!testSendReceive<TasGrid::mode_binary>()) return fail();
     MPI_Barrier(MPI_COMM_WORLD);
     if (me == 0)
         cout << "    MPI Send/Recv    <binary>    Pass\n";
 
     // ----------------- Bcast <ascii> ------------------ //
-    if (!testBcast<ascii>()) return fail();
+    if (!testBcast<TasGrid::mode_ascii>()) return fail();
     MPI_Barrier(MPI_COMM_WORLD);
     if (me == 0)
         cout << "        MPI Bcast     <ascii>    Pass\n";
 
     // ----------------- Bcast <binary> ----------------- //
-    if (!testBcast<binary>()) return fail();
+    if (!testBcast<TasGrid::mode_binary>()) return fail();
     MPI_Barrier(MPI_COMM_WORLD);
     if (me == 0)
         cout << "        MPI Bcast    <binary>    Pass\n";
 
     // ----------------- Scatter <ascii> --------------- //
-    if (!testScatterOutputs<ascii>()) return fail();
+    if (!testScatterOutputs<TasGrid::mode_ascii>()) return fail();
     MPI_Barrier(MPI_COMM_WORLD);
     if (me == 0)
         cout << "      MPI Scatter     <ascii>    Pass\n";
 
     // ----------------- Scatter <binary> --------------- //
-    if (!testScatterOutputs<binary>()) return fail();
+    if (!testScatterOutputs<TasGrid::mode_binary>()) return fail();
     MPI_Barrier(MPI_COMM_WORLD);
     if (me == 0)
         cout << "      MPI Scatter    <binary>    Pass\n";

--- a/Addons/tsgCandidateManager.hpp
+++ b/Addons/tsgCandidateManager.hpp
@@ -238,6 +238,21 @@ public:
     //! \brief Default destructor.
     ~CompleteStorage(){}
 
+    //! \brief Write the stored samples to a stream
+    void write(std::ostream &os) const{
+        IO::writeNumbers<mode_binary, IO::pad_auto>(os, points.size(), values.size());
+        IO::writeVector<mode_binary, IO::pad_auto>(points, os);
+        IO::writeVector<mode_binary, IO::pad_auto>(values, os);
+    }
+
+    //! \brief Read the stored samples from the stream
+    void read(std::istream &is){
+        points.resize(IO::readNumber<mode_binary, size_t>(is));
+        values.resize(IO::readNumber<mode_binary, size_t>(is));
+        IO::readVector<mode_binary>(is, points);
+        IO::readVector<mode_binary>(is, values);
+    }
+
     //! \brief Add a point to the stored list.
     void add(std::vector<double> const &x, std::vector<double> const &y){
         points.insert(points.end(), x.begin(), x.end());

--- a/Addons/tsgConstructSurrogate.hpp
+++ b/Addons/tsgConstructSurrogate.hpp
@@ -47,6 +47,19 @@
 namespace TasGrid{
 
 /*!
+ * \ingroup TasmanianAddonsConstruct
+ * \brief Allows for expressive calls to TasGrid::constructSurrogate().
+ */
+constexpr bool mode_parallel = true;
+
+/*!
+ * \ingroup TasmanianAddonsConstruct
+ * \brief Allows for expressive calls to TasGrid::constructSurrogate().
+ */
+constexpr bool mode_sequential = false;
+
+
+/*!
  * \internal
  * \ingroup TasmanianAddonsConstruct
  * \brief Construction algorithm using generic candidates procedure.
@@ -112,7 +125,7 @@ void constructCommon(std::function<void(std::vector<double> const &x, std::vecto
 
     refresh_candidates();
 
-    if (parallel_construction){
+    if (parallel_construction == mode_parallel){
         // allocate space for all x and y pairs, will be filled by workers and processed by main
         std::vector<std::vector<double>> x(num_parallel_jobs), y(num_parallel_jobs, std::vector<double>(grid.getNumOutputs()));
 
@@ -226,6 +239,9 @@ void constructCommon(std::function<void(std::vector<double> const &x, std::vecto
  * up to the specified maximum number.
  *
  * \tparam parallel_construction defines the use of parallel or sequential mode.
+ *      The variable is of type \b bool but the constexpr constants
+ *      TasGrid::mode_parallel and TasGrid::mode_sequential can be used to for more
+ *      expressive calls.
  *
  * \param model defines the input-output relation to be approximated by the surrogate.
  *      In each call, \b x will have size equal to an even multiple of the dimension of
@@ -309,7 +325,7 @@ void constructCommon(std::function<void(std::vector<double> const &x, std::vecto
  * \endcode
  *
  */
-template<bool parallel_construction = true>
+template<bool parallel_construction = TasGrid::mode_parallel>
 void constructSurrogate(std::function<void(std::vector<double> const &x, std::vector<double> &y, size_t thread_id)> model,
                         size_t max_num_samples, size_t num_parallel_jobs, size_t max_samples_per_job,
                         TasmanianSparseGrid &grid,
@@ -336,7 +352,7 @@ void constructSurrogate(std::function<void(std::vector<double> const &x, std::ve
  * thus sampling will continue until the budget is exhausted
  * or the level limits are reached (which will produce a full tensor grid).
  */
-template<bool parallel_construction = true>
+template<bool parallel_construction = TasGrid::mode_parallel>
 void constructSurrogate(std::function<void(std::vector<double> const &x, std::vector<double> &y, size_t thread_id)> model,
                         size_t max_num_samples, size_t num_parallel_jobs, size_t max_samples_per_job,
                         TasmanianSparseGrid &grid,
@@ -362,7 +378,7 @@ void constructSurrogate(std::function<void(std::vector<double> const &x, std::ve
  * thus sampling will continue until the budget is exhausted
  * or the level limits are reached (which will produce a full tensor grid).
  */
-template<bool parallel_construction = true>
+template<bool parallel_construction = TasGrid::mode_parallel>
 void constructSurrogate(std::function<void(std::vector<double> const &x, std::vector<double> &y, size_t thread_id)> model,
                         size_t max_num_samples, size_t num_parallel_jobs, size_t max_samples_per_job,
                         TasmanianSparseGrid &grid,

--- a/InterfacePython/TasmanianSG.in.py
+++ b/InterfacePython/TasmanianSG.in.py
@@ -339,7 +339,7 @@ class TasmanianSparseGrid:
             sFilename = bytes(sFilename, encoding='utf8')
         return (self.pLibTSG.tsgRead(self.pGrid, c_char_p(sFilename)) != 0)
 
-    def write(self, sFilename, bUseBinaryFormat = False):
+    def write(self, sFilename, bUseBinaryFormat = True):
         '''
         writes the grid to a file
 

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -78,11 +78,11 @@ public:
     static const char* getCmakeCxxFlags();
     static bool isOpenMPEnabled();
 
-    void write(const char *filename, bool binary = false) const;
+    void write(const char *filename, bool binary = mode_binary) const;
     void read(const char *filename); // auto-check if format is binary or ascii
 
-    void write(std::ostream &ofs, bool binary = false) const;
-    void read(std::istream &ifs, bool binary = false);
+    void write(std::ostream &ofs, bool binary = mode_binary) const;
+    void read(std::istream &ifs, bool binary = mode_binary);
 
     void makeGlobalGrid(int dimensions, int outputs, int depth, TypeDepth type, TypeOneDRule rule,
                         std::vector<int> const &anisotropic_weights, double alpha = 0.0, double beta = 0.0,

--- a/SparseGrids/tasgridWrapper.cpp
+++ b/SparseGrids/tasgridWrapper.cpp
@@ -374,7 +374,7 @@ bool TasgridWrapper::updateGrid(){
     }
     return true;
 }
-void TasgridWrapper::writeGrid() const{ grid.write(gridfilename.c_str(), !useASCII); }
+void TasgridWrapper::writeGrid() const{ grid.write(gridfilename.c_str(), (useASCII) ? mode_ascii : mode_binary); }
 bool TasgridWrapper::readGrid(){
     try{
         grid.read(gridfilename.c_str());

--- a/SparseGrids/tsgCoreOneDimensional.cpp
+++ b/SparseGrids/tsgCoreOneDimensional.cpp
@@ -32,6 +32,7 @@
 #define __TSG_CORE_ONE_DIMENSIONAL_CPP
 
 #include "tsgCoreOneDimensional.hpp"
+#include "tsgIOHelpers.hpp"
 
 namespace TasGrid{
 
@@ -40,8 +41,8 @@ CustomTabulated::~CustomTabulated(){}
 
 void CustomTabulated::reset(){ num_levels = 0; }
 
-template<bool useAscii> void CustomTabulated::write(std::ostream &ofs) const{
-    if (useAscii){ // format is messy here
+template<bool iomode> void CustomTabulated::write(std::ostream &ofs) const{
+    if (iomode == mode_ascii){ // format is messy here
         ofs << "description: " << description.c_str() << std::endl;
         ofs << "levels: " << num_levels << std::endl;
         for(int i=0; i<num_levels; i++){
@@ -66,9 +67,9 @@ template<bool useAscii> void CustomTabulated::write(std::ostream &ofs) const{
     }
 }
 
-template<bool useAscii> void CustomTabulated::read(std::istream &is){
+template<bool iomode> void CustomTabulated::read(std::istream &is){
     reset();
-    if (useAscii){ // messy format chosen for better human readability, hard to template and generalize
+    if (iomode == mode_ascii){ // messy format chosen for better human readability, hard to template and generalize
         std::string T;
         char dummy;
         is >> T;
@@ -119,10 +120,10 @@ template<bool useAscii> void CustomTabulated::read(std::istream &is){
     }
 }
 
-template void CustomTabulated::write<true>(std::ostream &) const;
-template void CustomTabulated::write<false>(std::ostream &) const;
-template void CustomTabulated::read<true>(std::istream &is);
-template void CustomTabulated::read<false>(std::istream &is);
+template void CustomTabulated::write<mode_ascii>(std::ostream &) const;
+template void CustomTabulated::write<mode_binary>(std::ostream &) const;
+template void CustomTabulated::read<mode_ascii>(std::istream &is);
+template void CustomTabulated::read<mode_binary>(std::istream &is);
 
 void CustomTabulated::read(const char* filename){
     std::ifstream ifs; ifs.open(filename);
@@ -131,7 +132,7 @@ void CustomTabulated::read(const char* filename){
         message += filename;
         throw std::invalid_argument(message);
     }
-    read<true>(ifs);
+    read<mode_ascii>(ifs);
     ifs.close();
 }
 

--- a/SparseGrids/tsgDConstructGridGlobal.cpp
+++ b/SparseGrids/tsgDConstructGridGlobal.cpp
@@ -39,38 +39,38 @@ DynamicConstructorDataGlobal::DynamicConstructorDataGlobal(size_t cnum_dimension
     : num_dimensions(cnum_dimensions), num_outputs(cnum_outputs){}
 DynamicConstructorDataGlobal::~DynamicConstructorDataGlobal(){}
 
-template<bool useAscii> void DynamicConstructorDataGlobal::write(std::ostream &os) const{
-    if (useAscii){ os << std::scientific; os.precision(17); }
+template<bool use_ascii> void DynamicConstructorDataGlobal::write(std::ostream &os) const{
+    if (use_ascii == mode_ascii){ os << std::scientific; os.precision(17); }
     auto tensor_refs =  makeReverseReferenceVector(tensors);
 
-    IO::writeNumbers<useAscii, IO::pad_line, int>(os, (int) tensor_refs.size());
+    IO::writeNumbers<use_ascii, IO::pad_line, int>(os, (int) tensor_refs.size());
     for(auto d : tensor_refs){
-        IO::writeNumbers<useAscii, IO::pad_rspace, double>(os, d->weight);
-        IO::writeVector<useAscii, IO::pad_line>(d->tensor, os);
+        IO::writeNumbers<use_ascii, IO::pad_rspace, double>(os, d->weight);
+        IO::writeVector<use_ascii, IO::pad_line>(d->tensor, os);
     }
-    writeNodeDataList<useAscii>(data, os);
+    writeNodeDataList<use_ascii>(data, os);
 }
 
-template<bool useAscii> void DynamicConstructorDataGlobal::read(std::istream &is){
-    int num_entries = IO::readNumber<useAscii, int>(is);
+template<bool use_ascii> void DynamicConstructorDataGlobal::read(std::istream &is){
+    int num_entries = IO::readNumber<use_ascii, int>(is);
 
     for(int i=0; i<num_entries; i++){
         tensors.emplace_front(TensorData{
                               std::vector<int>(num_dimensions), // tensor
                               MultiIndexSet(), // points, will be set later
                               std::vector<bool>(), // loaded, will be set later
-                              IO::readNumber<useAscii, double>(is) // weight
+                              IO::readNumber<use_ascii, double>(is) // weight
                               });
-        IO::readVector<useAscii>(is, tensors.front().tensor);
+        IO::readVector<use_ascii>(is, tensors.front().tensor);
     }
 
-    data = readNodeDataList<useAscii>(num_dimensions, num_outputs, is);
+    data = readNodeDataList<use_ascii>(num_dimensions, num_outputs, is);
 }
 
-template void DynamicConstructorDataGlobal::write<true>(std::ostream &) const; // instantiate for faster build
-template void DynamicConstructorDataGlobal::write<false>(std::ostream &) const;
-template void DynamicConstructorDataGlobal::read<true>(std::istream &);
-template void DynamicConstructorDataGlobal::read<false>(std::istream &);
+template void DynamicConstructorDataGlobal::write<mode_ascii>(std::ostream &) const; // instantiate for faster build
+template void DynamicConstructorDataGlobal::write<mode_binary>(std::ostream &) const;
+template void DynamicConstructorDataGlobal::read<mode_ascii>(std::istream &);
+template void DynamicConstructorDataGlobal::read<mode_binary>(std::istream &);
 
 int DynamicConstructorDataGlobal::getMaxTensor() const{
     int max_tensor = 0;

--- a/SparseGrids/tsgDConstructGridGlobal.hpp
+++ b/SparseGrids/tsgDConstructGridGlobal.hpp
@@ -129,16 +129,16 @@ std::vector<const T*> makeReverseReferenceVector(const std::forward_list<T> &lis
  * \brief Writes a NodeData std::forward_list to a file using either binary or ascii format.
  * \endinternal
  */
-template<bool useAscii>
+template<bool use_ascii>
 void writeNodeDataList(const std::forward_list<NodeData> &data, std::ostream &os){
-    if (useAscii){ os << std::scientific; os.precision(17); }
+    if (use_ascii == mode_ascii){ os << std::scientific; os.precision(17); }
 
     auto data_refs = makeReverseReferenceVector(data);
 
-    IO::writeNumbers<useAscii, IO::pad_line>(os, (int) data_refs.size());
+    IO::writeNumbers<use_ascii, IO::pad_line>(os, (int) data_refs.size());
     for(auto d : data_refs){
-        IO::writeVector<useAscii, IO::pad_rspace>(d->point, os);
-        IO::writeVector<useAscii, IO::pad_line>(d->value, os);
+        IO::writeVector<use_ascii, IO::pad_rspace>(d->point, os);
+        IO::writeVector<use_ascii, IO::pad_line>(d->value, os);
     }
 }
 
@@ -148,18 +148,18 @@ void writeNodeDataList(const std::forward_list<NodeData> &data, std::ostream &os
  * \brief Reads a NodeData std::forward_list from a file using either binary or ascii format.
  * \endinternal
  */
-template<bool useAscii>
+template<bool use_ascii>
 std::forward_list<NodeData> readNodeDataList(size_t num_dimensions, size_t num_outputs, std::istream &is){
     std::forward_list<NodeData> data;
-    int num_nodes = IO::readNumber<useAscii, int>(is);
+    int num_nodes = IO::readNumber<use_ascii, int>(is);
 
     for(int i=0; i<num_nodes; i++){
         data.emplace_front(NodeData{
                             std::vector<int>(num_dimensions), // point
                             std::vector<double>(num_outputs)  // value
                            });
-        IO::readVector<useAscii>(is, data.front().point);
-        IO::readVector<useAscii>(is, data.front().value);
+        IO::readVector<use_ascii>(is, data.front().point);
+        IO::readVector<use_ascii>(is, data.front().value);
     }
 
     return data;
@@ -186,9 +186,9 @@ public:
     ~DynamicConstructorDataGlobal();
 
     //! \brief Write the data to a stream using ascii or binary format.
-    template<bool useAscii> void write(std::ostream &os) const;
+    template<bool use_ascii> void write(std::ostream &os) const;
     //! \brief Read the data from a stream using ascii or binary format.
-    template<bool useAscii> void read(std::istream &is);
+    template<bool use_ascii> void read(std::istream &is);
 
     //! \brief Restrict data between \b ibegin and \b iend entries.
     void restrictData(int ibegin, int iend){ for(auto &d : data) d.value = std::vector<double>(d.value.begin() + ibegin, d.value.begin() + iend); }
@@ -241,10 +241,10 @@ struct SimpleConstructData{
     //! \brief Keeps track of the initial point set, so those can be computed first.
     MultiIndexSet initial_points;
     //! \brief Save to a file in either ascii or binary format.
-    template<bool useAscii>
+    template<bool use_ascii>
     void write(std::ostream &os) const{
-        initial_points.write<useAscii>(os);
-        writeNodeDataList<useAscii>(data, os);
+        initial_points.write<use_ascii>(os);
+        writeNodeDataList<use_ascii>(data, os);
     }
     //! \brief Restrict data between \b ibegin and \b iend entries.
     void restrictData(int ibegin, int iend){ for(auto &d : data) d.value = std::vector<double>(d.value.begin() + ibegin, d.value.begin() + iend); }
@@ -278,11 +278,11 @@ struct SimpleConstructData{
  *
  * \endinternal
  */
-template<bool useAscii>
+template<bool use_ascii>
 std::unique_ptr<SimpleConstructData> readSimpleConstructionData(size_t num_dimensions, size_t num_outputs, std::istream &is){
     std::unique_ptr<SimpleConstructData> dynamic_values = std::unique_ptr<SimpleConstructData>(new SimpleConstructData);
-    dynamic_values->initial_points.read<useAscii>(is);
-    dynamic_values->data = readNodeDataList<useAscii>(num_dimensions, num_outputs, is);
+    dynamic_values->initial_points.read<use_ascii>(is);
+    dynamic_values->data = readNodeDataList<use_ascii>(num_dimensions, num_outputs, is);
     return dynamic_values;
 }
 

--- a/SparseGrids/tsgGridCore.hpp
+++ b/SparseGrids/tsgGridCore.hpp
@@ -69,6 +69,9 @@ public:
     int getNumPoints() const{ return ((points.empty()) ? needed.getNumIndexes() : points.getNumIndexes()); }
     const int* getPointIndexes() const{ return ((points.empty()) ? needed.getIndex(0) : points.getIndex(0)); }
 
+    virtual void write(std::ostream&, bool) const = 0;
+    virtual void read(std::istream&, bool) = 0;
+
     virtual void getLoadedPoints(double *x) const = 0;
     virtual void getNeededPoints(double *x) const = 0;
     virtual void getPoints(double *x) const = 0;
@@ -98,10 +101,8 @@ public:
     virtual void mergeRefinement() = 0;
 
     virtual void beginConstruction(){}
-    virtual void writeConstructionDataBinary(std::ostream&) const{}
-    virtual void writeConstructionData(std::ostream&) const{}
-    virtual void readConstructionDataBinary(std::istream&){}
-    virtual void readConstructionData(std::istream&){}
+    virtual void writeConstructionData(std::ostream&, bool) const{}
+    virtual void readConstructionData(std::istream&, bool){}
     virtual void loadConstructedPoint(const double[], const std::vector<double> &){}
     virtual void loadConstructedPoint(const double[], int, const double[]){}
     virtual void finishConstruction(){}

--- a/SparseGrids/tsgGridFourier.cpp
+++ b/SparseGrids/tsgGridFourier.cpp
@@ -39,66 +39,66 @@ namespace TasGrid{
 GridFourier::GridFourier() : max_levels(0){}
 GridFourier::~GridFourier(){}
 
-template<bool useAscii> void GridFourier::write(std::ostream &os) const{
-    if (useAscii){ os << std::scientific; os.precision(17); }
-    IO::writeNumbers<useAscii, IO::pad_line>(os, num_dimensions, num_outputs);
+template<bool iomode> void GridFourier::write(std::ostream &os) const{
+    if (iomode == mode_ascii){ os << std::scientific; os.precision(17); }
+    IO::writeNumbers<iomode, IO::pad_line>(os, num_dimensions, num_outputs);
 
-    tensors.write<useAscii>(os);
-    active_tensors.write<useAscii>(os);
+    tensors.write<iomode>(os);
+    active_tensors.write<iomode>(os);
     if (!active_w.empty())
-        IO::writeVector<useAscii, IO::pad_line>(active_w, os);
+        IO::writeVector<iomode, IO::pad_line>(active_w, os);
 
-    IO::writeFlag<useAscii, IO::pad_auto>(!points.empty(), os);
-    if (!points.empty()) points.write<useAscii>(os);
-    IO::writeFlag<useAscii, IO::pad_auto>(!needed.empty(), os);
-    if (!needed.empty()) needed.write<useAscii>(os);
+    IO::writeFlag<iomode, IO::pad_auto>(!points.empty(), os);
+    if (!points.empty()) points.write<iomode>(os);
+    IO::writeFlag<iomode, IO::pad_auto>(!needed.empty(), os);
+    if (!needed.empty()) needed.write<iomode>(os);
 
-    IO::writeVector<useAscii, IO::pad_line>(max_levels, os);
+    IO::writeVector<iomode, IO::pad_line>(max_levels, os);
 
     if (num_outputs > 0){
-        values.write<useAscii>(os);
-        IO::writeFlag<useAscii, IO::pad_auto>((fourier_coefs.getNumStrips() != 0), os);
-        if (fourier_coefs.getNumStrips() != 0) IO::writeVector<useAscii, IO::pad_line>(fourier_coefs.getVector(), os);
+        values.write<iomode>(os);
+        IO::writeFlag<iomode, IO::pad_auto>((fourier_coefs.getNumStrips() != 0), os);
+        if (fourier_coefs.getNumStrips() != 0) IO::writeVector<iomode, IO::pad_line>(fourier_coefs.getVector(), os);
     }
 
-    IO::writeFlag<useAscii, IO::pad_line>(!updated_tensors.empty(), os);
+    IO::writeFlag<iomode, IO::pad_line>(!updated_tensors.empty(), os);
     if (!updated_tensors.empty()){
-        updated_tensors.write<useAscii>(os);
-        updated_active_tensors.write<useAscii>(os);
-        IO::writeVector<useAscii, IO::pad_line>(updated_active_w, os);
+        updated_tensors.write<iomode>(os);
+        updated_active_tensors.write<iomode>(os);
+        IO::writeVector<iomode, IO::pad_line>(updated_active_w, os);
     }
 }
-template<bool useAscii> void GridFourier::read(std::istream &is){
+template<bool iomode> void GridFourier::read(std::istream &is){
     reset();
-    num_dimensions = IO::readNumber<useAscii, int>(is);
-    num_outputs = IO::readNumber<useAscii, int>(is);
+    num_dimensions = IO::readNumber<iomode, int>(is);
+    num_outputs = IO::readNumber<iomode, int>(is);
 
-    tensors.read<useAscii>(is);
-    active_tensors.read<useAscii>(is);
+    tensors.read<iomode>(is);
+    active_tensors.read<iomode>(is);
     active_w.resize((size_t) active_tensors.getNumIndexes());
-    IO::readVector<useAscii>(is, active_w);
+    IO::readVector<iomode>(is, active_w);
 
-    if (IO::readFlag<useAscii>(is)) points.read<useAscii>(is);
-    if (IO::readFlag<useAscii>(is)) needed.read<useAscii>(is);
+    if (IO::readFlag<iomode>(is)) points.read<iomode>(is);
+    if (IO::readFlag<iomode>(is)) needed.read<iomode>(is);
 
     max_levels.resize((size_t) num_dimensions);
-    IO::readVector<useAscii>(is, max_levels);
+    IO::readVector<iomode>(is, max_levels);
 
     if (num_outputs > 0){
-        values.read<useAscii>(is);
-        if (IO::readFlag<useAscii>(is))
-            fourier_coefs = IO::readData2D<useAscii, double>(is, num_outputs, 2 * points.getNumIndexes());
+        values.read<iomode>(is);
+        if (IO::readFlag<iomode>(is))
+            fourier_coefs = IO::readData2D<iomode, double>(is, num_outputs, 2 * points.getNumIndexes());
     }
 
     int oned_max_level;
-    if (IO::readFlag<useAscii>(is)){
-        updated_tensors.read<useAscii>(is);
+    if (IO::readFlag<iomode>(is)){
+        updated_tensors.read<iomode>(is);
         oned_max_level = updated_tensors.getMaxIndex();
 
-        updated_active_tensors.read<useAscii>(is);
+        updated_active_tensors.read<iomode>(is);
 
         updated_active_w.resize((size_t) updated_active_tensors.getNumIndexes());
-        IO::readVector<useAscii>(is, updated_active_w);
+        IO::readVector<iomode>(is, updated_active_w);
     }else{
         oned_max_level = *std::max_element(max_levels.begin(), max_levels.end());
     }
@@ -108,10 +108,10 @@ template<bool useAscii> void GridFourier::read(std::istream &is){
     max_power = MultiIndexManipulations::getMaxIndexes(((points.empty()) ? needed : points));
 }
 
-template void GridFourier::write<true>(std::ostream &) const;
-template void GridFourier::write<false>(std::ostream &) const;
-template void GridFourier::read<true>(std::istream &);
-template void GridFourier::read<false>(std::istream &);
+template void GridFourier::write<mode_ascii>(std::ostream &) const;
+template void GridFourier::write<mode_binary>(std::ostream &) const;
+template void GridFourier::read<mode_ascii>(std::istream &);
+template void GridFourier::read<mode_binary>(std::istream &);
 
 void GridFourier::reset(){
     clearAccelerationData();

--- a/SparseGrids/tsgGridFourier.hpp
+++ b/SparseGrids/tsgGridFourier.hpp
@@ -42,8 +42,11 @@ public:
 
     bool isFourier() const{ return true; }
 
-    template<bool useAscii> void write(std::ostream &os) const;
-    template<bool useAscii> void read(std::istream &is);
+    void write(std::ostream &os, bool iomode) const{ if (iomode == mode_ascii) write<mode_ascii>(os); else write<mode_binary>(os); }
+    void read(std::istream &is, bool iomode){ if (iomode == mode_ascii) read<mode_ascii>(is); else read<mode_binary>(is); }
+
+    template<bool iomode> void write(std::ostream &os) const;
+    template<bool iomode> void read(std::istream &is);
 
     void makeGrid(int cnum_dimensions, int cnum_outputs, int depth, TypeDepth type, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits);
     void copyGrid(const GridFourier *fourier, int ibegin, int iend);

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -39,66 +39,66 @@ namespace TasGrid{
 GridGlobal::GridGlobal() : alpha(0.0), beta(0.0){}
 GridGlobal::~GridGlobal(){}
 
-template<bool useAscii> void GridGlobal::write(std::ostream &os) const{
-    if (useAscii){ os << std::scientific; os.precision(17); }
-    IO::writeNumbers<useAscii, IO::pad_rspace>(os, num_dimensions, num_outputs);
-    IO::writeNumbers<useAscii, IO::pad_line>(os, alpha, beta);
-    IO::writeRule<useAscii>(rule, os);
+template<bool iomode> void GridGlobal::write(std::ostream &os) const{
+    if (iomode == mode_ascii){ os << std::scientific; os.precision(17); }
+    IO::writeNumbers<iomode, IO::pad_rspace>(os, num_dimensions, num_outputs);
+    IO::writeNumbers<iomode, IO::pad_line>(os, alpha, beta);
+    IO::writeRule<iomode>(rule, os);
     if (rule == rule_customtabulated)
-        custom.write<useAscii>(os);
+        custom.write<iomode>(os);
 
-    tensors.write<useAscii>(os);
-    active_tensors.write<useAscii>(os);
+    tensors.write<iomode>(os);
+    active_tensors.write<iomode>(os);
     if (!active_w.empty())
-        IO::writeVector<useAscii, IO::pad_line>(active_w, os);
+        IO::writeVector<iomode, IO::pad_line>(active_w, os);
 
-    IO::writeFlag<useAscii, IO::pad_auto>(!points.empty(), os);
-    if (!points.empty()) points.write<useAscii>(os);
-    IO::writeFlag<useAscii, IO::pad_auto>(!needed.empty(), os);
-    if (!needed.empty()) needed.write<useAscii>(os);
+    IO::writeFlag<iomode, IO::pad_auto>(!points.empty(), os);
+    if (!points.empty()) points.write<iomode>(os);
+    IO::writeFlag<iomode, IO::pad_auto>(!needed.empty(), os);
+    if (!needed.empty()) needed.write<iomode>(os);
 
-    IO::writeVector<useAscii, IO::pad_line>(max_levels, os);
+    IO::writeVector<iomode, IO::pad_line>(max_levels, os);
 
-    if (num_outputs > 0) values.write<useAscii>(os);
+    if (num_outputs > 0) values.write<iomode>(os);
 
-    IO::writeFlag<useAscii, IO::pad_line>(!updated_tensors.empty(), os);
+    IO::writeFlag<iomode, IO::pad_line>(!updated_tensors.empty(), os);
     if (!updated_tensors.empty()){
-        updated_tensors.write<useAscii>(os);
-        updated_active_tensors.write<useAscii>(os);
-        IO::writeVector<useAscii, IO::pad_line>(updated_active_w, os);
+        updated_tensors.write<iomode>(os);
+        updated_active_tensors.write<iomode>(os);
+        IO::writeVector<iomode, IO::pad_line>(updated_active_w, os);
     }
 }
 
-template<bool useAscii> void GridGlobal::read(std::istream &is){
+template<bool iomode> void GridGlobal::read(std::istream &is){
     reset(true); // true deletes any custom rule
-    num_dimensions = IO::readNumber<useAscii, int>(is);
-    num_outputs = IO::readNumber<useAscii, int>(is);
-    alpha = IO::readNumber<useAscii, double>(is);
-    beta = IO::readNumber<useAscii, double>(is);
-    rule = IO::readRule<useAscii>(is);
-    if (rule == rule_customtabulated) custom.read<useAscii>(is);
-    tensors.read<useAscii>(is);
-    active_tensors.read<useAscii>(is);
+    num_dimensions = IO::readNumber<iomode, int>(is);
+    num_outputs = IO::readNumber<iomode, int>(is);
+    alpha = IO::readNumber<iomode, double>(is);
+    beta = IO::readNumber<iomode, double>(is);
+    rule = IO::readRule<iomode>(is);
+    if (rule == rule_customtabulated) custom.read<iomode>(is);
+    tensors.read<iomode>(is);
+    active_tensors.read<iomode>(is);
     active_w.resize((size_t) active_tensors.getNumIndexes());
-    IO::readVector<useAscii>(is, active_w);
+    IO::readVector<iomode>(is, active_w);
 
-    if (IO::readFlag<useAscii>(is)) points.read<useAscii>(is);
-    if (IO::readFlag<useAscii>(is)) needed.read<useAscii>(is);
+    if (IO::readFlag<iomode>(is)) points.read<iomode>(is);
+    if (IO::readFlag<iomode>(is)) needed.read<iomode>(is);
 
     max_levels.resize((size_t) num_dimensions);
-    IO::readVector<useAscii>(is, max_levels);
+    IO::readVector<iomode>(is, max_levels);
 
-    if (num_outputs > 0) values.read<useAscii>(is);
+    if (num_outputs > 0) values.read<iomode>(is);
 
     int oned_max_level;
-    if (IO::readFlag<useAscii>(is)){
-        updated_tensors.read<useAscii>(is);
+    if (IO::readFlag<iomode>(is)){
+        updated_tensors.read<iomode>(is);
         oned_max_level = updated_tensors.getMaxIndex();
 
-        updated_active_tensors.read<useAscii>(is);
+        updated_active_tensors.read<iomode>(is);
 
         updated_active_w.resize((size_t) updated_active_tensors.getNumIndexes());
-        IO::readVector<useAscii>(is, updated_active_w);
+        IO::readVector<iomode>(is, updated_active_w);
     }else{
         oned_max_level = *std::max_element(max_levels.begin(), max_levels.end());
     }
@@ -108,10 +108,10 @@ template<bool useAscii> void GridGlobal::read(std::istream &is){
     recomputeTensorRefs((points.empty()) ? needed : points);
 }
 
-template void GridGlobal::write<true>(std::ostream &) const;
-template void GridGlobal::write<false>(std::ostream &) const;
-template void GridGlobal::read<true>(std::istream &);
-template void GridGlobal::read<false>(std::istream &);
+template void GridGlobal::write<mode_ascii>(std::ostream &) const;
+template void GridGlobal::write<mode_binary>(std::ostream &) const;
+template void GridGlobal::read<mode_ascii>(std::istream &);
+template void GridGlobal::read<mode_binary>(std::istream &);
 
 void GridGlobal::reset(bool includeCustom){
     clearAccelerationData();
@@ -410,23 +410,15 @@ void GridGlobal::beginConstruction(){
         values.resize(num_outputs, 0);
     }
 }
-void GridGlobal::writeConstructionDataBinary(std::ostream &os) const{
-    dynamic_values->write<false>(os);
+void GridGlobal::writeConstructionData(std::ostream &os, bool iomode) const{
+    if (iomode == mode_ascii) dynamic_values->write<mode_ascii>(os); else dynamic_values->write<mode_binary>(os);
 }
-void GridGlobal::writeConstructionData(std::ostream &os) const{
-    dynamic_values->write<true>(os);
-}
-void GridGlobal::readConstructionDataBinary(std::istream &is){
+void GridGlobal::readConstructionData(std::istream &is, bool iomode){
     dynamic_values = std::unique_ptr<DynamicConstructorDataGlobal>(new DynamicConstructorDataGlobal((size_t) num_dimensions, (size_t) num_outputs));
-    dynamic_values->read<false>(is);
-    int max_level = dynamic_values->getMaxTensor();
-    if (max_level + 1 > wrapper.getNumLevels())
-        wrapper.load(custom, max_level, rule, alpha, beta);
-    dynamic_values->reloadPoints([&](int l)->int{ return wrapper.getNumPoints(l); });
-}
-void GridGlobal::readConstructionData(std::istream &is){
-    dynamic_values = std::unique_ptr<DynamicConstructorDataGlobal>(new DynamicConstructorDataGlobal((size_t) num_dimensions, (size_t) num_outputs));
-    dynamic_values->read<true>(is);
+    if (iomode == mode_ascii)
+        dynamic_values->read<mode_ascii>(is);
+    else
+        dynamic_values->read<mode_binary>(is);
     int max_level = dynamic_values->getMaxTensor();
     if (max_level + 1 > wrapper.getNumLevels())
         wrapper.load(custom, max_level, rule, alpha, beta);

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -43,8 +43,11 @@ public:
 
     bool isGlobal() const{ return true; }
 
-    template<bool useAscii> void write(std::ostream &os) const;
-    template<bool useAscii> void read(std::istream &is);
+    void write(std::ostream &os, bool iomode) const{ if (iomode == mode_ascii) write<mode_ascii>(os); else write<mode_binary>(os); }
+    void read(std::istream &is, bool iomode){ if (iomode == mode_ascii) read<mode_ascii>(is); else read<mode_binary>(is); }
+
+    template<bool iomode> void write(std::ostream &os) const;
+    template<bool iomode> void read(std::istream &is);
 
     void makeGrid(int cnum_dimensions, int cnum_outputs, int depth, TypeDepth type, TypeOneDRule crule, const std::vector<int> &anisotropic_weights, double calpha, double cbeta, const char* custom_filename, const std::vector<int> &level_limits);
     void copyGrid(const GridGlobal *global, int ibegin, int iend);
@@ -93,10 +96,8 @@ public:
     void mergeRefinement();
 
     void beginConstruction();
-    void writeConstructionDataBinary(std::ostream &os) const;
-    void writeConstructionData(std::ostream &os) const;
-    void readConstructionDataBinary(std::istream &is);
-    void readConstructionData(std::istream &is);
+    void writeConstructionData(std::ostream &os, bool) const;
+    void readConstructionData(std::istream &is, bool);
     std::vector<double> getCandidateConstructionPoints(TypeDepth type, const std::vector<int> &weights, const std::vector<int> &level_limits);
     std::vector<double> getCandidateConstructionPoints(TypeDepth type, int output, const std::vector<int> &level_limits);
     std::vector<double> getCandidateConstructionPoints(std::function<double(const int *)> getTensorWeight, const std::vector<int> &level_limits);

--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -67,80 +67,80 @@ void GridLocalPolynomial::makeRule(TypeOneDRule crule){
     rule->setMaxOrder(order);
 }
 
-template<bool useAscii> void GridLocalPolynomial::write(std::ostream &os) const{
-    if (useAscii){ os << std::scientific; os.precision(17); }
-    IO::writeNumbers<useAscii, IO::pad_line>(os, num_dimensions, num_outputs, order, top_level);
-    IO::writeRule<useAscii>(rule->getType(), os);
-    IO::writeFlag<useAscii, IO::pad_auto>(!points.empty(), os);
-    if (!points.empty()) points.write<useAscii>(os);
-    if (useAscii){ // backwards compatible: surpluses and needed, or needed and surpluses
-        IO::writeFlag<useAscii, IO::pad_auto>((surpluses.getNumStrips() != 0), os);
-        if (surpluses.getNumStrips() != 0) IO::writeVector<useAscii, IO::pad_line>(surpluses.getVector(), os);
-        IO::writeFlag<useAscii, IO::pad_auto>(!needed.empty(), os);
-        if (!needed.empty()) needed.write<useAscii>(os);
+template<bool iomode> void GridLocalPolynomial::write(std::ostream &os) const{
+    if (iomode == mode_ascii){ os << std::scientific; os.precision(17); }
+    IO::writeNumbers<iomode, IO::pad_line>(os, num_dimensions, num_outputs, order, top_level);
+    IO::writeRule<iomode>(rule->getType(), os);
+    IO::writeFlag<iomode, IO::pad_auto>(!points.empty(), os);
+    if (!points.empty()) points.write<iomode>(os);
+    if (iomode == mode_ascii){ // backwards compatible: surpluses and needed, or needed and surpluses
+        IO::writeFlag<iomode, IO::pad_auto>((surpluses.getNumStrips() != 0), os);
+        if (surpluses.getNumStrips() != 0) IO::writeVector<iomode, IO::pad_line>(surpluses.getVector(), os);
+        IO::writeFlag<iomode, IO::pad_auto>(!needed.empty(), os);
+        if (!needed.empty()) needed.write<iomode>(os);
     }else{
-        IO::writeFlag<useAscii, IO::pad_auto>(!needed.empty(), os);
-        if (!needed.empty()) needed.write<useAscii>(os);
-        IO::writeFlag<useAscii, IO::pad_auto>((surpluses.getNumStrips() != 0), os);
-        if (surpluses.getNumStrips() != 0) IO::writeVector<useAscii, IO::pad_line>(surpluses.getVector(), os);
+        IO::writeFlag<iomode, IO::pad_auto>(!needed.empty(), os);
+        if (!needed.empty()) needed.write<iomode>(os);
+        IO::writeFlag<iomode, IO::pad_auto>((surpluses.getNumStrips() != 0), os);
+        if (surpluses.getNumStrips() != 0) IO::writeVector<iomode, IO::pad_line>(surpluses.getVector(), os);
     }
-    IO::writeFlag<useAscii, IO::pad_auto>((parents.getNumStrips() != 0), os);
-    if (parents.getNumStrips() != 0) IO::writeVector<useAscii, IO::pad_line>(parents.getVector(), os);
+    IO::writeFlag<iomode, IO::pad_auto>((parents.getNumStrips() != 0), os);
+    if (parents.getNumStrips() != 0) IO::writeVector<iomode, IO::pad_line>(parents.getVector(), os);
 
-    IO::writeNumbers<useAscii, IO::pad_rspace>(os, (int) roots.size());
+    IO::writeNumbers<iomode, IO::pad_rspace>(os, (int) roots.size());
     if (roots.size() > 0){ // the tree is empty, can happend when using dynamic construction
-        IO::writeVector<useAscii, IO::pad_line>(roots, os);
-        IO::writeVector<useAscii, IO::pad_line>(pntr, os);
-        IO::writeVector<useAscii, IO::pad_line>(indx, os);
+        IO::writeVector<iomode, IO::pad_line>(roots, os);
+        IO::writeVector<iomode, IO::pad_line>(pntr, os);
+        IO::writeVector<iomode, IO::pad_line>(indx, os);
     }
 
-    if (num_outputs > 0) values.write<useAscii>(os);
+    if (num_outputs > 0) values.write<iomode>(os);
 }
 
-template<bool useAscii> void GridLocalPolynomial::read(std::istream &is){
+template<bool iomode> void GridLocalPolynomial::read(std::istream &is){
     reset();
-    num_dimensions = IO::readNumber<useAscii, int>(is);
-    num_outputs = IO::readNumber<useAscii, int>(is);
-    order = IO::readNumber<useAscii, int>(is);
-    top_level = IO::readNumber<useAscii, int>(is);
-    TypeOneDRule crule = IO::readRule<useAscii>(is);
+    num_dimensions = IO::readNumber<iomode, int>(is);
+    num_outputs = IO::readNumber<iomode, int>(is);
+    order = IO::readNumber<iomode, int>(is);
+    top_level = IO::readNumber<iomode, int>(is);
+    TypeOneDRule crule = IO::readRule<iomode>(is);
     makeRule(crule);
 
-    if (IO::readFlag<useAscii>(is)) points.read<useAscii>(is);
-    if (useAscii){ // backwards compatible: surpluses and needed, or needed and surpluses
-        if (IO::readFlag<useAscii>(is))
-            surpluses = IO::readData2D<useAscii, double>(is, num_outputs, points.getNumIndexes());
-        if (IO::readFlag<useAscii>(is)) needed.read<useAscii>(is);
+    if (IO::readFlag<iomode>(is)) points.read<iomode>(is);
+    if (iomode == mode_ascii){ // backwards compatible: surpluses and needed, or needed and surpluses
+        if (IO::readFlag<iomode>(is))
+            surpluses = IO::readData2D<iomode, double>(is, num_outputs, points.getNumIndexes());
+        if (IO::readFlag<iomode>(is)) needed.read<iomode>(is);
     }else{
-        if (IO::readFlag<useAscii>(is)) needed.read<useAscii>(is);
-        if (IO::readFlag<useAscii>(is))
-            surpluses = IO::readData2D<useAscii, double>(is, num_outputs, points.getNumIndexes());
+        if (IO::readFlag<iomode>(is)) needed.read<iomode>(is);
+        if (IO::readFlag<iomode>(is))
+            surpluses = IO::readData2D<iomode, double>(is, num_outputs, points.getNumIndexes());
     }
-    if (IO::readFlag<useAscii>(is))
-        parents = IO::readData2D<useAscii, int>(is, rule->getMaxNumParents() * num_dimensions, points.getNumIndexes());
+    if (IO::readFlag<iomode>(is))
+        parents = IO::readData2D<iomode, int>(is, rule->getMaxNumParents() * num_dimensions, points.getNumIndexes());
 
     size_t num_points = (size_t) ((points.empty()) ? needed.getNumIndexes() : points.getNumIndexes());
-    roots.resize((size_t) IO::readNumber<useAscii, int>(is));
+    roots.resize((size_t) IO::readNumber<iomode, int>(is));
     if (roots.size() > 0){
-        IO::readVector<useAscii>(is, roots);
+        IO::readVector<iomode>(is, roots);
         pntr.resize(num_points + 1);
-        IO::readVector<useAscii>(is, pntr);
+        IO::readVector<iomode>(is, pntr);
         if (pntr[num_points] > 0){
             indx.resize((size_t) pntr[num_points]);
-            IO::readVector<useAscii>(is, indx);
+            IO::readVector<iomode>(is, indx);
         }else{
             indx.resize(1);
-            indx[0] = IO::readNumber<useAscii, int>(is); // there is a special case when the grid has only one point without any children
+            indx[0] = IO::readNumber<iomode, int>(is); // there is a special case when the grid has only one point without any children
         }
     }
 
-    if (num_outputs > 0) values.read<useAscii>(is);
+    if (num_outputs > 0) values.read<iomode>(is);
 }
 
-template void GridLocalPolynomial::write<true>(std::ostream &) const;
-template void GridLocalPolynomial::write<false>(std::ostream &) const;
-template void GridLocalPolynomial::read<true>(std::istream &);
-template void GridLocalPolynomial::read<false>(std::istream &);
+template void GridLocalPolynomial::write<mode_ascii>(std::ostream &) const;
+template void GridLocalPolynomial::write<mode_binary>(std::ostream &) const;
+template void GridLocalPolynomial::read<mode_ascii>(std::istream &);
+template void GridLocalPolynomial::read<mode_binary>(std::istream &);
 
 void GridLocalPolynomial::makeGrid(int cnum_dimensions, int cnum_outputs, int depth, int corder, TypeOneDRule crule, const std::vector<int> &level_limits){
     reset();
@@ -445,17 +445,12 @@ void GridLocalPolynomial::beginConstruction(){
         indx.clear();
     }
 }
-void GridLocalPolynomial::writeConstructionDataBinary(std::ostream &os) const{
-    dynamic_values->write<false>(os);
+void GridLocalPolynomial::writeConstructionData(std::ostream &os, bool iomode) const{
+    if (iomode == mode_ascii) dynamic_values->write<mode_ascii>(os); else dynamic_values->write<mode_binary>(os);
 }
-void GridLocalPolynomial::writeConstructionData(std::ostream &os) const{
-    dynamic_values->write<true>(os);
-}
-void GridLocalPolynomial::readConstructionDataBinary(std::istream &is){
-    dynamic_values = readSimpleConstructionData<false>(num_dimensions, num_outputs, is);
-}
-void GridLocalPolynomial::readConstructionData(std::istream &is){
-    dynamic_values = readSimpleConstructionData<true>(num_dimensions, num_outputs, is);
+void GridLocalPolynomial::readConstructionData(std::istream &is, bool iomode){
+    if (iomode == mode_ascii) dynamic_values = readSimpleConstructionData<mode_ascii>(num_dimensions, num_outputs, is);
+    else dynamic_values = readSimpleConstructionData<mode_binary>(num_dimensions, num_outputs, is);
 }
 std::vector<double> GridLocalPolynomial::getCandidateConstructionPoints(double tolerance, TypeRefinement criteria, int output,
                                                                         std::vector<int> const &level_limits, double const *scale_correction){

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -57,8 +57,11 @@ public:
 
     bool isLocalPolynomial() const{ return true; }
 
-    template<bool useAscii> void write(std::ostream &os) const;
-    template<bool useAscii> void read(std::istream &is);
+    void write(std::ostream &os, bool iomode) const{ if (iomode == mode_ascii) write<mode_ascii>(os); else write<mode_binary>(os); }
+    void read(std::istream &is, bool iomode){ if (iomode == mode_ascii) read<mode_ascii>(is); else read<mode_binary>(is); }
+
+    template<bool iomode> void write(std::ostream &os) const;
+    template<bool iomode> void read(std::istream &is);
 
     void makeGrid(int cnum_dimensions, int cnum_outputs, int depth, int corder, TypeOneDRule crule, const std::vector<int> &level_limits);
     void copyGrid(const GridLocalPolynomial *pwpoly, int ibegin, int iend);
@@ -97,10 +100,8 @@ public:
     int removePointsByHierarchicalCoefficient(double tolerance, int output, const double *scale_correction); // returns the number of points kept
 
     void beginConstruction();
-    void writeConstructionDataBinary(std::ostream &os) const;
-    void writeConstructionData(std::ostream &os) const;
-    void readConstructionDataBinary(std::istream &is);
-    void readConstructionData(std::istream &is);
+    void writeConstructionData(std::ostream &os, bool) const;
+    void readConstructionData(std::istream &is, bool);
     std::vector<double> getCandidateConstructionPoints(double tolerance, TypeRefinement criteria, int output, std::vector<int> const &level_limits, double const *scale_correction);
     void loadConstructedPoint(const double x[], const std::vector<double> &y);
     void loadConstructedPoint(const double x[], int numx, const double y[]);

--- a/SparseGrids/tsgGridSequence.hpp
+++ b/SparseGrids/tsgGridSequence.hpp
@@ -42,8 +42,11 @@ public:
 
     bool isSequence() const{ return true; }
 
-    template<bool useAscii> void write(std::ostream &os) const;
-    template<bool useAscii> void read(std::istream &is);
+    void write(std::ostream &os, bool iomode) const{ if (iomode == mode_ascii) write<mode_ascii>(os); else write<mode_binary>(os); }
+    void read(std::istream &is, bool iomode){ if (iomode == mode_ascii) read<mode_ascii>(is); else read<mode_binary>(is); }
+
+    template<bool iomode> void write(std::ostream &os) const;
+    template<bool iomode> void read(std::istream &is);
 
     void makeGrid(int cnum_dimensions, int cnum_outputs, int depth, TypeDepth type, TypeOneDRule crule, const std::vector<int> &anisotropic_weights, const std::vector<int> &level_limits);
     void copyGrid(const GridSequence *seq, int ibegin, int iend);
@@ -91,10 +94,8 @@ public:
     void mergeRefinement();
 
     void beginConstruction();
-    void writeConstructionDataBinary(std::ostream &ofs) const;
-    void writeConstructionData(std::ostream &ofs) const;
-    void readConstructionDataBinary(std::istream &ifs);
-    void readConstructionData(std::istream &ifs);
+    void writeConstructionData(std::ostream &ofs, bool) const;
+    void readConstructionData(std::istream &ifs, bool);
     std::vector<double> getCandidateConstructionPoints(TypeDepth type, const std::vector<int> &weights, const std::vector<int> &level_limits);
     std::vector<double> getCandidateConstructionPoints(TypeDepth type, int output, const std::vector<int> &level_limits);
     std::vector<double> getCandidateConstructionPoints(std::function<double(const int *)> getTensorWeight, const std::vector<int> &level_limits);

--- a/SparseGrids/tsgGridWavelet.cpp
+++ b/SparseGrids/tsgGridWavelet.cpp
@@ -47,51 +47,51 @@ void GridWavelet::reset(){
     coefficients.clear();
 }
 
-template<bool useAscii> void GridWavelet::write(std::ostream &os) const{
-    if (useAscii){ os << std::scientific; os.precision(17); }
-    IO::writeNumbers<useAscii, IO::pad_line>(os, num_dimensions, num_outputs, order);
-    IO::writeFlag<useAscii, IO::pad_auto>(!points.empty(), os);
-    if (!points.empty()) points.write<useAscii>(os);
-    if (useAscii){ // backwards compatible: surpluses and needed, or needed and surpluses
-        IO::writeFlag<useAscii, IO::pad_auto>((coefficients.getNumStrips() != 0), os);
-        if (coefficients.getNumStrips() != 0) IO::writeVector<useAscii, IO::pad_line>(coefficients.getVector(), os);
-        IO::writeFlag<useAscii, IO::pad_auto>(!needed.empty(), os);
-        if (!needed.empty()) needed.write<useAscii>(os);
+template<bool iomode> void GridWavelet::write(std::ostream &os) const{
+    if (iomode == mode_ascii){ os << std::scientific; os.precision(17); }
+    IO::writeNumbers<iomode, IO::pad_line>(os, num_dimensions, num_outputs, order);
+    IO::writeFlag<iomode, IO::pad_auto>(!points.empty(), os);
+    if (!points.empty()) points.write<iomode>(os);
+    if (iomode == mode_ascii){ // backwards compatible: surpluses and needed, or needed and surpluses
+        IO::writeFlag<iomode, IO::pad_auto>((coefficients.getNumStrips() != 0), os);
+        if (coefficients.getNumStrips() != 0) IO::writeVector<iomode, IO::pad_line>(coefficients.getVector(), os);
+        IO::writeFlag<iomode, IO::pad_auto>(!needed.empty(), os);
+        if (!needed.empty()) needed.write<iomode>(os);
     }else{
-        IO::writeFlag<useAscii, IO::pad_auto>(!needed.empty(), os);
-        if (!needed.empty()) needed.write<useAscii>(os);
-        IO::writeFlag<useAscii, IO::pad_auto>((coefficients.getNumStrips() != 0), os);
-        if (coefficients.getNumStrips() != 0) IO::writeVector<useAscii, IO::pad_line>(coefficients.getVector(), os);
+        IO::writeFlag<iomode, IO::pad_auto>(!needed.empty(), os);
+        if (!needed.empty()) needed.write<iomode>(os);
+        IO::writeFlag<iomode, IO::pad_auto>((coefficients.getNumStrips() != 0), os);
+        if (coefficients.getNumStrips() != 0) IO::writeVector<iomode, IO::pad_line>(coefficients.getVector(), os);
     }
 
-    if (num_outputs > 0) values.write<useAscii>(os);
+    if (num_outputs > 0) values.write<iomode>(os);
 }
-template<bool useAscii> void GridWavelet::read(std::istream &is){
+template<bool iomode> void GridWavelet::read(std::istream &is){
     reset();
-    num_dimensions = IO::readNumber<useAscii, int>(is);
-    num_outputs = IO::readNumber<useAscii, int>(is);
-    order = IO::readNumber<useAscii, int>(is);
+    num_dimensions = IO::readNumber<iomode, int>(is);
+    num_outputs = IO::readNumber<iomode, int>(is);
+    order = IO::readNumber<iomode, int>(is);
     rule1D.updateOrder(order);
 
-    if (IO::readFlag<useAscii>(is)) points.read<useAscii>(is);
-    if (useAscii){ // backwards compatible: surpluses and needed, or needed and surpluses
-        if (IO::readFlag<useAscii>(is))
-            coefficients = IO::readData2D<useAscii, double>(is, num_outputs, points.getNumIndexes());
-        if (IO::readFlag<useAscii>(is)) needed.read<useAscii>(is);
+    if (IO::readFlag<iomode>(is)) points.read<iomode>(is);
+    if (iomode == mode_ascii){ // backwards compatible: surpluses and needed, or needed and surpluses
+        if (IO::readFlag<iomode>(is))
+            coefficients = IO::readData2D<iomode, double>(is, num_outputs, points.getNumIndexes());
+        if (IO::readFlag<iomode>(is)) needed.read<iomode>(is);
     }else{
-        if (IO::readFlag<useAscii>(is)) needed.read<useAscii>(is);
-        if (IO::readFlag<useAscii>(is))
-            coefficients = IO::readData2D<useAscii, double>(is, num_outputs, points.getNumIndexes());
+        if (IO::readFlag<iomode>(is)) needed.read<iomode>(is);
+        if (IO::readFlag<iomode>(is))
+            coefficients = IO::readData2D<iomode, double>(is, num_outputs, points.getNumIndexes());
     }
 
-    if (num_outputs > 0) values.read<useAscii>(is);
+    if (num_outputs > 0) values.read<iomode>(is);
     buildInterpolationMatrix();
 }
 
-template void GridWavelet::write<true>(std::ostream &) const;
-template void GridWavelet::write<false>(std::ostream &) const;
-template void GridWavelet::read<true>(std::istream &);
-template void GridWavelet::read<false>(std::istream &);
+template void GridWavelet::write<mode_ascii>(std::ostream &) const;
+template void GridWavelet::write<mode_binary>(std::ostream &) const;
+template void GridWavelet::read<mode_ascii>(std::istream &);
+template void GridWavelet::read<mode_binary>(std::istream &);
 
 void GridWavelet::makeGrid(int cnum_dimensions, int cnum_outputs, int depth, int corder, const std::vector<int> &level_limits){
     reset();

--- a/SparseGrids/tsgGridWavelet.hpp
+++ b/SparseGrids/tsgGridWavelet.hpp
@@ -42,8 +42,11 @@ public:
 
     bool isWavelet() const{ return true; }
 
-    template<bool useAscii> void write(std::ostream &os) const;
-    template<bool useAscii> void read(std::istream &is);
+    void write(std::ostream &os, bool iomode) const{ if (iomode == mode_ascii) write<mode_ascii>(os); else write<mode_binary>(os); }
+    void read(std::istream &is, bool iomode){ if (iomode == mode_ascii) read<mode_ascii>(is); else read<mode_binary>(is); }
+
+    template<bool iomode> void write(std::ostream &os) const;
+    template<bool iomode> void read(std::istream &is);
 
     void makeGrid(int cnum_dimensions, int cnum_outputs, int depth, int corder, const std::vector<int> &level_limits);
     void copyGrid(const GridWavelet *wav, int ibegin, int iend);

--- a/SparseGrids/tsgIOHelpers.hpp
+++ b/SparseGrids/tsgIOHelpers.hpp
@@ -55,6 +55,19 @@
 namespace TasGrid{
 
 /*!
+ * \ingroup TasmanianSG
+ * \brief Constant allowing for more expressive selection of ascii and binary mode in IO methods.
+ */
+constexpr bool mode_ascii = false;
+
+/*!
+ * \ingroup TasmanianSG
+ * \brief Constant allowing for more expressive selection of ascii and binary mode in IO methods.
+ */
+constexpr bool mode_binary = true;
+
+
+/*!
  * \internal
  * \ingroup TasmanianIO
  * \brief Collection of I/O handling templates.
@@ -272,9 +285,9 @@ inline TypeRefinement getTypeRefinementInt(int refinement){
  * \ingroup TasmanianIO
  * \brief Write the flag to file, ascii uses 0 and 1, binary uses characters y and n (counter intuitive, I know).
  */
-template<bool useAscii, IOPad pad>
+template<bool use_ascii, IOPad pad>
 void writeFlag(bool flag, std::ostream &os){
-    if (useAscii){
+    if (use_ascii == mode_ascii){
         os << ((flag) ? "1" : "0");
         if ((pad == pad_rspace) || ((pad == pad_auto) && flag)) os << " ";
         if ((pad == pad_line) || ((pad == pad_auto) && !flag)) os << std::endl;
@@ -288,9 +301,9 @@ void writeFlag(bool flag, std::ostream &os){
  * \ingroup TasmanianIO
  * \brief Read a flag, ascii uses 0 and 1, binary uses characters y and n (counter intuitive, I know).
  */
-template<bool useAscii>
+template<bool use_ascii>
 bool readFlag(std::istream &os){
-    if (useAscii){
+    if (use_ascii == mode_ascii){
         int flag;
         os >> flag;
         return (flag == 1);
@@ -305,9 +318,9 @@ bool readFlag(std::istream &os){
  * \ingroup TasmanianIO
  * \brief Write the vector to the stream, the vector cannot be empty.
  */
-template<bool useAscii, IOPad pad, typename VecType>
+template<bool use_ascii, IOPad pad, typename VecType>
 void writeVector(const std::vector<VecType> &x, std::ostream &os){
-    if (useAscii){
+    if (use_ascii == mode_ascii){
         if (pad == pad_lspace)
             for(auto i : x) os << " " << i;
         if (pad == pad_rspace)
@@ -326,9 +339,9 @@ void writeVector(const std::vector<VecType> &x, std::ostream &os){
  * \ingroup TasmanianIO
  * \brief Read the vector from the stream.
  */
-template<bool useAscii, typename VecType>
+template<bool use_ascii, typename VecType>
 void readVector(std::istream &os, std::vector<VecType> &x){
-    if (useAscii){
+    if (use_ascii == mode_ascii){
         for(auto &i : x) os >> i;
     }else{
         os.read((char*) x.data(), x.size() * sizeof(VecType));
@@ -339,20 +352,20 @@ void readVector(std::istream &os, std::vector<VecType> &x){
  * \ingroup TasmanianIO
  * \brief Write a bunch of numbers with the same type.
  */
-template<bool useAscii, IOPad pad, typename... Vals>
+template<bool use_ascii, IOPad pad, typename... Vals>
 void writeNumbers(std::ostream &os, Vals... vals){
     std::vector<typename std::tuple_element<0, std::tuple<Vals...>>::type> values = {vals...};
-    writeVector<useAscii, pad>(values, os);
+    writeVector<use_ascii, pad>(values, os);
 }
 
 /*!
  * \ingroup TasmanianIO
  * \brief Read a single number, used to read ints (and potentially cast to size_t) or read a double.
  */
-template<bool useAscii, typename Val>
+template<bool use_ascii, typename Val>
 Val readNumber(std::istream &os){
     Val v;
-    if (useAscii){
+    if (use_ascii == mode_ascii){
         os >> v;
     }else{
         os.read((char*) &v, sizeof(Val));
@@ -364,9 +377,9 @@ Val readNumber(std::istream &os){
  * \ingroup TasmanianIO
  * \brief Write a rule.
  */
-template<bool useAscii>
+template<bool use_ascii>
 void writeRule(TypeOneDRule rule, std::ostream &os){
-    if (useAscii){
+    if (use_ascii == mode_ascii){
         os << getRuleString(rule) << std::endl;
     }else{
         int r = getRuleInt(rule);
@@ -378,14 +391,14 @@ void writeRule(TypeOneDRule rule, std::ostream &os){
  * \ingroup TasmanianIO
  * \brief Read a rule.
  */
-template<bool useAscii>
+template<bool use_ascii>
 TypeOneDRule readRule(std::istream &is){
-    if (useAscii){
+    if (use_ascii == mode_ascii){
         std::string T;
         is >> T;
         return getRuleString(T);
     }else{
-        return getRuleInt(readNumber<false, int>(is));
+        return getRuleInt(readNumber<mode_binary, int>(is));
     }
 }
 

--- a/SparseGrids/tsgIndexSets.cpp
+++ b/SparseGrids/tsgIndexSets.cpp
@@ -35,28 +35,28 @@
 
 namespace TasGrid{
 
-template<bool useAscii>
+template<bool iomode>
 void MultiIndexSet::write(std::ostream &os) const{
     if (cache_num_indexes > 0){
-        IO::writeNumbers<useAscii, IO::pad_rspace>(os, (int) num_dimensions, cache_num_indexes);
-        IO::writeVector<useAscii, IO::pad_line>(indexes, os);
+        IO::writeNumbers<iomode, IO::pad_rspace>(os, (int) num_dimensions, cache_num_indexes);
+        IO::writeVector<iomode, IO::pad_line>(indexes, os);
     }else{
-        IO::writeNumbers<useAscii, IO::pad_line>(os, (int) num_dimensions, cache_num_indexes);
+        IO::writeNumbers<iomode, IO::pad_line>(os, (int) num_dimensions, cache_num_indexes);
     }
 }
 
-template<bool useAscii>
+template<bool iomode>
 void MultiIndexSet::read(std::istream &is){
-    num_dimensions = (size_t) IO::readNumber<useAscii, int>(is);
-    cache_num_indexes = IO::readNumber<useAscii, int>(is);
+    num_dimensions = (size_t) IO::readNumber<iomode, int>(is);
+    cache_num_indexes = IO::readNumber<iomode, int>(is);
     indexes.resize(num_dimensions * ((size_t) cache_num_indexes));
-    IO::readVector<useAscii>(is, indexes);
+    IO::readVector<iomode>(is, indexes);
 }
 
-template void MultiIndexSet::write<true>(std::ostream &) const; // instantiate for faster build
-template void MultiIndexSet::write<false>(std::ostream &) const;
-template void MultiIndexSet::read<true>(std::istream &);
-template void MultiIndexSet::read<false>(std::istream &);
+template void MultiIndexSet::write<mode_ascii>(std::ostream &) const; // instantiate for faster build
+template void MultiIndexSet::write<mode_binary>(std::ostream &) const;
+template void MultiIndexSet::read<mode_ascii>(std::istream &);
+template void MultiIndexSet::read<mode_binary>(std::istream &);
 
 void MultiIndexSet::addSortedIndexes(const std::vector<int> &addition){
     if (indexes.empty()){
@@ -229,27 +229,27 @@ void MultiIndexSet::removeIndex(const std::vector<int> &p){
 StorageSet::StorageSet() : num_outputs(0), num_values(0){}
 StorageSet::~StorageSet(){}
 
-template<bool useAscii>
+template<bool iomode>
 void StorageSet::write(std::ostream &os) const{
-    IO::writeNumbers<useAscii, IO::pad_rspace>(os, (int) num_outputs, (int) num_values);
-    IO::writeFlag<useAscii, IO::pad_auto>((values.size() != 0), os);
+    IO::writeNumbers<iomode, IO::pad_rspace>(os, (int) num_outputs, (int) num_values);
+    IO::writeFlag<iomode, IO::pad_auto>((values.size() != 0), os);
     if (values.size() != 0)
-        IO::writeVector<useAscii, IO::pad_line>(values, os);
+        IO::writeVector<iomode, IO::pad_line>(values, os);
 }
-template<bool useAscii>
+template<bool iomode>
 void StorageSet::read(std::istream &is){
-    num_outputs = (size_t) IO::readNumber<useAscii, int>(is);
-    num_values = (size_t) IO::readNumber<useAscii, int>(is);
-    if (IO::readFlag<useAscii>(is)){
+    num_outputs = (size_t) IO::readNumber<iomode, int>(is);
+    num_values = (size_t) IO::readNumber<iomode, int>(is);
+    if (IO::readFlag<iomode>(is)){
         values.resize(num_outputs * num_values);
-        IO::readVector<useAscii>(is, values);
+        IO::readVector<iomode>(is, values);
     }
 }
 
-template void StorageSet::write<true>(std::ostream &) const;
-template void StorageSet::write<false>(std::ostream &) const;
-template void StorageSet::read<true>(std::istream &);
-template void StorageSet::read<false>(std::istream &);
+template void StorageSet::write<mode_ascii>(std::ostream &) const;
+template void StorageSet::write<mode_binary>(std::ostream &) const;
+template void StorageSet::read<mode_ascii>(std::istream &);
+template void StorageSet::read<mode_binary>(std::istream &);
 
 void StorageSet::resize(int cnum_outputs, int cnum_values){
     values = std::vector<double>();


### PR DESCRIPTION
* added constexpr constants for expressive calls to mode selection (parallel and io-mode)
* consistent naming for IO variables and templates when using binary and ascii modes
* adjusted the checkpointing strategy for the parallel surrogate construction