### PR TITLE
Display logs

### DIFF
--- a/Config/AltBuildSystems/tasgridLogs.hpp
+++ b/Config/AltBuildSystems/tasgridLogs.hpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017, Miroslav Stoyanov
+ *
+ * This file is part of
+ * Toolkit for Adaptive Stochastic Modeling And Non-Intrusive ApproximatioN: TASMANIAN
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * UT-BATTELLE, LLC AND THE UNITED STATES GOVERNMENT MAKE NO REPRESENTATIONS AND DISCLAIM ALL WARRANTIES, BOTH EXPRESSED AND IMPLIED.
+ * THERE ARE NO EXPRESS OR IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE SOFTWARE WILL NOT INFRINGE ANY PATENT,
+ * COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS, OR THAT THE SOFTWARE WILL ACCOMPLISH THE INTENDED RESULTS OR THAT THE SOFTWARE OR ITS USE WILL NOT RESULT IN INJURY OR DAMAGE.
+ * THE USER ASSUMES RESPONSIBILITY FOR ALL LIABILITIES, PENALTIES, FINES, CLAIMS, CAUSES OF ACTION, AND COSTS AND EXPENSES, CAUSED BY, RESULTING FROM OR ARISING OUT OF,
+ * IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
+ */
+
+void show_log(){
+    std::cout << "Logs are not availeble with GNU Make" << std::endl;
+}
+
+void show_cmake_log(){
+    std::cout << "Logs are not availeble with GNU Make" << std::endl;
+}

--- a/Config/CMakeIncludes/CMakeLists.txt
+++ b/Config/CMakeIncludes/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # Do not put any other code here, this is for human readability only
 ########################################################################
-set(Tasmanian_post_install "--------------------------------------------------------------------------------\n")
+set(Tasmanian_post_install "--------------------------------------------------------------------------------\n\n")
 set(Tasmanian_post_install "${Tasmanian_post_install}Tasmanian Install Complete: Installed Version ${Tasmanian_VERSION_MAJOR}.${Tasmanian_VERSION_MINOR}${Tasmanian_version_comment}\n\n")
 set(Tasmanian_post_install "${Tasmanian_post_install}executable:\n    tasgrid${CMAKE_EXECUTABLE_SUFFIX_CXX}\n")
 
@@ -24,9 +24,9 @@ endforeach()
 unset(TSGLTYPE)
 unset(_tsglibtype)
 
-set(Tasmanian_post_install "${Tasmanian_post_install}\nsee the examples:\n    ${CMAKE_INSTALL_PREFIX}/share/Tasmanian/examples/\n\n")
+set(Tasmanian_post_install "${Tasmanian_post_install}\nsee the examples:\n    ${Tasmanian_final_install_path}/share/Tasmanian/examples/\n\n")
 
-set(Tasmanian_post_install "${Tasmanian_post_install}bash environment setup:\n    source ${CMAKE_INSTALL_PREFIX}/config/TasmanianENVsetup.sh\n\n")
+set(Tasmanian_post_install "${Tasmanian_post_install}bash environment setup:\n    source ${Tasmanian_final_install_path}/config/TasmanianENVsetup.sh\n\n")
 
 set(Tasmanian_post_install "${Tasmanian_post_install}cmake package config:\n    find_package(Tasmanian ${Tasmanian_VERSION_MAJOR}.${Tasmanian_VERSION_MINOR}.${Tasmanian_VERSION_PATCH} PATHS \\\"${CMAKE_INSTALL_PREFIX}/lib/\\\")\n\n")
 set(Tasmanian_post_install "${Tasmanian_post_install}    targets: Tasmanian::tasgrid    (executable)\n")
@@ -39,7 +39,7 @@ unset(_tsglibtype)
 set(Tasmanian_post_install "${Tasmanian_post_install}             Tasmanian::Tasmanian  (alias to static/shared)\n")
 set(Tasmanian_post_install "${Tasmanian_post_install}\n")
 
