### PR TITLE
fixed fortran examples memory leak

### DIFF
--- a/InterfaceFortran/Examples/example_sparse_grids.f90
+++ b/InterfaceFortran/Examples/example_sparse_grids.f90
@@ -396,6 +396,7 @@ IMPLICIT NONE
   WRITE(*,*)
   DEALLOCATE(res)
 
+  CALL tsgDeallocateGrid(grid)
 
 ! prepare random smaples for future tests
   call random_seed()


### PR DESCRIPTION
* fixed mem leak in fortran examples