### PR TITLE
Do not attempt to pull a newer version of images in Jenkins CI builds

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -13,7 +13,6 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile_stack'
                             dir 'docker'
-                            additionalBuildArgs '--pull'
                             label 'docker'
                         }
                     }
@@ -44,7 +43,6 @@ cmake \
                         dockerfile {
                             filename 'Dockerfile_stack'
                             dir 'docker'
-                            additionalBuildArgs '--pull'
                             label 'docker'
                         }
                     }
@@ -78,7 +76,6 @@ cmake \
                         dockerfile {
                             filename 'Dockerfile_nvidia-cuda9.0-ubuntu16.04'
                             dir 'docker'
-                            additionalBuildArgs '--pull'
                             label 'nvidia-docker'
                         }
                     }
@@ -159,7 +156,6 @@ cmake \
                 dockerfile {
                     filename 'Dockerfile.doxygen'
                     dir 'docker'
-                    additionalBuildArgs '--pull'
                     label 'docker'
                 }
             }


### PR DESCRIPTION
Docker Hub started enforcing rate limits and we started having issues on our Jenkins CI server
```
 You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
