### PR TITLE
Cmake split fortran cxx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog for version 7.1
 --------------
 
+* split the Tasmanian::Tasmanian and Tasmanian::Fortran targets
+    * also added Tasmanian::Fortran::shared and Tasmanian::Fortran::static
 * added mixed-precision templates for
     * `evaluateBatchGPU()` and `evaluateHierarchicalFunctionsGPU()`
     * `evaluateBatch()` when the acceleration mode is cuda or magma

--- a/Config/CMakeIncludes/CMakeLists.txt
+++ b/Config/CMakeIncludes/CMakeLists.txt
@@ -24,20 +24,35 @@ endforeach()
 unset(TSGLTYPE)
 unset(_tsglibtype)
 
+if (Tasmanian_ENABLE_FORTRAN)
+    set(Tasmanian_post_install "${Tasmanian_post_install}Fortran module:\n")
+    set(Tasmanian_post_install "${Tasmanian_post_install}    tasmaniansg.mod\n")
+endif()
+
 set(Tasmanian_post_install "${Tasmanian_post_install}\nsee the examples:\n    ${Tasmanian_final_install_path}/share/Tasmanian/examples/\n\n")
 
 set(Tasmanian_post_install "${Tasmanian_post_install}bash environment setup:\n    source ${Tasmanian_final_install_path}/share/Tasmanian/TasmanianENVsetup.sh\n\n")
 
 set(Tasmanian_post_install "${Tasmanian_post_install}cmake package config:\n    find_package(Tasmanian ${Tasmanian_VERSION_MAJOR}.${Tasmanian_VERSION_MINOR}.${Tasmanian_VERSION_PATCH} PATHS \\\"${Tasmanian_final_install_path}/lib/\\\")\n\n")
-set(Tasmanian_post_install "${Tasmanian_post_install}    targets: Tasmanian::tasgrid    (executable)\n")
+set(Tasmanian_post_install "${Tasmanian_post_install}    CXX targets:\n")
+set(Tasmanian_post_install "${Tasmanian_post_install}             Tasmanian::tasgrid    (executable)\n")
 
 foreach(_tsglibtype ${Tasmanian_libs_type})
     set(Tasmanian_post_install "${Tasmanian_post_install}             Tasmanian::${_tsglibtype}     (${_tsglibtype} libraries)\n")
 endforeach()
 unset(_tsglibtype)
+set(Tasmanian_post_install "${Tasmanian_post_install}             Tasmanian::Tasmanian  (alias to static/shared)\n\n")
 
-set(Tasmanian_post_install "${Tasmanian_post_install}             Tasmanian::Tasmanian  (alias to static/shared)\n")
-set(Tasmanian_post_install "${Tasmanian_post_install}\n")
+set(Tasmanian_post_install "${Tasmanian_post_install}    Fortran targets:\n")
+if (Tasmanian_ENABLE_FORTRAN)
+    foreach(_tsglibtype ${Tasmanian_libs_type})
+        set(Tasmanian_post_install "${Tasmanian_post_install}             Tasmanian::Fortran::${_tsglibtype}   (${_tsglibtype} libraries)\n")
+    endforeach()
+    unset(_tsglibtype)
+
+    set(Tasmanian_post_install "${Tasmanian_post_install}             Tasmanian::Fortran           (alias to static/shared)\n\n")
+endif()
+
 set(Tasmanian_post_install "${Tasmanian_post_install}    see also:\n        ${Tasmanian_final_install_path}/share/Tasmanian/examples/CMakeLists.txt\n")
 set(Tasmanian_post_install "${Tasmanian_post_install}\n")
 

--- a/Config/CMakeIncludes/all_examples.cmake
+++ b/Config/CMakeIncludes/all_examples.cmake
@@ -31,5 +31,5 @@ if (Tasmanian_ENABLE_FORTRAN)
     set_target_properties(Tasmanian_example_sparse_grids_f90 PROPERTIES
                             OUTPUT_NAME "example_sparse_grids_f90"
                             LINKER_LANGUAGE Fortran)
-    target_link_libraries(Tasmanian_example_sparse_grids_f90 Tasmanian_master)
+    target_link_libraries(Tasmanian_example_sparse_grids_f90 Tasmanian_libfortran90_${Tasmanian_lib_default})
 endif()

