### PR TITLE
updated the sycl device selection logic

### DIFF
--- a/Doxygen/CMakeLists.txt
+++ b/Doxygen/CMakeLists.txt
@@ -42,7 +42,7 @@ if (NOT DOXYGEN_INTERNAL_DOCS)
         TasGrid::IO::mode_ascii_type TasGrid::IO::mode_binary_type TasGrid::HandleDeleter
         TasGrid::AccHandle::Cublas TasGrid::AccHandle::Cusparse TasGrid::AccHandle::Cusolver
         TasGrid::AccHandle::Rocblas TasGrid::AccHandle::Rocsparse TasGrid::AccHandle::Syclqueue
-        TasGrid::int_gpu_lapack
+        TasGrid::tsg_gpu_selector TasGrid::int_gpu_lapack
         TasDREAM::IO TasDREAM::Utils)
     set(DOXYGEN_PREDEFINED "__TASMANIAN_DOXYGEN_SKIP;__TASMANIAN_DOXYGEN_SKIP_INTERNAL;Tasmanian_ENABLE_BLAS;Tasmanian_ENABLE_CUDA;Tasmanian_ENABLE_DPCPP;Tasmanian_ENABLE_HIP;Tasmanian_ENABLE_MPI")
 endif()

--- a/InterfaceTPL/tsgDpcppWrappers.cpp
+++ b/InterfaceTPL/tsgDpcppWrappers.cpp
@@ -46,7 +46,7 @@ namespace TasGrid{
 
 void InternalSyclQueue::init_testing(){
     use_testing = true;
-    test_queue = makeNewQueue();
+    test_queue = makeNewQueue(0);
 }
 InternalSyclQueue test_queue;
 
@@ -114,16 +114,14 @@ void GpuEngine::setSyclQueue(void *queue){
 }
 
 int AccelerationMeta::getNumGpuDevices(){
-    return 1; // fake device for now, will actually use the CPU
+    return readSyclDevices().names.size();
 }
 void AccelerationMeta::setDefaultGpuDevice(int){}
-unsigned long long AccelerationMeta::getTotalGPUMemory(int){ // int deviceID
-    sycl::queue q;
-    return q.get_device().get_info<sycl::info::device::global_mem_size>();
+unsigned long long AccelerationMeta::getTotalGPUMemory(int deviceID){ // int deviceID
+    return readSyclDevices().memory[deviceID];
 }
-std::string AccelerationMeta::getGpuDeviceName(int){ // int deviceID
-    sycl::queue q;
-    return q.get_device().get_info<sycl::info::device::name>();
+std::string AccelerationMeta::getGpuDeviceName(int deviceID){ // int deviceID
+    return readSyclDevices().names[deviceID];
 }
 template<typename T> void AccelerationMeta::recvGpuArray(AccelerationContext const *acc, size_t num_entries, const T *gpu_data, std::vector<T> &cpu_data){
     sycl::queue *q = getSyclQueue(acc);


### PR DESCRIPTION
Allows for device selection logic similar to CUDA and HIP, but note that passing in a `sycl::queue` is still the preferred and most SYCL-ish way to select the device.