### PR TITLE
skip testing build when merging

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -4,6 +4,11 @@ pipeline {
     }
     stages {
         stage('Automated testing') {
+            when {
+                not {
+                    branch 'master'
+                }
+            }
             parallel {
                 stage('Clang50-Python3') {
                     agent {


### PR DESCRIPTION
Skip the tests when building the documentation right after merging a PR.