-if (Tasmanian_ENABLE_PYTHON)
+if (Tasmanian_ENABLE_PYTHON AND ("${Tasmanian_final_install_path}" STREQUAL "${CMAKE_INSTALL_PREFIX}"))
     set(Tasmanian_post_install "${Tasmanian_post_install}python module and the sym-link alternative:\n")
     set(Tasmanian_post_install "${Tasmanian_post_install}    ${Tasmanian_python_install_path}/Tasmanian.py\n    ${CMAKE_INSTALL_PREFIX}/share/Tasmanian/python/Tasmanian.py\n\n")
     set(Tasmanian_post_install "${Tasmanian_post_install}    import sys\n")
@@ -48,8 +48,8 @@ if (Tasmanian_ENABLE_PYTHON)
 endif()
 
 if (NOT "${Tasmanian_MATLAB_WORK_FOLDER}" STREQUAL "")
-    set(Tasmanian_post_install "${Tasmanian_post_install}matlab scripts location:\n    ${CMAKE_INSTALL_PREFIX}/share/Tasmanian/matlab/\n\n")
-    set(Tasmanian_post_install "${Tasmanian_post_install}    addpath('${CMAKE_INSTALL_PREFIX}/share/Tasmanian/matlab/')\n")
+    set(Tasmanian_post_install "${Tasmanian_post_install}matlab scripts location:\n    ${Tasmanian_final_install_path}/share/Tasmanian/matlab/\n\n")
+    set(Tasmanian_post_install "${Tasmanian_post_install}    addpath('${Tasmanian_final_install_path}/share/Tasmanian/matlab/')\n")
 endif()
 set(Tasmanian_post_install "${Tasmanian_post_install}--------------------------------------------------------------------------------\n")
 

--- a/Config/CMakeIncludes/setup_message.cmake
+++ b/Config/CMakeIncludes/setup_message.cmake
@@ -37,6 +37,9 @@ if (NOT "${Tasmanian_MATLAB_WORK_FOLDER}" STREQUAL "")
 endif()
 message(STATUS "")
 
+# configure the headers for the logs
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/SparseGrids/tasgridLogs.in.hpp" "${CMAKE_CURRENT_BINARY_DIR}/configured/tasgridLogs.hpp")
+
 ########################################################################
 # Print final message (a bit of a hack)
 # The message is written in the CMakeLists.txt, as the subdir is added last

--- a/InterfacePython/Tasmanian.py
+++ b/InterfacePython/Tasmanian.py
@@ -43,3 +43,10 @@ SparseGrid = TasmanianSparseGrid
 import TasmanianDREAM as DREAM
 
 from TasmanianAddons import *
+
+if __name__ == "__main__":
+    with open(TasmanianConfig.__path_logfile__, 'r') as logfile:
+        print("")
+        print(logfile.read())
+    # this is a test for creating a simple grid
+    grid = makeLocalPolynomialGrid(2, 1, 1, 1, "localp")

--- a/InterfacePython/TasmanianConfig.in.py
+++ b/InterfacePython/TasmanianConfig.in.py
@@ -39,6 +39,7 @@ __git_commit_hash__ = "@Tasmanian_git_hash@"
 __path_libsparsegrid__ = "@Tasmanian_libsparsegrid_path@"
 __path_libdream__      = "@Tasmanian_libdream_path@"
 __path_libcaddons__    = "@Tasmanian_libcaddons_path@"
+__path_logfile__       = "@Tasmanian_final_install_path@/share/Tasmanian/Tasmanian.log"
 
 # the transitive library dependencies on Linux/OsX are handled by rpath, Windows needs help
 if "@CMAKE_SYSTEM_NAME@" == "Windows":

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ALL_TARGETS = GaussPattersonRule.table \
 DREAM_EXAMPLES_OBJ = $(patsubst ./DREAM/Examples/%,%,$(patsubst %.cpp,%.o,$(wildcard ./DREAM/Examples/example_dream*.cpp)))
 SG_EXAMPLES_OBJ = $(patsubst ./SparseGrids/Examples/%,%,$(patsubst %.cpp,%.o,$(wildcard ./SparseGrids/Examples/example_sparse_grids*.cpp)))
 
