### PR TITLE
Scatter likelihood

### DIFF
--- a/Addons/CMakeLists.txt
+++ b/Addons/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(Tasmanian_addons INTERFACE)
 Tasmanian_addon_sources(PATH .
                         FILES tsgAddonsCommon.hpp
                               tsgMPIScatterGrid.hpp
+                              tsgMPIScatterDREAM.hpp
                               tsgLoadNeededValues.hpp
                               tsgCandidateManager.hpp
                               tsgConstructSurrogate.hpp
@@ -46,7 +47,7 @@ if (Tasmanian_ENABLE_MPI)
         set_target_properties(Tasmanian_addons PROPERTIES INTERFACE_LINK_OPTIONS "${MPI_CXX_LINK_FLAGS}")
     endif()
 
-    add_executable(Tasmanian_mpitester testMPI.cpp testMPI.hpp)
+    add_executable(Tasmanian_mpitester testMPI.cpp testMPI.hpp testMPIDREAM.hpp)
     set_target_properties(Tasmanian_mpitester PROPERTIES OUTPUT_NAME "mpitester")
     target_link_libraries(Tasmanian_mpitester Tasmanian_addons Tasmanian_libdream)
     add_test(MPISparseGridsIO ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS} mpitester ${MPIEXEC_POSTFLAGS})

--- a/Addons/testMPI.cpp
+++ b/Addons/testMPI.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "testMPI.hpp"
+#include "testMPIDREAM.hpp"
 
 using std::cout;
 using std::setw;