--- a/Config/CMakeIncludes/exports.cmake
+++ b/Config/CMakeIncludes/exports.cmake
@@ -65,6 +65,10 @@ unset(_comp)
 if (NOT "${Tasmanian_MATLAB_WORK_FOLDER}" STREQUAL "")
     set(Tasmanian_components "${Tasmanian_components} MATLAB")
 endif()
+set(Tasmanian_langs "CXX")
+if (Tasmanian_ENABLE_FORTRAN)
+    set(Tasmanian_langs "${Tasmanian_langs} Fortran")
+endif()
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Config/CMakeLists.examples.txt" "${CMAKE_CURRENT_BINARY_DIR}/configured/CMakeLists.txt" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/CMakeLists.txt"
         DESTINATION "share/Tasmanian/examples/"

--- a/Config/CMakeIncludes/master_targets.cmake
+++ b/Config/CMakeIncludes/master_targets.cmake
@@ -20,7 +20,8 @@ foreach(_tsglibtype ${Tasmanian_libs_type})
         set_target_properties(Tasmanian::${_tsglibtype} PROPERTIES INTERFACE_LINK_LIBRARIES Tasmanian_${_tsglibtype})
     endif()
     if (TARGET Tasmanian_libfortran90_${_tsglibtype})
-        target_link_libraries(Tasmanian_${_tsglibtype} INTERFACE Tasmanian_libfortran90_${_tsglibtype})
+        add_library(Tasmanian::Fortran::${_tsglibtype} INTERFACE IMPORTED GLOBAL)
+        target_link_libraries(Tasmanian::Fortran::${_tsglibtype} INTERFACE Tasmanian_libfortran90_${_tsglibtype})
     endif()
 endforeach()
 unset(_tsglibtype)
@@ -31,7 +32,7 @@ install(TARGETS Tasmanian_master EXPORT "${Tasmanian_export_name}")
 
 if (Tasmanian_ENABLE_FORTRAN)
     add_library(Tasmanian::Fortran INTERFACE IMPORTED GLOBAL)
-    set_target_properties(Tasmanian::Fortran PROPERTIES INTERFACE_LINK_LIBRARIES Tasmanian::Tasmania)
+    set_target_properties(Tasmanian::Fortran PROPERTIES INTERFACE_LINK_LIBRARIES Tasmanian_libfortran90_${Tasmanian_lib_default})
 endif()
 
 # add executable that has the sole purpose of testing the master target

--- a/Config/CMakeLists.examples.txt
+++ b/Config/CMakeLists.examples.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.10)
-cmake_policy(VERSION 3.10)
+cmake_minimum_required(VERSION @CMAKE_MAJOR_VERSION@.@CMAKE_MINOR_VERSION@)
+cmake_policy(VERSION @CMAKE_MAJOR_VERSION@.@CMAKE_MINOR_VERSION@)
 project(Tasmanian_Examples VERSION @Tasmanian_VERSION_MAJOR@.@Tasmanian_VERSION_MINOR@.@Tasmanian_VERSION_PATCH@ LANGUAGES @Tasmanian_langs@)
 
 # the following find_package() command will help us locate an existing Tasmanian installation.