-CONFIGURED_HEADERS = ./SparseGrids/TasmanianConfig.hpp
+CONFIGURED_HEADERS = ./SparseGrids/TasmanianConfig.hpp ./SparseGrids/tasgridLogs.hpp
 
 # all target
 .PHONY: all
@@ -58,6 +58,9 @@ SparseGrids/TasmanianConfig.hpp: ./Config/AltBuildSystems/TasmanianConfig.hpp
 include/TasmanianConfig.hpp: ./SparseGrids/TasmanianConfig.hpp
 	mkdir -p ./include
 	cp ./SparseGrids/TasmanianConfig.hpp ./include/
+
+./SparseGrids/tasgridLogs.hpp: ./Config/AltBuildSystems/tasgridLogs.hpp
+	cp ./Config/AltBuildSystems/tasgridLogs.hpp ./SparseGrids/tasgridLogs.hpp
 
 include/Tasmanian.hpp: ./Config/Tasmanian.hpp
 	mkdir -p ./include
@@ -239,6 +242,7 @@ clean:
 	rm -fr *.py
 	rm -fr include
 	rm -fr ./SparseGrids/TasmanianConfig.hpp
+	rm -fr ./SparseGrids/tasgridLogs.hpp
 	rm -fr ./InterfacePython/testConfigureData.py
 	cd SparseGrids; make clean
 	cd DREAM; make clean

