### PR TITLE
added cmake post-install-testing

### DIFF
--- a/Config/CMakeIncludes/exports.cmake
+++ b/Config/CMakeIncludes/exports.cmake
@@ -2,14 +2,19 @@
 # Testing: post install, make test_install
 # checks if the executables run and if the examples compile and run
 ########################################################################
+set(Tasmanian_langs "CXX")
 set(Tasmanian_compilers  "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
 if (Tasmanian_ENABLE_FORTRAN)
+    set(Tasmanian_langs "${Tasmanian_langs} Fortran")
     set(Tasmanian_compilers  "${Tasmanian_compilers} -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}")
 endif()
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Testing/test_post_install.in.sh" "${CMAKE_CURRENT_BINARY_DIR}/test_post_install.sh")
-add_custom_target(test_install COMMAND "${CMAKE_CURRENT_BINARY_DIR}/test_post_install.sh")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/test_post_install.sh"
-        DESTINATION "share/Tasmanian/"
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Testing/test_post_install.in.sh" "${CMAKE_CURRENT_BINARY_DIR}/test_post_install.sh" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Testing/CMakeLists.test.cmake" "${CMAKE_CURRENT_BINARY_DIR}/configured/testing/CMakeLists.txt" @ONLY)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tasmanian_test_install)
+add_custom_target(test_install COMMAND "${CMAKE_CURRENT_BINARY_DIR}/test_post_install.sh"
+                               WORKING_DIRECTORY tasmanian_test_install)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/testing/CMakeLists.txt"
+        DESTINATION "share/Tasmanian/testing/"
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 
 ########################################################################
@@ -67,10 +72,6 @@ endforeach()
 unset(_comp)
 if (NOT "${Tasmanian_MATLAB_WORK_FOLDER}" STREQUAL "")
     set(Tasmanian_components "${Tasmanian_components} MATLAB")
-endif()
-set(Tasmanian_langs "CXX")
-if (Tasmanian_ENABLE_FORTRAN)
-    set(Tasmanian_langs "${Tasmanian_langs} Fortran")
 endif()
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Config/CMakeLists.examples.cmake" "${CMAKE_CURRENT_BINARY_DIR}/configured/CMakeLists.txt" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/configured/CMakeLists.txt"

--- a/Config/TasmanianConfig.in.cmake
+++ b/Config/TasmanianConfig.in.cmake
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 
+if (TARGET Tasmanian::Tasmanian)
+    return() # exit if Tasmanian has already been found and defined
+endif()
+
 @PACKAGE_INIT@
 
 # https://cmake.org/cmake/help/v3.5/module/CMakePackageConfigHelpers.html#module:CMakePackageConfigHelpers

--- a/InterfacePython/example_dream.in.py
+++ b/InterfacePython/example_dream.in.py
@@ -47,7 +47,9 @@ import example_dream_05
 if __name__ == "__main__":
     example_dream_01.example_01()
     example_dream_02.example_02()
-    example_dream_03.example_03()
-    example_dream_04.example_04()
-    example_dream_05.example_05()
+    if len(sys.argv) < 2:
+        # if running a long test
+        example_dream_03.example_03()
+        example_dream_04.example_04()
+        example_dream_05.example_05()
     print("")

--- a/InterfacePython/example_sparse_grids.in.py
+++ b/InterfacePython/example_sparse_grids.in.py
@@ -54,12 +54,14 @@ if __name__ == "__main__":
     example_sparse_grids_02.example_02()
     example_sparse_grids_03.example_03()
     example_sparse_grids_04.example_04()
-    example_sparse_grids_05.example_05()
-    example_sparse_grids_06.example_06()
-    example_sparse_grids_07.example_07()
-    example_sparse_grids_08.example_08()
-    example_sparse_grids_09.example_09()
-    example_sparse_grids_10.example_10()
+    if len(sys.argv) < 2:
+        # if running a long test
+        example_sparse_grids_05.example_05()
+        example_sparse_grids_06.example_06()
+        example_sparse_grids_07.example_07()
+        example_sparse_grids_08.example_08()
+        example_sparse_grids_09.example_09()
+        example_sparse_grids_10.example_10()
     print("")
 
 