--- a/Addons/testMPI.cpp
+++ b/Addons/testMPI.cpp
@@ -52,6 +52,8 @@ int main(int argc, char ** argv){
     // --------------- Send/Recv <binary> ----------------- //
     if (!testSendReceive<TasGrid::mode_binary>()) throw std::runtime_error("failed Send/Recv binary");
     MPI_Barrier(MPI_COMM_WORLD);
+    if (!testLikelySendRecv()) throw std::runtime_error("failed Send/Recv DREAM");
+    MPI_Barrier(MPI_COMM_WORLD);
     if (me == 0)
         cout << "    MPI Send/Recv    <binary>    Pass\n";
 

--- a/Addons/testMPI.cpp
+++ b/Addons/testMPI.cpp
@@ -78,6 +78,8 @@ int main(int argc, char ** argv){
     // ----------------- Scatter <binary> --------------- //
     if (!testScatterOutputs<TasGrid::mode_binary>()) throw std::runtime_error("failed Scatter binary");
     MPI_Barrier(MPI_COMM_WORLD);
+    if (!testLikelyScatter()) throw std::runtime_error("failed Scatter DREAM");
+    MPI_Barrier(MPI_COMM_WORLD);
     if (me == 0)
         cout << "      MPI Scatter    <binary>    Pass\n";
 

--- a/Addons/testMPI.hpp
+++ b/Addons/testMPI.hpp
@@ -51,15 +51,15 @@ template<bool use_binary>
 bool testSendReceive(){
     auto true_grid = TasGrid::makeGlobalGrid(5, 3, 4, TasGrid::type_level, TasGrid::rule_clenshawcurtis);
 
-    int tag_size = 0, tag_data = 1;
+    int tag = 1;
     int me = TasGrid::getMPIRank(MPI_COMM_WORLD);
 
     if (me == 0){
-        return (TasGrid::MPIGridSend<use_binary>(true_grid, 1, tag_size, tag_data, MPI_COMM_WORLD) == MPI_SUCCESS);
+        return (TasGrid::MPIGridSend<use_binary>(true_grid, 1, tag, MPI_COMM_WORLD) == MPI_SUCCESS);
     }else if (me == 1){
         MPI_Status status;
         TasGrid::TasmanianSparseGrid grid;
-        auto result = TasGrid::MPIGridRecv<use_binary>(grid, 0, tag_size, tag_data, MPI_COMM_WORLD, &status);
+        auto result = TasGrid::MPIGridRecv<use_binary>(grid, 0, tag, MPI_COMM_WORLD, &status);
         if (result != MPI_SUCCESS) return false;
         return checkPoints(true_grid, grid);
     }else{
@@ -121,9 +121,9 @@ bool testScatterOutputs(){
                                             for(size_t i=0; i<7; i++)
                                                 y[i] = double(i+1) * expval;
                                         }, full_grid, 0);
-        MPIGridScatterOutputs<use_binary>(full_grid, grid, 1, 2, 3, MPI_COMM_WORLD);
+        MPIGridScatterOutputs<use_binary>(full_grid, grid, 1, 2, MPI_COMM_WORLD);
     }else{
-        MPIGridScatterOutputs<use_binary>(TasmanianSparseGrid(), grid, 1, 2, 3, MPI_COMM_WORLD);
+        MPIGridScatterOutputs<use_binary>(TasmanianSparseGrid(), grid, 1, 2, MPI_COMM_WORLD);
     }
 
     std::minstd_rand park_miller(99);
@@ -143,7 +143,7 @@ bool testScatterOutputs(){
 
     if (!match(grid, reference_grid)) throw std::runtime_error("ERROR: first iteration of MPIGridScatterOutputs() failed.");
 
-    MPIGridScatterOutputs<use_binary>(copyGrid(grid), grid, 1, 2, 3, MPI_COMM_WORLD);
+    MPIGridScatterOutputs<use_binary>(copyGrid(grid), grid, 1, 2, MPI_COMM_WORLD);
     if (me == 2){
         if (!grid.empty()) throw std::runtime_error("ERROR: second iteration of MPIGridScatterOutputs() failed.");
     }else{
@@ -155,7 +155,7 @@ bool testScatterOutputs(){
         if (!match(grid, reference_grid)) throw std::runtime_error("ERROR: second iteration of MPIGridScatterOutputs() failed.");
     }
 
-    MPIGridScatterOutputs<use_binary>(copyGrid(grid), grid, 1, 2, 3, MPI_COMM_WORLD);
+    MPIGridScatterOutputs<use_binary>(copyGrid(grid), grid, 1, 2, MPI_COMM_WORLD);
     if (me == 0){
         reference_grid = TasGrid::makeGlobalGrid(3, 1, 4, TasGrid::type_level, TasGrid::rule_clenshawcurtis);
         loadNeededPoints<false, false>([&](double const x[], double y[], size_t)->void{

--- a/Addons/testMPIDREAM.hpp
+++ b/Addons/testMPIDREAM.hpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017, Miroslav Stoyanov
+ *
+ * This file is part of
+ * Toolkit for Adaptive Stochastic Modeling And Non-Intrusive ApproximatioN: TASMANIAN
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * UT-BATTELLE, LLC AND THE UNITED STATES GOVERNMENT MAKE NO REPRESENTATIONS AND DISCLAIM ALL WARRANTIES, BOTH EXPRESSED AND IMPLIED.
+ * THERE ARE NO EXPRESS OR IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE SOFTWARE WILL NOT INFRINGE ANY PATENT,
+ * COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS, OR THAT THE SOFTWARE WILL ACCOMPLISH THE INTENDED RESULTS OR THAT THE SOFTWARE OR ITS USE WILL NOT RESULT IN INJURY OR DAMAGE.
+ * THE USER ASSUMES RESPONSIBILITY FOR ALL LIABILITIES, PENALTIES, FINES, CLAIMS, CAUSES OF ACTION, AND COSTS AND EXPENSES, CAUSED BY, RESULTING FROM OR ARISING OUT OF,
+ * IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
+ */
+
+#include "TasmanianAddons.hpp"
+#include "tasgridCLICommon.hpp"

--- a/Addons/tsgMPIConstructGrid.hpp
+++ b/Addons/tsgMPIConstructGrid.hpp
@@ -42,7 +42,7 @@
  * \endinternal
  */
 
-#include "tsgMPIScatterGrid.hpp"
+#include "tsgMPIScatterDREAM.hpp"
 #include "tsgConstructSurrogate.hpp"
 
 /*!

--- a/Addons/tsgMPIScatterDREAM.hpp
+++ b/Addons/tsgMPIScatterDREAM.hpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017, Miroslav Stoyanov
+ *
+ * This file is part of
+ * Toolkit for Adaptive Stochastic Modeling And Non-Intrusive ApproximatioN: TASMANIAN
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * UT-BATTELLE, LLC AND THE UNITED STATES GOVERNMENT MAKE NO REPRESENTATIONS AND DISCLAIM ALL WARRANTIES, BOTH EXPRESSED AND IMPLIED.
+ * THERE ARE NO EXPRESS OR IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE SOFTWARE WILL NOT INFRINGE ANY PATENT,
+ * COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS, OR THAT THE SOFTWARE WILL ACCOMPLISH THE INTENDED RESULTS OR THAT THE SOFTWARE OR ITS USE WILL NOT RESULT IN INJURY OR DAMAGE.
+ * THE USER ASSUMES RESPONSIBILITY FOR ALL LIABILITIES, PENALTIES, FINES, CLAIMS, CAUSES OF ACTION, AND COSTS AND EXPENSES, CAUSED BY, RESULTING FROM OR ARISING OUT OF,
+ * IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
+ */
+
+#ifndef __TASMANIAN_ADDONS_MPIDREAMSCATTER_HPP
+#define __TASMANIAN_ADDONS_MPIDREAMSCATTER_HPP
+
+/*!
+ * \internal
+ * \file tsgMPIScatterDREAM.hpp
+ * \brief DREAM objects send/receive through MPI.
+ * \author Miroslav Stoyanov
+ * \ingroup TasmanianAddonsCommon
+ *
+ * Templates that communicate DREAM objects through an MPI commands.
+ * \endinternal
+ */
+
+#include "tsgMPIScatterGrid.hpp"
+
+/*!
+ * \ingroup TasmanianAddons
+ * \addtogroup TasmanianAddonsMPIDREAMSend MPI Send/Receive/Scatter for DREAM
+ *
+ * Methods to send/receive DREAM likelihood objects.
+ * The syntax mimics the raw MPI_Send and MPI_Recv calls,
+ * and the templates require Tasmanian_ENABLE_MPI=ON.
+ */
+
+#ifdef Tasmanian_ENABLE_MPI
+
+namespace TasGrid{
+
+}
+
+#endif // Tasmanian_ENABLE_MPI
+
+#endif

--- a/Addons/tsgMPIScatterDREAM.hpp
+++ b/Addons/tsgMPIScatterDREAM.hpp
@@ -59,40 +59,25 @@ namespace TasDREAM{
 
 /*!
  * \ingroup TasmanianAddonsMPIDREAMSend
- * \brief Send a grid to another process in the MPI comm.
+ * \brief Send a likelihood to another process in the MPI comm.
  *
- * Send the grid to the destination rank across an MPI comm.
- * The grid is frist writtein to a stream in either binary or ASCII
- * format and then send with a single MPI_Send() call.
- * Binary results in smaller messages and less computational overhead;
- * thus, ASCII is provided mostly for debugging purposes.
+ * Works with both isotropic and anisotropic Gaussian likelihood
+ * object implemented in Tasmanian.
+ * The usage is very similar to MPI_Send() and TasGrid::MPIGridSend().
  *
- * \tparam binary defines whether to use binary (\b true) or ASCII (\b false) mode.
- *                Recommended use with constexpr constant TasGrid::mode_binary
- *                and TasGrid::mode_ascii.
+ * \tparam Likelihood is a Tasmanian likelihood class, currently
+ *                    LikeliTasDREAM::LikelihoodGaussIsotropic and
+ *                    LikeliTasDREAM::LikelihoodGaussAnisotropic.
  *
- * \param grid        is the grid to send.
+ * \param likely      is the likelihood to send.
  * \param destination is the rank of the recipient MPI process.
  * \param tag         is the tag to use for the MPI message.
  * \param comm        is the MPI comm where the source and destination reside.
  *
  * \return the error code of the MPI_Send() command.
  *
- * \b Note: this call must be mirrored by TasGrid::MPIGridRecv() on the
+ * \b Note: this call must be mirrored by TasDREAM::MPILikelihoodRecv() on the
  *          destination process.
- *
- * Example usage, process 0 creates a grid and sends it to process 1:
- * \code
- *   int me, tag = 0;
- *   MPI_Comm_rank(MPI_COMM_WORLD, &me);
- *   MPI_Status status;
- *   TasGrid::TasmanianSparseGrid grid;
- *   if (me == 0) grid.makeGlobalGrid(3, 4, 5, TasGrid::type_level, TasGrid::rule_clenshawcurtis);
- *   if (me == 0) MPIGridSend(grid, 1, tag, MPI_COMM_WORLD);
- *   else if (me == 1) MPIGridRecv(grid, 0, tag, MPI_COMM_WORLD, &status);
- *   // at this line, process 1 has a grid equivalent to that of process 0
- *   // processes with rank 2 and above do nothing, i.e., they have an empty grid
- * \endcode
  */
 template<class Likelihood>
 int MPILikelihoodSend(Likelihood const &likely, int destination, int tag, MPI_Comm comm){
@@ -104,23 +89,25 @@ int MPILikelihoodSend(Likelihood const &likely, int destination, int tag, MPI_Co
 
 /*!
  * \ingroup TasmanianAddonsMPIDREAMSend
- * \brief Receive a grid from another process in the MPI comm.
+ * \brief Receive a likelihood from another process in the MPI comm.
  *
- * Receive a grid that has been send with TasGrid::MPIGridSend().
- * This call intercepts both messages and compiles them into a sparse grid object.
+ * Works with both isotropic and anisotropic Gaussian likelihood
+ * object implemented in Tasmanian.
+ * The usage is very similar to MPI_Recv() and TasGrid::MPIGridRecv().
  *
- * \tparam binary defines whether to use binary (\b true) or ASCII (\b false) mode.
- *                Recommended use with constexpr constant TasGrid::mode_binary
- *                and TasGrid::mode_ascii.
+ * \tparam Likelihood is a Tasmanian likelihood class, currently
+ *                    LikeliTasDREAM::LikelihoodGaussIsotropic and
+ *                    LikeliTasDREAM::LikelihoodGaussAnisotropic.
  *
- * \param grid is the output grid, it will be overwritten with grid send by
- *             the source rank similar to TasGrid::TasmanianSparseGrid::read().
+ * \param likely   is the output likelihood, it will be overwritten with the one send.
  * \param source   is the rank of the process in the MPI comm that issued the send command.
  * \param tag      is the tag used in the MPI send command.
  * \param comm     is the MPI comm where the source and destination reside.
- * \param status is the status of the MPI_Recv() command.
+ * \param status   is the status of the MPI_Recv() command.
  *
  * \return the error code of the MPI_Recv() command.
+ *
+ * \b Note: see TasDREAM::MPILikelihoodSend().
  */
 template<class Likelihood>
 int MPILikelihoodRecv(Likelihood &likely, int source, int tag, MPI_Comm comm, MPI_Status *status = MPI_STATUS_IGNORE){

--- a/Addons/tsgMPIScatterGrid.hpp
+++ b/Addons/tsgMPIScatterGrid.hpp
@@ -91,12 +91,9 @@ inline int getMPIRank(MPI_Comm comm){ int rank; MPI_Comm_rank(comm, &rank); retu
  * \brief Send a grid to another process in the MPI comm.
  *
  * Send the grid to the destination rank across an MPI comm.
- * The syntax deliberately mimics MPI_Send and the behavior is mostly the same,
- * except the process uses two messages:
- * the size of the grid (in units of memory as opposed to points),
- * and the the actual data and meta-data similar to the file I/O methods.
- * The transfer can be done in either binary or ASCII format, but binary results
- * in smaller messages and less computational overhead;
+ * The grid is frist writtein to a stream in either binary or ASCII
+ * format and then send with a single MPI_Send() call.
+ * Binary results in smaller messages and less computational overhead;
  * thus, ASCII is provided mostly for debugging purposes.
  *
  * \tparam binary defines whether to use binary (\b true) or ASCII (\b false) mode.
@@ -105,42 +102,33 @@ inline int getMPIRank(MPI_Comm comm){ int rank; MPI_Comm_rank(comm, &rank); retu
  *
  * \param grid        is the grid to send.
  * \param destination is the rank of the recipient MPI process.
- * \param tag_size    is the tag to use for the size message.
- * \param tag_data    is the tag to use for the data message.
+ * \param tag         is the tag to use for the MPI message.
  * \param comm        is the MPI comm where the source and destination reside.
  *
- * \return the error code of the fist failed MPI_Send command
- *         (corresponding to either the size of the data message),
- *         if MPI_SUCCESS is returned then both messages were successful.
+ * \return the error code of the MPI_Send() command.
  *
  * \b Note: this call must be mirrored by TasGrid::MPIGridRecv() on the
  *          destination process.
  *
  * Example usage, process 0 creates a grid and sends it to process 1:
  * \code
- *   int me, tag_size = 0, tag_data = 1;
+ *   int me, tag = 0;
  *   MPI_Comm_rank(MPI_COMM_WORLD, &me);
  *   MPI_Status status;
  *   TasGrid::TasmanianSparseGrid grid;
  *   if (me == 0) grid.makeGlobalGrid(3, 4, 5, TasGrid::type_level, TasGrid::rule_clenshawcurtis);
- *   if (me == 0) MPIGridSend(grid, 1, tag_size, tag_data, MPI_COMM_WORLD);
- *   else if (me == 1) MPIGridRecv(grid, 0, tag_size, tag_data, MPI_COMM_WORLD, &status);
+ *   if (me == 0) MPIGridSend(grid, 1, tag, MPI_COMM_WORLD);
+ *   else if (me == 1) MPIGridRecv(grid, 0, tag, MPI_COMM_WORLD, &status);
  *   // at this line, process 1 has a grid equivalent to that of process 0
  *   // processes with rank 2 and above do nothing, i.e., they have an empty grid
  * \endcode
  */
 template<bool binary = TasGrid::mode_binary>
-int MPIGridSend(TasmanianSparseGrid const &grid, int destination, int tag_size, int tag_data, MPI_Comm comm){
+int MPIGridSend(TasmanianSparseGrid const &grid, int destination, int tag, MPI_Comm comm){
     std::stringstream ss;
     grid.write(ss, binary);
-
-    while(ss.str().size() % 16 != 0) ss << " "; // pad with empty chars to align to 16 bytes, i.e., long double
-
-    unsigned long long data_size = (unsigned long long) ss.str().size();
-    auto result = MPI_Send(&data_size, 1, MPI_UNSIGNED_LONG_LONG, destination, tag_size, comm);
-    if (result != MPI_SUCCESS) return result;
-
-    return MPI_Send(ss.str().c_str(), (int) (data_size / 16), MPI_LONG_DOUBLE, destination, tag_data, comm);
+    while(ss.str().size() % 16 != 0) ss << " ";
+    return MPI_Send(ss.str().c_str(), (int) (ss.str().size() / 16), MPI_LONG_DOUBLE, destination, tag, comm);
 }
 
 /*!
@@ -157,29 +145,25 @@ int MPIGridSend(TasmanianSparseGrid const &grid, int destination, int tag_size, 
  * \param grid is the output grid, it will be overwritten with grid send by
  *             the source rank similar to TasGrid::TasmanianSparseGrid::read().
  * \param source   is the rank of the process in the MPI comm that issued the send command.
- * \param tag_size is the tag used in the size portion of the send command.
- * \param tag_data is the tag used in the data portion of the send command.
+ * \param tag      is the tag used in the MPI send command.
  * \param comm     is the MPI comm where the source and destination reside.
- * \param status is the status of the first faield MPI_Recv() command
- *               (corresponding to either the size of the data message),
- *               if MPI_SUCCESS is returned, then the status corresponds
- *               to the successful data message
+ * \param status is the status of the MPI_Recv() command.
  *
- * \return the error code of the fist failed MPI_Recv() command
- *         (corresponding to either the size of the data message),
- *         if MPI_SUCCESS is returned then both messages were successful.
+ * \return the error code of the MPI_Recv() command.
  */
 template<bool binary = TasGrid::mode_binary>
-int MPIGridRecv(TasmanianSparseGrid &grid, int source, int tag_size, int tag_data, MPI_Comm comm, MPI_Status *status = nullptr){
+int MPIGridRecv(TasmanianSparseGrid &grid, int source, int tag, MPI_Comm comm, MPI_Status *status = MPI_STATUS_IGNORE){
     MPI_Status internal_status;
-    if (status == nullptr) status = &internal_status;
-    unsigned long long data_size;
+    if (status == MPI_STATUS_IGNORE) status = &internal_status;
 
-    auto result = MPI_Recv(&data_size, 1, MPI_UNSIGNED_LONG_LONG, source, tag_size, comm,  status);
-    if (result != MPI_SUCCESS) return result;
+    int short_data_size;
+    MPI_Probe(source, tag, comm, status);
+    MPI_Get_count(status, MPI_LONG_DOUBLE, &short_data_size);
 
-    std::vector<char> buff((size_t) data_size);
-    result = MPI_Recv(buff.data(), (int) buff.size(), MPI_UNSIGNED_CHAR, source, tag_data, comm, status);
+    size_t data_size = Utils::size_mult(short_data_size, 16);
+
+    std::vector<char> buff(data_size);
+    auto result = MPI_Recv(buff.data(), (int) (data_size / 16), MPI_LONG_DOUBLE, source, tag, comm, status);
 
     VectorToStreamBuffer data_buffer(buff); // do not modify buff after this point
     std::istream is(&data_buffer);
@@ -272,8 +256,7 @@ int MPIGridBcast(TasmanianSparseGrid &grid, int root, MPI_Comm comm){
  *                    If the \b source outputs are less than the number of \b comm ranks,
  *                    then some of the destination grids will be empty.
  * \param root is the rank that will hold the source sparse grid.
- * \param tag_size same as in TasGrid::MPIGridSend().
- * \param tag_data same as in TasGrid::MPIGridSend().
+ * \param tag  same as in TasGrid::MPIGridSend().
  * \param comm is the MPI comm of all process that need to share a portion of the grid.
  *
  * Example usage, rank 0 creates a large grid and scatters is across comm:
@@ -290,7 +273,7 @@ int MPIGridBcast(TasmanianSparseGrid &grid, int root, MPI_Comm comm){
  * \endcode
  */
 template<bool binary = TasGrid::mode_binary>
-int MPIGridScatterOutputs(TasmanianSparseGrid const &source, TasmanianSparseGrid &destination, int root, int tag_size, int tag_data, MPI_Comm comm){
+int MPIGridScatterOutputs(TasmanianSparseGrid const &source, TasmanianSparseGrid &destination, int root, int tag, MPI_Comm comm){
     int me = getMPIRank(comm); // my rank within the comm
 
     if (me == root){ // splitting and sending the grid
@@ -307,21 +290,21 @@ int MPIGridScatterOutputs(TasmanianSparseGrid const &source, TasmanianSparseGrid
             if (rank == root){ // this is me, take my own copy of the grid
                 destination = copyGrid(source, offset(rank), offset(rank+1));
             }else{ // send the grid out
-                auto result = MPIGridSend<binary>(copyGrid(source, offset(rank), offset(rank+1)) , rank, tag_size, tag_data, comm);
+                auto result = MPIGridSend<binary>(copyGrid(source, offset(rank), offset(rank+1)) , rank, tag, comm);
                 if (result != MPI_SUCCESS) return result;
             }
         }
         for(int rank=num_effective_ranks; rank<num_ranks; rank++){ // if there are any grid remaining, set those to empty
             if (rank == root){ // this is me, take my own copy of the grid
-                destination = TasmanianSparseGrid();
+                destination = makeEmpty();
             }else{ // send the grid out
-                auto result = MPIGridSend<binary>(TasmanianSparseGrid() , rank, tag_size, tag_data, comm);
+                auto result = MPIGridSend<binary>(makeEmpty() , rank, tag, comm);
                 if (result != MPI_SUCCESS) return result;
             }
         }
         return MPI_SUCCESS; // if we got here, all was successful
     }else{ // receiving a grid
-        return MPIGridRecv<binary>(destination, root, tag_size, tag_data, comm);
+        return MPIGridRecv<binary>(destination, root, tag, comm);
     }
 }
 

--- a/DREAM/tsgDreamLikelihoodCore.hpp
+++ b/DREAM/tsgDreamLikelihoodCore.hpp
@@ -78,7 +78,7 @@ public:
     virtual void getLikelihood(TypeSamplingForm form, const std::vector<double> &model, std::vector<double> &likely) const = 0;
 
     //! \brief Return the number of expected model outputs.
-    virtual int getNumOuputs() const = 0;
+    virtual int getNumOutputs() const = 0;
 };
 
 }

--- a/DREAM/tsgDreamLikelyGaussian.hpp
+++ b/DREAM/tsgDreamLikelyGaussian.hpp
@@ -81,6 +81,36 @@ public:
     //! \brief Returns the size of the \b data_mean vector (for error checking purposes).
     int getNumOuputs() const{ return (int) data.size(); }
 
+    /*!
+     * \brief Writes the data for a portion of the outputs into a stream.
+     *
+     * The likelihood object does not store the raw inputs to setData(), instead optimized data-structures are used.
+     * This method writes either entire likelihood or the optimized data for a portion of the outputs.
+     *
+     * \param os is the stream where the data will be written.
+     * \param outputs_begin is the first output to include in the write process.
+     * \param outputs_end is one more than the last output to write,
+     *      use -1 to indicate all outputs after \b output_begin.
+     *
+     * This method is used by the MPI scatter likelihood template.
+     */
+    void write(std::ostream &os, int outputs_begin = 0, int outputs_end = -1) const{
+        if (outputs_end < 0) outputs_end = getNumOuputs();
+        outputs_end = std::min(std::max(outputs_begin + 1, outputs_end), getNumOuputs());
+        int num_entries = outputs_end - outputs_begin;
+        TasGrid::IO::writeNumbers<TasGrid::mode_binary, TasGrid::IO::pad_none>(os, num_entries);
+        TasGrid::IO::writeNumbers<TasGrid::mode_binary, TasGrid::IO::pad_none>(os, scale);
+        os.write((char*) &data[outputs_begin], num_entries * sizeof(double));
+    }
+
+    //! \brief Reads the data from a stream, assumes write() has been used first.
+    void read(std::istream &is){
+        int num_entries = TasGrid::IO::readNumber<TasGrid::mode_binary, int>(is);
+        scale = TasGrid::IO::readNumber<TasGrid::mode_binary, double>(is);
+        data = std::vector<double>((size_t) num_entries);
+        TasGrid::IO::readVector<TasGrid::mode_binary>(is, data);
+    }
+
 private:
     std::vector<double> data;
     double scale;
@@ -126,6 +156,29 @@ public:
 
     //! \brief Returns the size of the \b data_mean vector (for error checking purposes).
     int getNumOuputs() const{ return (int) noise_variance.size(); }
+
+    /*!
+     * \brief Writes the data for a portion of the outputs into a stream.
+     *
+     * See LikelihoodGaussIsotropic::write().
+     */
+    void write(std::ostream &os, int outputs_begin = 0, int outputs_end = -1) const{
+        if (outputs_end < 0) outputs_end = getNumOuputs();
+        outputs_end = std::min(std::max(outputs_begin + 1, outputs_end), getNumOuputs());
+        int num_entries = outputs_end - outputs_begin;
+        TasGrid::IO::writeNumbers<TasGrid::mode_binary, TasGrid::IO::pad_none>(os, num_entries);
+        os.write((char*) &data_by_variance[outputs_begin], num_entries * sizeof(double));
+        os.write((char*) &noise_variance[outputs_begin], num_entries * sizeof(double));
+    }
+
+    //! \brief Reads the data from a stream, assumes write() has been used first.
+    void read(std::istream &is){
+        int num_entries = TasGrid::IO::readNumber<TasGrid::mode_binary, int>(is);
+        data_by_variance = std::vector<double>((size_t) num_entries);
+        noise_variance   = std::vector<double>((size_t) num_entries);
+        TasGrid::IO::readVector<TasGrid::mode_binary>(is, data_by_variance);
+        TasGrid::IO::readVector<TasGrid::mode_binary>(is, noise_variance);
+    }
 
 private:
     std::vector<double> data_by_variance;

--- a/DREAM/tsgDreamLikelyGaussian.hpp
+++ b/DREAM/tsgDreamLikelyGaussian.hpp
@@ -79,7 +79,7 @@ public:
     void getLikelihood(TypeSamplingForm form, const std::vector<double> &model, std::vector<double> &likely) const;
 
     //! \brief Returns the size of the \b data_mean vector (for error checking purposes).
-    int getNumOuputs() const{ return (int) data.size(); }
+    int getNumOutputs() const{ return (int) data.size(); }
 
     /*!
      * \brief Writes the data for a portion of the outputs into a stream.
@@ -95,8 +95,8 @@ public:
      * This method is used by the MPI scatter likelihood template.
      */
     void write(std::ostream &os, int outputs_begin = 0, int outputs_end = -1) const{
-        if (outputs_end < 0) outputs_end = getNumOuputs();
-        outputs_end = std::min(std::max(outputs_begin + 1, outputs_end), getNumOuputs());
+        if (outputs_end < 0) outputs_end = getNumOutputs();
+        outputs_end = std::min(std::max(outputs_begin + 1, outputs_end), getNumOutputs());
         int num_entries = outputs_end - outputs_begin;
         TasGrid::IO::writeNumbers<TasGrid::mode_binary, TasGrid::IO::pad_none>(os, num_entries);
         TasGrid::IO::writeNumbers<TasGrid::mode_binary, TasGrid::IO::pad_none>(os, scale);
@@ -155,7 +155,7 @@ public:
     void getLikelihood(TypeSamplingForm form, std::vector<double> const &model, std::vector<double> &likely) const;
 
     //! \brief Returns the size of the \b data_mean vector (for error checking purposes).
-    int getNumOuputs() const{ return (int) noise_variance.size(); }
+    int getNumOutputs() const{ return (int) noise_variance.size(); }
 
     /*!
      * \brief Writes the data for a portion of the outputs into a stream.
@@ -163,8 +163,8 @@ public:
      * See LikelihoodGaussIsotropic::write().
      */
     void write(std::ostream &os, int outputs_begin = 0, int outputs_end = -1) const{
-        if (outputs_end < 0) outputs_end = getNumOuputs();
-        outputs_end = std::min(std::max(outputs_begin + 1, outputs_end), getNumOuputs());
+        if (outputs_end < 0) outputs_end = getNumOutputs();
+        outputs_end = std::min(std::max(outputs_begin + 1, outputs_end), getNumOutputs());
         int num_entries = outputs_end - outputs_begin;
         TasGrid::IO::writeNumbers<TasGrid::mode_binary, TasGrid::IO::pad_none>(os, num_entries);
         os.write((char*) &data_by_variance[outputs_begin], num_entries * sizeof(double));

--- a/DREAM/tsgDreamSamplePosterior.hpp
+++ b/DREAM/tsgDreamSamplePosterior.hpp
@@ -70,7 +70,7 @@ makePDFPosterior(TasmanianLikelihood const &likelihood,
                  std::function<void(std::vector<double> const &candidates, std::vector<double> &values)> &model,
                  std::function<void(std::vector<double> const &candidates, std::vector<double> &values)> &prior){
     return [&](const std::vector<double> &candidates, std::vector<double> &values)->void{
-        std::vector<double> model_outs(likelihood.getNumOuputs() * values.size());
+        std::vector<double> model_outs(likelihood.getNumOutputs() * values.size());
         model(candidates, model_outs);
         likelihood.getLikelihood(form, model_outs, values);
 

--- a/Doxygen/CMakeLists.txt
+++ b/Doxygen/CMakeLists.txt
@@ -82,6 +82,7 @@ doxygen_add_docs(Tasmanian_doxygen
                  Addons/tsgMPIConstructGrid.hpp
                  Addons/tsgConstructSurrogate.hpp
                  Addons/tsgCandidateManager.hpp
+                 Addons/tsgMPIScatterDREAM.hpp
                  Addons/tsgMPIScatterGrid.hpp
                  Addons/tsgLoadNeededValues.hpp
                  Addons/tsgAddonsCommon.hpp


### PR DESCRIPTION
* switched all MPI send/recv commands for objects to a single MPI API call
* added methods to send/recv/scatter a Bayesian likelihood across an MPI comm