--- a/SparseGrids/tasgridLogs.in.hpp
+++ b/SparseGrids/tasgridLogs.in.hpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2017, Miroslav Stoyanov
+ *
+ * This file is part of
+ * Toolkit for Adaptive Stochastic Modeling And Non-Intrusive ApproximatioN: TASMANIAN
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * UT-BATTELLE, LLC AND THE UNITED STATES GOVERNMENT MAKE NO REPRESENTATIONS AND DISCLAIM ALL WARRANTIES, BOTH EXPRESSED AND IMPLIED.
+ * THERE ARE NO EXPRESS OR IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE SOFTWARE WILL NOT INFRINGE ANY PATENT,
+ * COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS, OR THAT THE SOFTWARE WILL ACCOMPLISH THE INTENDED RESULTS OR THAT THE SOFTWARE OR ITS USE WILL NOT RESULT IN INJURY OR DAMAGE.
+ * THE USER ASSUMES RESPONSIBILITY FOR ALL LIABILITIES, PENALTIES, FINES, CLAIMS, CAUSES OF ACTION, AND COSTS AND EXPENSES, CAUSED BY, RESULTING FROM OR ARISING OUT OF,
+ * IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
+ */
+
+#include <iostream>
+#include <fstream>
+
+void show_log(){
+    std::ifstream logfile("@Tasmanian_final_install_path@/share/Tasmanian/Tasmanian.log");
+    std::cout << "\n" << logfile.rdbuf() << std::endl;
+}
+
+void show_cmake_log(){
+    std::cout << "\n--------------------------------------------------------------------------------\nCMake parameters:\n"
+    << "CMAKE_COMMAND                      @CMAKE_COMMAND@\n"
+    << "CMAKE_BUILD_TYPE                   @CMAKE_BUILD_TYPE@\n"
+    << "CMAKE_INSTALL_PREFIX               @CMAKE_INSTALL_PREFIX@\n"
+    << "CMAKE_CXX_FLAGS                    @CMAKE_CXX_FLAGS@\n"
+    << "CMAKE_CXX_FLAGS_DEBUG              @CMAKE_CXX_FLAGS_DEBUG@\n"
+    << "CMAKE_CXX_FLAGS_RELEASE            @CMAKE_CXX_FLAGS_RELEASE@\n"
+    << "CMAKE_CXX_COMPILER                 @CMAKE_CXX_COMPILER@\n"
+    << "CMAKE_CUDA_COMPILER                @CMAKE_CUDA_COMPILER@\n"
+    << "CMAKE_CUDA_FLAGS                   @CMAKE_CUDA_FLAGS@\n"
+    << "CMAKE_CUDA_FLAGS_DEBUG             @CMAKE_CUDA_FLAGS_DEBUG@\n"
+    << "CMAKE_CUDA_FLAGS_RELEASE           @CMAKE_CUDA_FLAGS_RELEASE@\n"
+    << "PYTHON_EXECUTABLE                  @PYTHON_EXECUTABLE@\n"
+    << "BUILD_SHARED_LIBS                  @BUILD_SHARED_LIBS@\n"
+    << "BLAS_LIBRARIES                     @BLAS_LIBRARIES@\n"
+    << "CMAKE_THREAD_LIBS_INIT             @CMAKE_THREAD_LIBS_INIT@\n"
+    << "OpenMP_CXX_LIBRARIES               @OpenMP_CXX_LIBRARIES@\n"
+    << "OpenMP_CXX_FLAGS                   @OpenMP_CXX_FLAGS@\n"
+    << "MPI_CXX_LIBRARIES                  @MPI_CXX_LIBRARIES@\n"
+    << "MPI_CXX_INCLUDE_PATH               @MPI_CXX_INCLUDE_PATH@\n"
+    << "MPI_CXX_COMPILE_FLAGS              @MPI_CXX_COMPILE_FLAGS@\n"
+    << "MPI_CXX_LINK_FLAGS                 @MPI_CXX_LINK_FLAGS@\n"
+    << "MPIEXEC_EXECUTABLE                 @MPIEXEC_EXECUTABLE@\n"
+    << "Tasmanian_ENABLE_RECOMMENDED       @Tasmanian_ENABLE_RECOMMENDED@\n"
+    << "Tasmanian_ENABLE_OPENMP            @Tasmanian_ENABLE_OPENMP@\n"
+    << "Tasmanian_ENABLE_BLAS              @Tasmanian_ENABLE_BLAS@\n"
+    << "Tasmanian_ENABLE_PYTHON            @Tasmanian_ENABLE_PYTHON@\n"
+    << "Tasmanian_ENABLE_CUDA              @Tasmanian_ENABLE_CUDA@\n"
+    << "Tasmanian_ENABLE_FORTRAN           @Tasmanian_ENABLE_FORTRAN@\n"
+    << "Tasmanian_ENABLE_MPI               @Tasmanian_ENABLE_MPI@\n"
+    << "Tasmanian_ENABLE_MAGMA             @Tasmanian_ENABLE_MAGMA@\n"
+    << "Tasmanian_MATLAB_WORK_FOLDER       @Tasmanian_MATLAB_WORK_FOLDER@\n"
+    << "Tasmanian_ENABLE_DOXYGEN           @Tasmanian_ENABLE_DOXYGEN@\n"
+    << "DOXYGEN_INTERNAL_DOCS              @DOXYGEN_INTERNAL_DOCS@\n"
+    << "Tasmanian_PYTHONPATH               @Tasmanian_PYTHONPATH@\n"
+    << "Tasmanian_final_install_path       @Tasmanian_final_install_path@\n"
+    << "--------------------------------------------------------------------------------\n"
+    << std::endl;
+}

--- a/SparseGrids/tasgrid_main.cpp
+++ b/SparseGrids/tasgrid_main.cpp
@@ -30,6 +30,7 @@
 
 #include "tasgridExternalTests.hpp"
 #include "tasgridWrapper.hpp"
+#include "tasgridLogs.hpp"
 
 using namespace std;
 using namespace TasGrid;
@@ -57,6 +58,16 @@ int main(int argc, const char ** argv){
     // basic help
     if (hasHelp(args.front())){
         printHelp();
+        return 0;
+    }
+
+    // print log files
+    if(args.front() == "-log"){
+        show_log();
+        return 0;
+    }
+    if(args.front() == "-cmakelog"){
+        show_cmake_log();
         return 0;
     }
 


### PR DESCRIPTION
* `tasgrid -log` and `python -m Tasmanian` now dump the install log
* `tasgrid -cmakelog` now dumps a bunch of CMAKE parameters
* scikit deletes the temp build folder after install, this gives a fighting change to debug CMAKE issues when running pip-install