--- a/Testing/CMakeLists.test.cmake
+++ b/Testing/CMakeLists.test.cmake
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION @CMAKE_MAJOR_VERSION@.@CMAKE_MINOR_VERSION@)
+cmake_policy(VERSION @CMAKE_MAJOR_VERSION@.@CMAKE_MINOR_VERSION@)
+project(TasmanianTesting VERSION @Tasmanian_VERSION_MAJOR@.@Tasmanian_VERSION_MINOR@.@Tasmanian_VERSION_PATCH@ LANGUAGES @Tasmanian_langs@)
+enable_testing()
+
+message(STATUS "Tasmanian post-installation testing")
+
+# the following find_package() command will help us locate an existing Tasmanian installation.
+find_package(Tasmanian @Tasmanian_VERSION_MAJOR@.@Tasmanian_VERSION_MINOR@.@Tasmanian_VERSION_PATCH@ PATHS "@Tasmanian_final_install_path@"
+             REQUIRED @Tasmanian_components@)
+
+if (Tasmanian_PYTHON_FOUND)
+    add_custom_target(Tasmanian_python_interface ALL)
+    message(STATUS "Tasmanian Python Test")
+
+    execute_process(COMMAND @PYTHON_EXECUTABLE@ "@Tasmanian_final_install_path@/share/Tasmanian/examples/example_sparse_grids.py" -fast
+                    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+                    RESULT_VARIABLE   Tasmanian_python_sg OUTPUT_QUIET)
+
+    if ("${Tasmanian_python_sg}" STREQUAL "0")
+        message(STATUS "  Testing Sparse Grid: pass")
+    else()
+        message(FATAL_ERROR "Tasmanian Python Sparse Grid Failed")
+    endif()
+
+    execute_process(COMMAND @PYTHON_EXECUTABLE@ "@Tasmanian_final_install_path@/share/Tasmanian/examples/example_dream.py" -fast
+                    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+                    RESULT_VARIABLE   Tasmanian_python_dream OUTPUT_QUIET)
+
+    if ("${Tasmanian_python_dream}" STREQUAL "0")
+        message(STATUS "  Testing DREAM:       pass")
+    else()
+        message(FATAL_ERROR "Tasmanian Python DREAM Failed")
+    endif()
+
+endif()
+
+add_subdirectory("@Tasmanian_final_install_path@/share/Tasmanian/examples" examples_cxx)
+
+add_test(SparseGrids   "${CMAKE_CURRENT_BINARY_DIR}/examples_cxx/example_sparse_grids"  -fast)
+add_test(DREAM         "${CMAKE_CURRENT_BINARY_DIR}/examples_cxx/example_dream"         -fast)
+if (Tasmanian_FORTRAN_FOUND)
+    add_test(Fortran      "${CMAKE_CURRENT_BINARY_DIR}/examples_cxx/example_sparse_grids_fortran"     -fast)
+endif()

--- a/Testing/test_post_install.in.sh
+++ b/Testing/test_post_install.in.sh
@@ -1,77 +1,22 @@
 #!/usr/bin/env bash
 
-#TasmanianPostInstallTest
-
 if (( @Tasmanian_TESTS_OMP_NUM_THREADS@ != -1 )); then
     export OMP_NUM_THREADS=@Tasmanian_TESTS_OMP_NUM_THREADS@
 fi
 