@@ -16,16 +16,18 @@ find_package(Tasmanian @Tasmanian_VERSION_MAJOR@.@Tasmanian_VERSION_MINOR@.@Tasm
 #                    for example using -DCMAKE_PREFIX_PATH="@CMAKE_INSTALL_PREFIX@/lib/"
 #  Tasmanian_DIR or Tasmanian_ROOT environment variables (depending on the version of CMake)
 
-# Tasmanian::Tasmanian will be the name of the IMPORTED master target.
-# The master target includes all of the Tasmanian C++ and Fortran libraries.
+# Tasmanian::Tasmanian will be the name of the IMPORTED master C++ target.
 # Tasmanian::Tasmanian will point to the shared libraries if the static libraries are not available
 #                      or if the SHARED component is requested without the STATIC one.
 # Tasmanian::Tasmanian will point to the static libraries in all other cases.
+# Tasmanian::Fortran will follow the same logic as Tasmanian::Tasmanian but use Fortran instead
 
 # Additional targets:
 #  Tasmanian::shared will point to the shared libraries, if those are available
 #  Tasmanian::static will point to the static libraries, if those are available
 #  Tasmanian::tasgrid will point to the executable ./tasgrid@CMAKE_EXECUTABLE_SUFFIX_CXX@
+#  Tasmanian::Fortran::shared will point to the shared Fortran libraries
+#  Tasmanian::Fortran::static will point to the static Fortran libraries
 
 # Additional variables (if the corresponding options have been enabled):
 #  Tasmanian_PYTHONPATH is the path to the python scripts
@@ -55,14 +57,15 @@ add_executable(example_dream         example_dream_01.cpp
 target_link_libraries(example_sparse_grids  Tasmanian::Tasmanian)
 target_link_libraries(example_dream         Tasmanian::Tasmanian)
 
-# if Fortran was enabled on compile time
+# if the Fortran component was found
+# can also use "if (TARGET Tasmanian::Fortran)"
 if (Tasmanian_FORTRAN_FOUND)
     add_executable(example_sparse_grids_f90  example_sparse_grids.f90)
-    target_link_libraries(example_sparse_grids_f90  Tasmanian::Tasmanian)
-    # also available is the Tasmanian::Fortran target
-    # Tasmanian::Fortran is equivalent to Tasmanian::Tasmanian but has more expressive name
+    target_link_libraries(example_sparse_grids_f90  Tasmanian::Fortran)
+    # note that as of 7.1 Tasmanian::Fortran is not equivalent to Tasmanian::Tasmanian
     set_property(TARGET example_sparse_grids_f90 PROPERTY LINKER_LANGUAGE Fortran)
     # the LINKER_LANGUAGE property is required by some compilers, e.g., Intel ifort
 endif()
 
+# Tasmanian also includes the executable target Tasmanian::tasgrid
 add_custom_command(TARGET example_sparse_grids PRE_BUILD COMMAND Tasmanian::tasgrid -v)

--- a/Config/CMakeLists.examples.txt
+++ b/Config/CMakeLists.examples.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 cmake_policy(VERSION 3.10)
-project(Tasmanian_Examples)
+project(Tasmanian_Examples VERSION @Tasmanian_VERSION_MAJOR@.@Tasmanian_VERSION_MINOR@.@Tasmanian_VERSION_PATCH@ LANGUAGES @Tasmanian_langs@)
 
 # the following find_package() command will help us locate an existing Tasmanian installation.
 find_package(Tasmanian @Tasmanian_VERSION_MAJOR@.@Tasmanian_VERSION_MINOR@.@Tasmanian_VERSION_PATCH@ PATHS "@Tasmanian_final_install_path@"
@@ -57,7 +57,6 @@ target_link_libraries(example_dream         Tasmanian::Tasmanian)
 
 # if Fortran was enabled on compile time
 if (Tasmanian_FORTRAN_FOUND)
-    enable_language(Fortran)
     add_executable(example_sparse_grids_f90  example_sparse_grids.f90)
     target_link_libraries(example_sparse_grids_f90  Tasmanian::Tasmanian)
     # also available is the Tasmanian::Fortran target

--- a/Doxygen/Installation.md
+++ b/Doxygen/Installation.md
@@ -281,7 +281,12 @@ The imported targets will be named:
   Tasmanian::static     (link to all static libraries, if static libraries were build)
   Tasmanian::Tasmanian  (always available and equivalent to either static or shared)
   Tasmanian::tasgrid    (imported executable pointing to the command line tool)
+  Tasmanian::Fortran::shared   (shared libraries for Fortran)
+  Tasmanian::Fortran::static   (static libraries for Fortran)
+  Tasmanian::Fortran           (equivalent to Tasmanian::Tasmanian but using Fortran)
 ```
+Note that the `Tasmanian::Tasmanian` and `Tasmanian::Fortran` targets are no longer equivalent (as of 7.1).
+
 In addition, the following variables will be set:
 ```
   Tasmanian_PYTHONPATH         (path to the Python module, if Python was enabled)


### PR DESCRIPTION
* split the Tasmanian::Tasmanian and the Tasmanian::Fortran into two targets
* updated the documentation to reflect the change