### PR TITLE
Enable hip magma

### DIFF
--- a/Addons/tsgLoadUnstructuredPoints.hpp
+++ b/Addons/tsgLoadUnstructuredPoints.hpp
@@ -209,9 +209,6 @@ inline void loadUnstructuredDataL2tmpl(double const data_points[], int num_data,
 
     Data2D<scalar_type> coefficients =
         [&]()->Data2D<scalar_type>{
-            #ifdef Tasmanian_ENABLE_HIP
-            if (grid.isFourier()) return generateCoefficients<scalar_type>(data_points, num_data, model_values, tolerance, grid);
-            #endif
             if (acceleration->mode == accel_gpu_cuda and hasGPUBasis(grid)){
                 acceleration->setDevice();
                 GpuVector<double> gpu_points(num_dimensions, num_data, data_points);

--- a/Addons/tsgLoadUnstructuredPoints.hpp
+++ b/Addons/tsgLoadUnstructuredPoints.hpp
@@ -210,7 +210,7 @@ inline void loadUnstructuredDataL2tmpl(double const data_points[], int num_data,
     Data2D<scalar_type> coefficients =
         [&]()->Data2D<scalar_type>{
             #ifdef Tasmanian_ENABLE_HIP
-            return generateCoefficients<scalar_type>(data_points, num_data, model_values, tolerance, grid);
+            if (grid.isFourier()) return generateCoefficients<scalar_type>(data_points, num_data, model_values, tolerance, grid);
             #endif
             if (acceleration->mode == accel_gpu_cuda and hasGPUBasis(grid)){
                 acceleration->setDevice();

--- a/Config/CMakeIncludes/FindTasmanianMagma.cmake
+++ b/Config/CMakeIncludes/FindTasmanianMagma.cmake
@@ -11,6 +11,10 @@
 #    Tasmanian_magma_h: path to the folder containing magma.h
 #    Tasmanian_magma: the libmagma library
 
+if (NOT MAGMA_ROOT)
+    set(MAGMA_ROOT "$ENV{MAGMA_ROOT}")
+endif()
+
 set(Tasmanian_MAGMA_ROOT "${MAGMA_ROOT}" CACHE PATH "The root folder for the MAGMA installation, e.g., containing lib and include folders")
 
 if (Tasmanian_MAGMA_ROOT)
@@ -34,3 +38,4 @@ endif()
 find_package_handle_standard_args(TasmanianMagma DEFAULT_MSG Tasmanian_magma Tasmanian_magma_h)
 
 unset(Tasmanian_magma_nodefault)
+unset(MAGMA_ROOT)

--- a/Config/CMakeIncludes/sanity_check_and_xsdk.cmake
+++ b/Config/CMakeIncludes/sanity_check_and_xsdk.cmake
@@ -132,8 +132,8 @@ endif()
 
 # check for MAGMA
 if (Tasmanian_ENABLE_MAGMA)
-    if (NOT Tasmanian_ENABLE_CUDA)
-        message(FATAL_ERROR "Currently Tasmanian can use only CUDA related capability from MAGMA, hence Tasmanian_ENABLE_CUDA must be set ON")
+    if (NOT Tasmanian_ENABLE_CUDA AND NOT Tasmanian_ENABLE_HIP)
+        message(FATAL_ERROR "Tasmanian uses the GPU capabilities of MAGMA thus either CUDA or HIP must be enabled too.")
     endif()
 
     find_package(TasmanianMagma REQUIRED)

--- a/InterfaceTPL/tsgCudaWrappers.cpp
+++ b/InterfaceTPL/tsgCudaWrappers.cpp
@@ -488,19 +488,7 @@ void solveLSmultiGPU(AccelerationContext const *acceleration, int n, int m, scal
 template void solveLSmultiGPU<double>(AccelerationContext const*, int, int, double[], int, double[]);
 template void solveLSmultiGPU<std::complex<double>>(AccelerationContext const*, int, int, std::complex<double>[], int, std::complex<double>[]);
 
-#ifdef Tasmanian_ENABLE_MAGMA
-template<typename scalar_type>
-void solveLSmultiOOC(AccelerationContext const *acceleration, int n, int m, scalar_type A[], int nrhs, scalar_type B[]){
-    initMagma(acceleration);
-    std::vector<scalar_type> tau(m);
-    auto AT = Utils::transpose(m, n, A);
-    auto BT = Utils::transpose(nrhs, n, B);
-    geqrf_ooc(n, m, AT.data(), n, tau.data());
-    gemqr_ooc(MagmaLeft, (std::is_same<scalar_type, double>::value) ? MagmaTrans : MagmaConjTrans, n, nrhs, m, AT.data(), n, tau.data(), BT.data(), n);
-    trsm_ooc(MagmaLeft, MagmaUpper, MagmaNoTrans, MagmaNonUnit, m, nrhs, 1.0, AT.data(), n, BT.data(), n);
-    Utils::transpose(n, nrhs, BT.data(), B);
-}
-#else
+#ifndef Tasmanian_ENABLE_MAGMA
 template<typename scalar_type>
 void solveLSmultiOOC(AccelerationContext const*, int, int, scalar_type[], int, scalar_type[]){}
 #endif

--- a/InterfaceTPL/tsgHipWrappers.cpp
+++ b/InterfaceTPL/tsgHipWrappers.cpp
@@ -300,8 +300,10 @@ void solveLSmultiGPU(AccelerationContext const *acceleration, int n, int m, scal
 template void solveLSmultiGPU<double>(AccelerationContext const*, int, int, double[], int, double[]);
 template void solveLSmultiGPU<std::complex<double>>(AccelerationContext const*, int, int, std::complex<double>[], int, std::complex<double>[]);
 
+#ifndef Tasmanian_ENABLE_MAGMA
 template<typename scalar_type>
 void solveLSmultiOOC(AccelerationContext const*, int, int, scalar_type[], int, scalar_type[]){}
+#endif
 
 template void solveLSmultiOOC<double>(AccelerationContext const*, int, int, double[], int, double[]);
 template void solveLSmultiOOC<std::complex<double>>(AccelerationContext const*, int, int, std::complex<double>[], int, std::complex<double>[]);

--- a/InterfaceTPL/tsgHipWrappers.cpp
+++ b/InterfaceTPL/tsgHipWrappers.cpp
@@ -279,11 +279,12 @@ inline void gemlq(rocblas_handle handle, int m, int n, int k, double A[], double
     hipcheck(rocsolver_dormlq(handle, rocblas_side_right, rocblas_operation_transpose, m, n, k, A, k, tau, C, m), "rocsolver_dormlq()");
 }
 //! \brief Wrapper around rocsolver_dunmlq(), does Q^T times C.
-inline void gemlq(rocblas_handle, int, int, int, std::complex<double>[], std::complex<double>[], std::complex<double>[]){
+inline void gemlq(rocblas_handle handle, int m, int n, int k, std::complex<double> A[], std::complex<double> tau[], std::complex<double> C[]){
+    hipcheck(rocsolver_zunmlq(handle, rocblas_side_right, rocblas_operation_conjugate_transpose, m, n, k,
+                              reinterpret_cast<rocblas_double_complex*>(A), k,
+                              reinterpret_cast<rocblas_double_complex*>(tau), reinterpret_cast<rocblas_double_complex*>(C), m),
+             "rocsolver_zunmlq()");
 }
-// inline void gemlq(rocblas_handle handle, int m, int n, int k, std::complex<double> A[], std::complex<double> tau[], std::complex<double> C[]){
-//     hipcheck(rocsolver_dunmlq(handle, rocblas_side_right, rocblas_operation_conjugate_transpose, m, n, k, reinterpret_cast<rocblas_double_complex*>(A), k, reinterpret_cast<rocblas_double_complex*>(tau), reinterpret_cast<rocblas_double_complex*>(C), m), "rocsolver_dunmlq()");
-// }
 
 /*
  * Algorithm section

--- a/InterfaceTPL/tsgHipWrappers.hpp
+++ b/InterfaceTPL/tsgHipWrappers.hpp
@@ -45,6 +45,11 @@
 #include <rocsparse.h>
 #include <rocsolver.h>
 
+#ifdef Tasmanian_ENABLE_MAGMA
+#define HAVE_HIP
+#include "tsgMagmaWrappers.hpp"
+#endif
+
 /*!
  * \file tsgHipWrappers.hpp
  * \brief Wrappers to HIP functionality.

--- a/SparseGrids/tsgAcceleratedDataStructures.hpp
+++ b/SparseGrids/tsgAcceleratedDataStructures.hpp
@@ -226,12 +226,14 @@ struct GpuEngine{
     GpuEngine()
     #ifdef Tasmanian_ENABLE_CUDA
                 : cublasHandle(nullptr), own_cublas_handle(false),
-                  cusparseHandle(nullptr), own_cusparse_handle(false), cusolverDnHandle(nullptr), own_cusolverdn_handle(false),
-                  called_magma_init(false)
+                  cusparseHandle(nullptr), own_cusparse_handle(false), cusolverDnHandle(nullptr), own_cusolverdn_handle(false)
     #endif
     #ifdef Tasmanian_ENABLE_HIP
                 : rocblasHandle(nullptr), own_rocblas_handle(false),
                   rocsparseHandle(nullptr), own_rocsparse_handle(false)
+    #endif
+    #ifdef Tasmanian_ENABLE_MAGMA
+                  , called_magma_init(false)
     #endif
         {}
     //! \brief Destructor, clear all handles and queues.
@@ -245,8 +247,10 @@ struct GpuEngine{
         cusparseHandle(Utils::exchange(other.cusparseHandle, nullptr)),
         own_cusparse_handle(Utils::exchange(other.own_cusparse_handle, false)),
         cusolverDnHandle(Utils::exchange(other.cusolverDnHandle, nullptr)),
-        own_cusolverdn_handle(Utils::exchange(other.own_cusolverdn_handle, false)),
-        called_magma_init(Utils::exchange(other.called_magma_init, false))
+        own_cusolverdn_handle(Utils::exchange(other.own_cusolverdn_handle, false))
+        #ifdef Tasmanian_ENABLE_MAGMA
+        , called_magma_init(Utils::exchange(other.called_magma_init, false))
+        #endif
         {}
     #else
     #ifdef Tasmanian_ENABLE_HIP
@@ -272,7 +276,9 @@ struct GpuEngine{
         std::swap(own_cusparse_handle, temp.own_cusparse_handle);
         std::swap(cusolverDnHandle, temp.cusolverDnHandle);
         std::swap(own_cusolverdn_handle, temp.own_cusolverdn_handle);
+        #ifdef Tasmanian_ENABLE_MAGMA
         std::swap(called_magma_init, temp.called_magma_init);
+        #endif
         return *this;
     }
     #else
@@ -284,6 +290,9 @@ struct GpuEngine{
         std::swap(own_rocblas_handle, temp.own_rocblas_handle);
         std::swap(rocsparseHandle, temp.rocsparseHandle);
         std::swap(own_rocsparse_handle, temp.own_rocsparse_handle);
+        #ifdef Tasmanian_ENABLE_MAGMA
+        std::swap(called_magma_init, temp.called_magma_init);
+        #endif
         return *this;
     }
     #else
@@ -311,8 +320,6 @@ struct GpuEngine{
     void *cusolverDnHandle;
     //! \brief Remembers the ownership of the handle.
     bool own_cusolverdn_handle;
-    //! \brief Remembers whether MAGMA init has been called.
-    bool called_magma_init;
     #endif
 
     #ifdef Tasmanian_ENABLE_HIP
@@ -324,6 +331,11 @@ struct GpuEngine{
     void *rocsparseHandle;
     //! \brief Remember the ownership of the handle.
     bool own_rocsparse_handle;
+    #endif
+
+    #ifdef Tasmanian_ENABLE_MAGMA
+    //! \brief Remembers whether MAGMA init has been called.
+    bool called_magma_init;
     #endif
 };
 

--- a/SparseGrids/tsgLinearSolvers.cpp
+++ b/SparseGrids/tsgLinearSolvers.cpp
@@ -100,9 +100,9 @@ void TasmanianDenseSolver::solveLeastSquares(AccelerationContext const *accelera
 template<typename scalar_type>
 void TasmanianDenseSolver::solvesLeastSquares(AccelerationContext const *acceleration, int n, int m, scalar_type A[], int nrhs, scalar_type B[]){
     #ifdef Tasmanian_ENABLE_HIP
-    TypeAcceleration mode = (acceleration->mode == accel_gpu_magma) ? accel_gpu_cuda : acceleration->mode;
-    if (std::is_same<scalar_type, std::complex<double>>::value) // complex LQ (specifically zunmlq) is not yet supported on the AMD GPUs
-        mode = (acceleration->mode == accel_none) ? accel_none : accel_cpu_blas;
+    // complex LQ (specifically zunmlq) is not yet supported on the AMD GPUs
+    TypeAcceleration mode = (std::is_same<scalar_type, std::complex<double>>::value) ?
+         ((acceleration->mode == accel_none) ? accel_none : accel_cpu_blas) : acceleration->mode;
     switch(mode){
     #else
     switch(acceleration->mode){

--- a/SparseGrids/tsgLinearSolvers.cpp
+++ b/SparseGrids/tsgLinearSolvers.cpp
@@ -99,14 +99,7 @@ void TasmanianDenseSolver::solveLeastSquares(AccelerationContext const *accelera
 
 template<typename scalar_type>
 void TasmanianDenseSolver::solvesLeastSquares(AccelerationContext const *acceleration, int n, int m, scalar_type A[], int nrhs, scalar_type B[]){
-    #ifdef Tasmanian_ENABLE_HIP
-    // complex LQ (specifically zunmlq) is not yet supported on the AMD GPUs
-    TypeAcceleration mode = (std::is_same<scalar_type, std::complex<double>>::value) ?
-         ((acceleration->mode == accel_none) ? accel_none : accel_cpu_blas) : acceleration->mode;
-    switch(mode){
-    #else
     switch(acceleration->mode){
-    #endif
         case accel_gpu_magma:
             TasGpu::solveLSmultiOOC(acceleration, n, m, A, nrhs, B);
             break;


### PR DESCRIPTION
* out-of-core MAGMA methods are now usable through the HIP backend with HIP-MAGMA
* enabled complex LQ factorization that was added in rocm 3.7