-if [ ! -d "TasmanianPostInstallTest" ]; then
-    mkdir TasmanianPostInstallTest
-fi
-cd TasmanianPostInstallTest || { echo "ERROR: Could not cd into TasmanianPostInstallTest, terminating"; exit 1; }
-
-rm -fr ../TasmanianPostInstallTest/*
-
-echo ""
-echo "--------------------------------------------------------------------------------"
-echo " Test 1: source the PATH and the LD_LIBRARY_PATH and run the executable"
-echo "--------------------------------------------------------------------------------"
-
 source "@Tasmanian_final_install_path@"/share/Tasmanian/TasmanianENVsetup.sh || { echo "ERROR: Could not source <install_prefix>/share/Tasmanian/TasmanianENVsetup.sh"; exit 1; }
-tasgrid -v  || { echo "ERROR: Could not execute ./tasgrid -v"; exit 1; }
 
-
-echo "--------------------------------------------------------------------------------"
-echo " Test 2: compile and run the C++ examples"
-echo "--------------------------------------------------------------------------------"
-echo 'Building  "cmake @Tasmanian_final_install_path@/share/Tasmanian/examples"'
-if [[ -z $1 ]]; then
-    @CMAKE_COMMAND@ @Tasmanian_compilers@ "@Tasmanian_final_install_path@/share/Tasmanian/examples" || { echo "ERROR: Could not cmake the C++ examples"; exit 1; }
-else
-    @CMAKE_COMMAND@ $1 "@Tasmanian_final_install_path@/share/Tasmanian/examples" || { echo "ERROR: Could not cmake the C++ examples"; exit 1; }
-fi
-echo 'Compiling "make"'
-make -j3 || { echo "ERROR: Could not compile the C++ examples"; exit 1; }
-echo 'Executing "./example_sparse_grids"'
-./example_sparse_grids -fast >/dev/null || { echo "ERROR: Could not run the C++ Sparse Grid example"; exit 1; }
-if [ -f "@Tasmanian_final_install_path@"/share/Tasmanian/examples/example_sparse_grids.f90 ]; then
-    echo 'Executing "./example_sparse_grids_fortran"'
-    ./example_sparse_grids_fortran -fast >/dev/null 2>&1 || { echo "ERROR: Could not run the Fortran Sparse Grid example"; exit 1; }
-fi
-echo 'Executing "./example_dream"'
-./example_dream -fast >/dev/null || { echo "ERROR: Could not run the C++ DREAM example"; exit 1; }
-
-
-echo ""
-echo "--------------------------------------------------------------------------------"
-echo " Test 3: run a basic python test"
-echo "--------------------------------------------------------------------------------"
-sPSuccess=1
-if [[ "@Tasmanian_ENABLE_PYTHON@" == "ON" ]]; then
-    echo 'Executing "@Tasmanian_final_install_path@/share/examples/example_sparse_grids.py"'
-    "@PYTHON_EXECUTABLE@" "@Tasmanian_final_install_path@"/share/Tasmanian/examples/example_sparse_grids.py -fast > /dev/null || { echo "ERROR: could not run the python example post install!"; sPSuccess=0; }
-    echo 'import Tasmanian' >> hello_world.py
-    echo 'print("Tasmanian Python module version: {0:1s}".format(Tasmanian.__version__))' >> hello_world.py
-    "@PYTHON_EXECUTABLE@" hello_world.py || { echo "ERROR: Could not run the dummy python test"; echo "      This is a problem either with Python install or the Tasmanian library."; sPSuccess=0; }
-else
-    echo "Python not enabled, skipping"
+if [[ $(basename "$(pwd)") != "tasmanian_test_install" ]]; then
+    if [ -d tasmanian_test_install ]; then
+        cd tasmanian_test_install
+    else
+        echo "ERROR: must run this script from the tasmanian_test_install folder or the CMake build root folder"
+        exit 1
+    fi
 fi
 
+rm -fr ../tasmanian_test_install/*
 
-if (( $sPSuccess == 0 )); then
-    echo ""
-    echo "--------------------------------------------------------------------------------"
-    echo "   SOME TESTS FAILED, but the install may be OK"
-    echo "--------------------------------------------------------------------------------"
-    echo ""
-    exit 1;
-else
-    echo ""
-    echo "--------------------------------------------------------------------------------"
-    echo "   ALL POST INSTALL TESTS COMPLETED SUCCESSFULLY"
-    echo "--------------------------------------------------------------------------------"
-    echo ""
-fi
-
-exit 0;
+@CMAKE_COMMAND@ @Tasmanian_compilers@ "@Tasmanian_final_install_path@/share/Tasmanian/testing"
+make -j
+make test


### PR DESCRIPTION
* move the `test_install` testing into a CMake module for use post-install (previously it was a bash script)
* should facilitate better smoke testing in spack