### PR TITLE
Allow `getExoticQuadrature()` to use `decompose()` instead of `LAPACK` + Bug fixes.

### DIFF
--- a/Addons/testAddons.cpp
+++ b/Addons/testAddons.cpp
@@ -66,19 +66,21 @@ int main(int argc, char const **argv){
     cout << "          Tasmanian Addons Module: Functionality Test" << endl;
     cout << "---------------------------------------------------------------------" << endl << endl;
 
-    bool pass = testConstructSurrogate(verbose);
-    cout << std::setw(40) << "Automated construction" << std::setw(10) << ((pass) ? "Pass" : "FAIL") << endl;
-    pass_all = pass_all && pass;
+    bool pass = true;
 
-    #if defined(Tasmanian_ENABLE_BLAS) || defined(Tasmanian_ENABLE_GPU)
-    pass = true;
-    pass = testLoadUnstructuredL2(verbose, gpuid);
-    cout << std::setw(40) << "Unstructured construction" << std::setw(10) << ((pass) ? "Pass" : "FAIL") << endl;
-    pass_all = pass_all && pass;
-    #else
-    cout << std::setw(40) << "Unstructured construction" << std::setw(10) << "skipping" << endl;
-    gpuid *= 2; // no op to register the use of gpuid
-    #endif
+    // bool pass = testConstructSurrogate(verbose);
+    // cout << std::setw(40) << "Automated construction" << std::setw(10) << ((pass) ? "Pass" : "FAIL") << endl;
+    // pass_all = pass_all && pass;
+
+    // #if defined(Tasmanian_ENABLE_BLAS) || defined(Tasmanian_ENABLE_GPU)
+    // pass = true;
+    // pass = testLoadUnstructuredL2(verbose, gpuid);
+    // cout << std::setw(40) << "Unstructured construction" << std::setw(10) << ((pass) ? "Pass" : "FAIL") << endl;
+    // pass_all = pass_all && pass;
+    // #else
+    // cout << std::setw(40) << "Unstructured construction" << std::setw(10) << "skipping" << endl;
+    // gpuid *= 2; // no op to register the use of gpuid
+    // #endif
 
     // Tests for Exotic Quadrature.
     #ifdef Tasmanian_ENABLE_BLAS

--- a/Addons/testAddons.cpp
+++ b/Addons/testAddons.cpp
@@ -81,14 +81,10 @@ int main(int argc, char const **argv){
     #endif
 
     // Tests for Exotic Quadrature.
-    #ifdef Tasmanian_ENABLE_BLAS
     pass = true;
     pass = testExoticQuadrature();
     cout << std::setw(40) << "Exotic quadrature" << std::setw(10) << ((pass) ? "Pass" : "FAIL") << endl;
     pass_all = pass_all && pass;
-    #else
-    cout << std::setw(40) << "Exotic quadrature" << std::setw(10) << "skipping" << endl;
-    #endif
 
     cout << "\n";
     if (pass){

--- a/Addons/testAddons.cpp
+++ b/Addons/testAddons.cpp
@@ -66,21 +66,19 @@ int main(int argc, char const **argv){
     cout << "          Tasmanian Addons Module: Functionality Test" << endl;
     cout << "---------------------------------------------------------------------" << endl << endl;
 
-    bool pass = true;
+    bool pass = testConstructSurrogate(verbose);
+    cout << std::setw(40) << "Automated construction" << std::setw(10) << ((pass) ? "Pass" : "FAIL") << endl;
+    pass_all = pass_all && pass;
 
-    // bool pass = testConstructSurrogate(verbose);
-    // cout << std::setw(40) << "Automated construction" << std::setw(10) << ((pass) ? "Pass" : "FAIL") << endl;
-    // pass_all = pass_all && pass;
-
-    // #if defined(Tasmanian_ENABLE_BLAS) || defined(Tasmanian_ENABLE_GPU)
-    // pass = true;
-    // pass = testLoadUnstructuredL2(verbose, gpuid);
-    // cout << std::setw(40) << "Unstructured construction" << std::setw(10) << ((pass) ? "Pass" : "FAIL") << endl;
-    // pass_all = pass_all && pass;
-    // #else
-    // cout << std::setw(40) << "Unstructured construction" << std::setw(10) << "skipping" << endl;
-    // gpuid *= 2; // no op to register the use of gpuid
-    // #endif
+    #if defined(Tasmanian_ENABLE_BLAS) || defined(Tasmanian_ENABLE_GPU)
+    pass = true;
+    pass = testLoadUnstructuredL2(verbose, gpuid);
+    cout << std::setw(40) << "Unstructured construction" << std::setw(10) << ((pass) ? "Pass" : "FAIL") << endl;
+    pass_all = pass_all && pass;
+    #else
+    cout << std::setw(40) << "Unstructured construction" << std::setw(10) << "skipping" << endl;
+    gpuid *= 2; // no op to register the use of gpuid
+    #endif
 
     // Tests for Exotic Quadrature.
     #ifdef Tasmanian_ENABLE_BLAS

--- a/Addons/testAddons.cpp
+++ b/Addons/testAddons.cpp
@@ -33,51 +33,8 @@
 #include "testExoticQuadrature.hpp"
 
 void debugTest() {
-    // cout << "Debug Test (callable from the CMake build folder)" << endl;
-    // cout << "Put testing code here and call with ./Addons/addontester debug" << endl;
-
-    // Set weight function.
-    double freq = 1.0;
-    double phase_shift = 1.0;
-    int dimension = 1;
-    int level = 40;
-    int shift = 1.0;
-    int depth = 20;
-    bool symmetric_weights = false;
-    // Get exotic nodes and weights for the sinc function.
-    auto sinc = [freq, phase_shift](double x)->double {return (fabs(freq * (x - phase_shift)) <= 1e-20) ?
-                1.0 :
-                sin(freq * (x - phase_shift)) / (freq * (x - phase_shift));};
-    TasGrid::CustomTabulated ct1, ct2;
-    TasGrid::gauss_quadrature_version = 1;
-    ct1 = TasGrid::getExoticQuadrature(level, shift, sinc, 50 * depth + 1, "Sinc-Weighted Quadrature 1", symmetric_weights);
-    TasGrid::gauss_quadrature_version = 2;
-    ct2 = TasGrid::getExoticQuadrature(level, shift, sinc, 50 * depth + 1, "Sinc-Weighted Quadrature 2", symmetric_weights);
-    // Form the grid.
-    TasGrid::TasmanianSparseGrid sg1, sg2;
-    sg1.makeGlobalGrid(dimension, 1, depth, TasGrid::type_qptotal, std::move(ct1));
-    std::vector<double> quad_points1 = sg1.getPoints();
-    std::vector<double> quad_weights1 = sg1.getQuadratureWeights();
-    sg2.makeGlobalGrid(dimension, 1, depth, TasGrid::type_qptotal, std::move(ct2));
-    std::vector<double> quad_points2 = sg2.getPoints();
-    std::vector<double> quad_weights2 = sg2.getQuadratureWeights();
-    // Print
-    std::cout << "n1, n2" << std::endl;
-    std::cout << quad_points1.size() << ", " << quad_points2.size() << "\n" << std::endl;
-    if (!(quad_points1.size() == quad_points2.size())) {
-        std::cout << "Node/Weight lengths differ!" << std::endl;
-    }
-    size_t n = std::min(quad_points1.size(), quad_points2.size()); 
-    std::cout << "      p1[],       p2[],        err[]" << std::endl;
-    for (size_t i=0; i<n; i++)
-        std::cout << std::fixed << std::setw(10) << quad_points1[i] << ", " << std::setw(10) << quad_points2[i] << ", "
-                  << std::setw(10) << std::scientific << std::fabs(quad_points1[i] - quad_points2[i]) << std::fixed << std::endl;
-    std::cout << endl;
-    std::cout << "      w1[],       w2[],        err[]" << std::endl;
-    for (size_t i=0; i<n; i++)
-        std::cout << std::fixed << std::setw(10) << quad_weights1[i] << ", " << std::setw(10) << quad_weights2[i] << ", "
-                  << std::setw(10) << std::scientific << std::fabs(quad_weights1[i] - quad_weights2[i]) << std::fixed << std::endl;
-    std::cout << endl;
+    cout << "Debug Test (callable from the CMake build folder)" << endl;
+    cout << "Put testing code here and call with ./Addons/addontester debug" << endl;
 }
 
 int main(int argc, char const **argv){

--- a/Addons/testAddons.cpp
+++ b/Addons/testAddons.cpp
@@ -33,8 +33,51 @@
 #include "testExoticQuadrature.hpp"
 
 void debugTest() {
-    cout << "Debug Test (callable from the CMake build folder)" << endl;
-    cout << "Put testing code here and call with ./Addons/addontester debug" << endl;
+    // cout << "Debug Test (callable from the CMake build folder)" << endl;
+    // cout << "Put testing code here and call with ./Addons/addontester debug" << endl;
+
+    // Set weight function.
+    double freq = 1.0;
+    double phase_shift = 1.0;
+    int dimension = 1;
+    int level = 40;
+    int shift = 1.0;
+    int depth = 20;
+    bool symmetric_weights = false;
+    // Get exotic nodes and weights for the sinc function.
+    auto sinc = [freq, phase_shift](double x)->double {return (fabs(freq * (x - phase_shift)) <= 1e-20) ?
+                1.0 :
+                sin(freq * (x - phase_shift)) / (freq * (x - phase_shift));};
+    TasGrid::CustomTabulated ct1, ct2;
+    TasGrid::gauss_quadrature_version = 1;
+    ct1 = TasGrid::getExoticQuadrature(level, shift, sinc, 50 * depth + 1, "Sinc-Weighted Quadrature 1", symmetric_weights);
+    TasGrid::gauss_quadrature_version = 2;
+    ct2 = TasGrid::getExoticQuadrature(level, shift, sinc, 50 * depth + 1, "Sinc-Weighted Quadrature 2", symmetric_weights);
+    // Form the grid.
+    TasGrid::TasmanianSparseGrid sg1, sg2;
+    sg1.makeGlobalGrid(dimension, 1, depth, TasGrid::type_qptotal, std::move(ct1));
+    std::vector<double> quad_points1 = sg1.getPoints();
+    std::vector<double> quad_weights1 = sg1.getQuadratureWeights();
+    sg2.makeGlobalGrid(dimension, 1, depth, TasGrid::type_qptotal, std::move(ct2));
+    std::vector<double> quad_points2 = sg2.getPoints();
+    std::vector<double> quad_weights2 = sg2.getQuadratureWeights();
+    // Print
+    std::cout << "n1, n2" << std::endl;
+    std::cout << quad_points1.size() << ", " << quad_points2.size() << "\n" << std::endl;
+    if (!(quad_points1.size() == quad_points2.size())) {
+        std::cout << "Node/Weight lengths differ!" << std::endl;
+    }
+    size_t n = std::min(quad_points1.size(), quad_points2.size()); 
+    std::cout << "      p1[],       p2[],        err[]" << std::endl;
+    for (size_t i=0; i<n; i++)
+        std::cout << std::fixed << std::setw(10) << quad_points1[i] << ", " << std::setw(10) << quad_points2[i] << ", "
+                  << std::setw(10) << std::scientific << std::fabs(quad_points1[i] - quad_points2[i]) << std::fixed << std::endl;
+    std::cout << endl;
+    std::cout << "      w1[],       w2[],        err[]" << std::endl;
+    for (size_t i=0; i<n; i++)
+        std::cout << std::fixed << std::setw(10) << quad_weights1[i] << ", " << std::setw(10) << quad_weights2[i] << ", "
+                  << std::setw(10) << std::scientific << std::fabs(quad_weights1[i] - quad_weights2[i]) << std::fixed << std::endl;
+    std::cout << endl;
 }
 
 int main(int argc, char const **argv){

--- a/Addons/testExoticQuadrature.hpp
+++ b/Addons/testExoticQuadrature.hpp
@@ -44,7 +44,7 @@ inline bool testNodeAndWeightSizes() {
     std::vector<double> ref_weights(nref), ref_points(nref);
     TasGrid::OneDimensionalNodes::getGaussLegendre(nref, ref_weights, ref_points);
     // n = 1, 2, 5
-    std::vector<int> n_vec = {1, 2, 5};
+    std::vector<size_t> n_vec = {1, 2, 5};
     for (auto n : n_vec) {
         TasGrid::getGaussNodesAndWeights<true>(n, ref_points, ref_weights, nodes_cache, weights_cache);
         if (nodes_cache.size() != n) {

--- a/Addons/testExoticQuadrature.hpp
+++ b/Addons/testExoticQuadrature.hpp
@@ -39,15 +39,15 @@
 // Test the output of getGaussNodesAndWeights().
 inline bool testNodeAndWeightSizes() {
     bool passed = true;
-    std::vector<std::vector<double>> nodes_cache, weights_cache;
+    std::vector<std::vector<double>> points_cache, weights_cache;
     int nref = 5;
     std::vector<double> ref_weights(nref), ref_points(nref);
     TasGrid::OneDimensionalNodes::getGaussLegendre(nref, ref_weights, ref_points);
     // n = 1, 2, 5
     std::vector<size_t> n_vec = {1, 2, 5};
     for (auto n : n_vec) {
-        TasGrid::getGaussNodesAndWeights<true>(n, ref_points, ref_weights, nodes_cache, weights_cache);
-        if (nodes_cache.size() != n) {
+        TasGrid::getGaussNodesAndWeights<true>(n, ref_points, ref_weights, points_cache, weights_cache);
+        if (points_cache.size() != n) {
             std::cout << "ERROR: Test failed in testNodeAndWeightSizes() for n = " << n << std::endl;
             passed = false;
         }

--- a/Addons/testExoticQuadrature.hpp
+++ b/Addons/testExoticQuadrature.hpp
@@ -36,19 +36,23 @@
 #include "tasgridCLICommon.hpp"
 #include <cstring>
 
-// Test the output of getRoots().
-inline bool testRootSizes() {
+// Test the output of getGaussNodesAndWeights().
+inline bool testNodeAndWeightSizes() {
     bool passed = true;
-    std::vector<std::vector<double>> roots;
+    std::vector<std::vector<double>> nodes_cache, weights_cache;
     int nref = 5;
     std::vector<double> ref_weights(nref), ref_points(nref);
     TasGrid::OneDimensionalNodes::getGaussLegendre(nref, ref_weights, ref_points);
-    // n = 0, 1, 5
+    // n = 1, 2, 5
     std::vector<int> n_vec = {1, 2, 5};
     for (auto n : n_vec) {
-        roots = TasGrid::getRoots<true>(0, ref_weights, ref_points);
-        if (roots.size() != 0) {
-            std::cout << "ERROR: Test failed in testRootSizes() for n = " << n << std::endl;
+        TasGrid::getGaussNodesAndWeights<true>(n, ref_points, ref_weights, nodes_cache, weights_cache);
+        if (nodes_cache.size() != n) {
+            std::cout << "ERROR: Test failed in testNodeAndWeightSizes() for n = " << n << std::endl;
+            passed = false;
+        }
+        if (weights_cache.size() != n) {
+            std::cout << "ERROR: Test failed in testNodeAndWeightSizes() for n = " << n << std::endl;
             passed = false;
         }
     }
@@ -96,7 +100,7 @@ inline bool wrapSincTest(std::function<double(const double*)> f, const int dimen
     // Initialize.
     bool passed = true;
     auto sinc = [freq, phase_shift](double x)->double {return (fabs(freq * (x - phase_shift)) <= 1e-20) ?
-                                                              0.0 :
+                                                              1.0 :
                                                               sin(freq * (x - phase_shift)) / (freq * (x - phase_shift));};
     int level = depth % 2 == 1 ? (depth + 1) / 2 : depth / 2 + 1;
     TasGrid::CustomTabulated ct;
@@ -181,7 +185,7 @@ inline bool testAccuracy() {
 // Main wrapper
 inline bool testExoticQuadrature() {
     bool passed = true;
-    passed = passed && testRootSizes();
+    passed = passed && testNodeAndWeightSizes();
     passed = passed && testBasicAttributes();
     passed = passed && testAccuracy();
     return passed;

--- a/Addons/tsgExoticQuadrature.hpp
+++ b/Addons/tsgExoticQuadrature.hpp
@@ -73,22 +73,22 @@ inline double lagrange_eval(size_t idx, const std::vector<double> &roots, double
 /*!
  * \internal
  * \ingroup TasmanianAddonsExoticQuad
- * \brief Generate the nodes and weights of a Gaussian quadrature (up to degree n) whose weight function is evaluated on \b
- * ref_nodes and its corresponding values are stored in \b ref_weights. Specializes depending on if the underlying weight
+ * \brief Generate the points and weights of a Gaussian quadrature (up to degree n) whose weight function is evaluated on \b
+ * ref_points and its corresponding values are stored in \b ref_weights. Specializes depending on if the underlying weight
  * function is symmetric or not.
  * \endinternal
  */
 template <bool is_symmetric>
-inline void getGaussNodesAndWeights(const int n, const std::vector<double> &ref_nodes, const std::vector<double> &ref_weights,
-                                    std::vector<std::vector<double>> &nodes_cache, std::vector<std::vector<double>> &weights_cache) {
+inline void getGaussNodesAndWeights(const int n, const std::vector<double> &ref_points, const std::vector<double> &ref_weights,
+                                    std::vector<std::vector<double>> &points_cache, std::vector<std::vector<double>> &weights_cache) {
     // Compute the roots incrementally.
-    assert(ref_nodes.size() == ref_weights.size());
-    assert(ref_nodes.size() > 0);
+    assert(ref_points.size() == ref_weights.size());
+    assert(ref_points.size() > 0);
     double mu0 = 0.0;
-    for (auto w : ref_weights) mu0 += w;
-    std::vector<double> poly_m1_vals(ref_nodes.size(), 0.0), poly_vals(ref_nodes.size(), 1.0);
+    for (auto &w : ref_weights) mu0 += w;
+    std::vector<double> poly_m1_vals(ref_points.size(), 0.0), poly_vals(ref_points.size(), 1.0);
     std::vector<double> diag, off_diag;
-    nodes_cache.resize(n);
+    points_cache.resize(n);
     weights_cache.resize(n);
     for (int i=0; i<n; i++) {
         // Form the diagonal and offdiagonal vectors of the Jacobi matrix.
@@ -97,48 +97,47 @@ inline void getGaussNodesAndWeights(const int n, const std::vector<double> &ref_
         } else {
             double diag_numr = 0.0;
             double diag_denm = 0.0;
-            for (size_t j=0; j<ref_nodes.size(); j++) {
-            diag_numr += ref_nodes[j] * (poly_vals[j] * poly_vals[j]) * ref_weights[j];
+            for (size_t j=0; j<ref_points.size(); j++) {
+            diag_numr += ref_points[j] * (poly_vals[j] * poly_vals[j]) * ref_weights[j];
             diag_denm += (poly_vals[j] * poly_vals[j]) * ref_weights[j];
             }
             diag.push_back(diag_numr / diag_denm);
         }
         if (i >= 1) {
-            double sqr_offdiag_numr = 0.0;
-            double sqr_offdiag_denm = 0.0;
-            for (size_t j=0; j<ref_nodes.size(); j++) {
-                sqr_offdiag_numr += (poly_vals[j] * poly_vals[j]) * ref_weights[j];
-                sqr_offdiag_denm += (poly_m1_vals[j] * poly_m1_vals[j])  * ref_weights[j];
+            double sqr_off_diag_numr = 0.0;
+            double sqr_off_diag_denm = 0.0;
+            for (size_t j=0; j<ref_points.size(); j++) {
+                sqr_off_diag_numr += (poly_vals[j] * poly_vals[j]) * ref_weights[j];
+                sqr_off_diag_denm += (poly_m1_vals[j] * poly_m1_vals[j])  * ref_weights[j];
             }
-            off_diag.push_back(std::sqrt(sqr_offdiag_numr / sqr_offdiag_denm));
+            off_diag.push_back(std::sqrt(sqr_off_diag_numr / sqr_off_diag_denm));
         }
-        // Compute the Gauss nodes and weights.
+        // Compute the Gauss points and weights.
         if (gauss_quadrature_version == 1) {
-            // Use LAPACK to obtain the Gauss nodes and the reference nodes and weights to obtain the Gauss weights.
-            nodes_cache[i] = TasmanianTridiagonalSolver::getSymmetricEigenvalues(i+1, diag, off_diag);
-            weights_cache[i] = std::vector<double>(nodes_cache[i].size(), 0.0);
-            for (size_t j=0; j<nodes_cache[i].size(); j++) {
+            // Use LAPACK to obtain the Gauss points, and use the reference points and weights to obtain the Gauss weights.
+            points_cache[i] = TasmanianTridiagonalSolver::getSymmetricEigenvalues(i+1, diag, off_diag);
+            if (points_cache[i].size() % 2 == 1) {
+                points_cache[i][(points_cache[i].size() - 1) / 2] = 0.0;
+            }
+            weights_cache[i] = std::vector<double>(points_cache[i].size(), 0.0);
+            for (size_t j=0; j<points_cache[i].size(); j++) {
                 // Integrate the function l_j(x) according to the measure induced by the function [weight_fn(x) + shift].
-                for (size_t k=0; k<ref_nodes.size(); k++) {
-                    weights_cache[i][j] += lagrange_eval(j, nodes_cache[i], ref_nodes[k]) * ref_weights[k];
+                for (size_t k=0; k<ref_points.size(); k++) {
+                    weights_cache[i][j] += lagrange_eval(j, points_cache[i], ref_points[k]) * ref_weights[k];
                 }
             }
         } else if (gauss_quadrature_version == 2) {
             // Use TasmanianTridiagonalSolver::decompose().
             std::vector<double> dummy_diag = diag;
             std::vector<double> dummy_off_diag = off_diag;
-            TasmanianTridiagonalSolver::decompose(dummy_diag, dummy_off_diag, mu0, nodes_cache[i], weights_cache[i]);
+            TasmanianTridiagonalSolver::decompose(dummy_diag, dummy_off_diag, mu0, points_cache[i], weights_cache[i]);
         } else {
             throw std::invalid_argument("ERROR: gauss_quadrature_version must be a valid number!");
         }
-        // Zero out the center for stability.
-        if (nodes_cache[i].size() % 2 == 1) {
-            nodes_cache[i][(nodes_cache[i].size() - 1) / 2] = 0.0;
-        }
-        // Update the values of the polynomials at ref_nodes.
+        // Update the values of the polynomials at ref_points.
         std::swap(poly_m1_vals, poly_vals);
-        std::transform(ref_nodes.begin(), ref_nodes.end(), poly_vals.begin(),
-                       [&nodes_cache, i](double x){return poly_eval(nodes_cache[i], x);});
+        std::transform(ref_points.begin(), ref_points.end(), poly_vals.begin(),
+                       [&points_cache, i](double x){return poly_eval(points_cache[i], x);});
     }
     return roots;
 }
@@ -146,43 +145,25 @@ inline void getGaussNodesAndWeights(const int n, const std::vector<double> &ref_
 /*!
  * \internal
  * \ingroup TasmanianAddonsExoticQuad
- * \brief Evaluates a Lagrange basis polynomial at a point \b x.
- * \endinternal
- */
-inline double lagrange_eval(size_t idx, const std::vector<double> &roots, double x) {
-    double eval_value = 1.0;
-    for (size_t i=0; i<idx; i++) {
-        eval_value *= (x - roots[i]) / (roots[idx] - roots[i]);
-    }
-    for (size_t i=idx+1; i<roots.size(); i++) {
-        eval_value *= (x - roots[i]) / (roots[idx] - roots[i]);
-    }
-    return eval_value;
-}
-
-
-/*!
- * \internal
- * \ingroup TasmanianAddonsExoticQuad
- * \brief Generate the full cache of Exotic (weighted and possibly shifted) quadrature weights and nodes for an (input) max level
- * \b n, using parameters \b shift, \b weight_fn_vals, \b shifted_weights, and \b ref_nodes.
+ * \brief Generate the full cache of Exotic (weighted and possibly shifted) quadrature weights and points for an (input) max level
+ * \b n, using parameters \b shift, \b weight_fn_vals, \b shifted_weights, and \b ref_points.
  *
  * It is assumed that shifted_weights[i] is nonnegative and is already computed as shifted_weights[i] = ref_weights[i] *
  * (weight_fn_vals[i] + shift) for every i.
  * \endinternal
  */
 inline TasGrid::CustomTabulated getShiftedExoticQuadrature(const int n, const double shift, const std::vector<double> &weight_fn_vals,
-                                                           const std::vector<double> &shifted_weights, const std::vector<double> &ref_nodes,
+                                                           const std::vector<double> &shifted_weights, const std::vector<double> &ref_points,
                                                            const char* description, const bool is_symmetric = false) {
 
-    // Create the set of nodes (roots) for the first term.
-    assert(shifted_weights.size() == ref_nodes.size());
-    assert(weight_fn_vals.size() == ref_nodes.size());
-    std::vector<std::vector<double>> nodes_cache(n), weights_cache(n);
+    // Create the set of points (roots) and weights for the first term.
+    assert(shifted_weights.size() == ref_points.size());
+    assert(weight_fn_vals.size() == ref_points.size());
+    std::vector<std::vector<double>> points_cache, weights_cache;
     if (is_symmetric) {
-        getGaussNodesAndWeights<true>(n, ref_nodes, shifted_weights, nodes_cache, weights_cache);
+        getGaussNodesAndWeights<true>(n, ref_points, shifted_weights, points_cache, weights_cache);
     } else {
-        getGaussNodesAndWeights<false>(n, ref_nodes, shifted_weights, nodes_cache, weights_cache);
+        getGaussNodesAndWeights<false>(n, ref_points, shifted_weights, points_cache, weights_cache);
     }
 
     // Create the set of weights for the first term.
@@ -190,28 +171,28 @@ inline TasGrid::CustomTabulated getShiftedExoticQuadrature(const int n, const do
     for (int i=0; i<n; i++) {
            }
 
-    // Create and append the set of correction nodes and weights for the second term only if the shift is nonzero.
+    // Create and append the set of correction points and weights for the second term only if the shift is nonzero.
     if (shift != 0.0) {
         for (int i=0; i<n; i++) {
-            const int init_size = nodes_cache[i].size();
-            std::vector<double> correction_nodes, correction_weights;
-            TasGrid::OneDimensionalNodes::getGaussLegendre(init_size, correction_weights, correction_nodes);
+            const int init_size = points_cache[i].size();
+            std::vector<double> correction_points, correction_weights;
+            TasGrid::OneDimensionalNodes::getGaussLegendre(init_size, correction_weights, correction_points);
             for (auto &w : correction_weights) w *= -shift;
-            if (correction_nodes.size() % 2 == 1) {
+            if (correction_points.size() % 2 == 1) {
                 // Zero out for stability.
-                correction_nodes[(correction_nodes.size() - 1) / 2] = 0.0;
+                correction_points[(correction_points.size() - 1) / 2] = 0.0;
             }
             // Account for duplicates up to a certain tolerance.
-            for (size_t j=0; j<correction_nodes.size(); j++) {
+            for (size_t j=0; j<correction_points.size(); j++) {
                 int nonunique_idx = -1;
                 for (int k=0; k<init_size; k++) {
-                    if (std::abs(correction_nodes[j] - nodes_cache[i][k]) <= Maths::num_tol) {
+                    if (std::abs(correction_points[j] - points_cache[i][k]) <= Maths::num_tol) {
                         nonunique_idx = k;
                         break;
                     }
                 }
                 if (nonunique_idx == -1) {
-                    nodes_cache[i].push_back(correction_nodes[j]);
+                    points_cache[i].push_back(correction_points[j]);
                     weights_cache[i].push_back(correction_weights[j]);
                 } else {
                     weights_cache[i][nonunique_idx] += correction_weights[j];
@@ -223,10 +204,10 @@ inline TasGrid::CustomTabulated getShiftedExoticQuadrature(const int n, const do
     // Output to a CustomTabulated instance.
     std::vector<int> num_nodes(n), precision(n);
     for (int i=0; i<n; i++) {
-        num_nodes[i] = nodes_cache[i].size();
+        num_nodes[i] = points_cache[i].size();
         precision[i] = 2 * (i + 1) - 1;
     }
-    return TasGrid::CustomTabulated(n, std::move(num_nodes), std::move(precision), std::move(nodes_cache),
+    return TasGrid::CustomTabulated(n, std::move(num_nodes), std::move(precision), std::move(points_cache),
                                     std::move(weights_cache), description);
 }
 
@@ -253,11 +234,11 @@ inline void shiftReferenceWeights(std::vector<double> const &vals, double shift,
 
 /*
  * \ingroup TasmanianAddonsExoticQuad
- * \brief Constructs a CustomTabulated object containing the exotic quadrature nodes and quadrature weights for a given level \b n,
+ * \brief Constructs a CustomTabulated object containing the exotic quadrature points and quadrature weights for a given level \b n,
  * scalar \b shift, a reference TasmanianSparseGrid \b grid containing loaded values of the weight function, a string \b description,
  * and an optional bool \b is_symmetric that should be set to true if the weight function is symmetric.
  *
- * It is assumed that grid is a one dimensional interpolant/surrogate to the weight function. Only the nodes in grid.getLoadedPoints(),
+ * It is assumed that grid is a one dimensional interpolant/surrogate to the weight function. Only the points in grid.getLoadedPoints(),
  * the quadrature weights in grid.getQuadratureWeights(), and the loaded weight function values in grid.getLoadedValues() are used
  * in the computation of the exotic quadrature. Specifically, these vectors are used to orthogonalize the polynomial basis needed
  * to compute the optimal exotic quadrature.
@@ -273,21 +254,21 @@ inline TasGrid::CustomTabulated getExoticQuadrature(const int n, const double sh
     if (grid.getNumOutputs() != 1) {
         throw std::invalid_argument("ERROR: grid needs to have scalar outputs!");
     }
-    std::vector<double> ref_nodes = grid.getLoadedPoints();
+    std::vector<double> ref_points = grid.getLoadedPoints();
     std::vector<double> shifted_weights = grid.getQuadratureWeights();
     std::vector<double> weight_fn_vals = std::vector<double>(grid.getLoadedValues(), grid.getLoadedValues() + grid.getNumLoaded());
     if (not std::all_of(weight_fn_vals.begin(), weight_fn_vals.end(), [shift](double x){return (x+shift)>=0.0;})) {
         throw std::invalid_argument("ERROR: shift needs to be chosen so that weight_fn(x)+shift is nonnegative!");
     }
-    for (size_t k=0; k<ref_nodes.size(); k++) {
+    for (size_t k=0; k<ref_points.size(); k++) {
         shifted_weights[k] *= (weight_fn_vals[k] + shift);
     }
-    return getShiftedExoticQuadrature(n, shift, weight_fn_vals, shifted_weights, ref_nodes, description, is_symmetric);
+    return getShiftedExoticQuadrature(n, shift, weight_fn_vals, shifted_weights, ref_points, description, is_symmetric);
 }
 
 /*
  * \ingroup TasmanianAddonsExoticQuad
- * \brief Constructs a CustomTabulated object containing the exotic quadrature nodes and quadrature weights for a given level \b n,
+ * \brief Constructs a CustomTabulated object containing the exotic quadrature points and quadrature weights for a given level \b n,
  * scalar \b shift, a 1D function \b weight_fn() that returns the value of the weight function at its input, a positive integer
  * \b nref that specifies how many points are used in orthogonalizing the polynomial basis, a string \b description, and an optional
  * bool \b is_symmetric that should be set to true if the weight function is symmetric.
@@ -297,16 +278,16 @@ inline TasGrid::CustomTabulated getExoticQuadrature(const int n, const double sh
  */
 inline TasGrid::CustomTabulated getExoticQuadrature(const int n, const double shift, std::function<double(double)> weight_fn,
                                                     const int nref, const char* description, const bool is_symmetric = false) {
-    std::vector<double> shifted_weights, ref_nodes, weight_fn_vals(nref);
-    TasGrid::OneDimensionalNodes::getGaussLegendre(nref, shifted_weights, ref_nodes);
-    std::transform(ref_nodes.begin(), ref_nodes.end(), weight_fn_vals.begin(), weight_fn);
+    std::vector<double> shifted_weights, ref_points, weight_fn_vals(nref);
+    TasGrid::OneDimensionalNodes::getGaussLegendre(nref, shifted_weights, ref_points);
+    std::transform(ref_points.begin(), ref_points.end(), weight_fn_vals.begin(), weight_fn);
     if (not std::all_of(weight_fn_vals.begin(), weight_fn_vals.end(), [shift](double x){return (x+shift)>=0.0;})) {
         throw std::invalid_argument("ERROR: shift needs to be chosen so that weight_fn(x)+shift is nonnegative!");
     }
     for (int k=0; k<nref; k++) {
         shifted_weights[k] *= (weight_fn_vals[k] + shift);
     }
-    return getShiftedExoticQuadrature(n, shift, weight_fn_vals, shifted_weights, ref_nodes, description, is_symmetric);
+    return getShiftedExoticQuadrature(n, shift, weight_fn_vals, shifted_weights, ref_points, description, is_symmetric);
 }
 
 } // namespace(TasGrid)

--- a/Addons/tsgExoticQuadrature.hpp
+++ b/Addons/tsgExoticQuadrature.hpp
@@ -38,6 +38,9 @@
 
 namespace TasGrid {
 
+// Specifies which algorithm is used in computing the Gauss quadrature nodes and weights in getGaussNodesAndWeights() (developer use only).
+static constexpr int gauss_quadrature_version = 2;
+
 /*!
  * \internal
  * \ingroup TasmanianAddonsExoticQuad
@@ -53,13 +56,19 @@ inline double poly_eval(const std::vector<double> &roots, double x) {
 /*!
  * \internal
  * \ingroup TasmanianAddonsExoticQuad
- * \brief Generate the roots of all orthogonal polynomials up to degree n, where orthogonality is with respect to the
- * measure given by ref_weights. Specializes depending on if the underlying weight function is symmetric or not.
+ * \brief Evaluates a Lagrange basis polynomial at a point \b x.
  * \endinternal
  */
-template <bool is_symmetric>
-inline std::vector<std::vector<double>> getRoots(const int n, const std::vector<double> &ref_weights,
-                                                 const std::vector<double> &ref_points) {
+inline double lagrange_eval(size_t idx, const std::vector<double> &roots, double x) {
+    double eval_value = 1.0;
+    for (size_t i=0; i<idx; i++) {
+        eval_value *= (x - roots[i]) / (roots[idx] - roots[i]);
+    }
+    for (size_t i=idx+1; i<roots.size(); i++) {
+        eval_value *= (x - roots[i]) / (roots[idx] - roots[i]);
+    }
+    return eval_value;
+}
 
 /*!
  * \internal
@@ -73,11 +82,14 @@ template <bool is_symmetric>
 inline void getGaussNodesAndWeights(const int n, const std::vector<double> &ref_nodes, const std::vector<double> &ref_weights,
                                     std::vector<std::vector<double>> &nodes_cache, std::vector<std::vector<double>> &weights_cache) {
     // Compute the roots incrementally.
-    assert(ref_points.size() == ref_weights.size());
-    assert(ref_points.size() > 0);
-    std::vector<double> poly_m1_vals(ref_points.size(), 0.0), poly_vals(ref_points.size(), 1.0);
-    std::vector<double> diag, offdiag;
-    std::vector<std::vector<double>> roots(n);
+    assert(ref_nodes.size() == ref_weights.size());
+    assert(ref_nodes.size() > 0);
+    double mu0 = 0.0;
+    for (auto w : ref_weights) mu0 += w;
+    std::vector<double> poly_m1_vals(ref_nodes.size(), 0.0), poly_vals(ref_nodes.size(), 1.0);
+    std::vector<double> diag, off_diag;
+    nodes_cache.resize(n);
+    weights_cache.resize(n);
     for (int i=0; i<n; i++) {
         // Form the diagonal and offdiagonal vectors of the Jacobi matrix.
         if (is_symmetric) {
@@ -85,8 +97,8 @@ inline void getGaussNodesAndWeights(const int n, const std::vector<double> &ref_
         } else {
             double diag_numr = 0.0;
             double diag_denm = 0.0;
-            for (size_t j=0; j<ref_points.size(); j++) {
-            diag_numr += ref_points[j] * (poly_vals[j] * poly_vals[j]) * ref_weights[j];
+            for (size_t j=0; j<ref_nodes.size(); j++) {
+            diag_numr += ref_nodes[j] * (poly_vals[j] * poly_vals[j]) * ref_weights[j];
             diag_denm += (poly_vals[j] * poly_vals[j]) * ref_weights[j];
             }
             diag.push_back(diag_numr / diag_denm);
@@ -94,21 +106,39 @@ inline void getGaussNodesAndWeights(const int n, const std::vector<double> &ref_
         if (i >= 1) {
             double sqr_offdiag_numr = 0.0;
             double sqr_offdiag_denm = 0.0;
-            for (size_t j=0; j<ref_points.size(); j++) {
+            for (size_t j=0; j<ref_nodes.size(); j++) {
                 sqr_offdiag_numr += (poly_vals[j] * poly_vals[j]) * ref_weights[j];
                 sqr_offdiag_denm += (poly_m1_vals[j] * poly_m1_vals[j])  * ref_weights[j];
             }
-            offdiag.push_back(std::sqrt(sqr_offdiag_numr / sqr_offdiag_denm));
+            off_diag.push_back(std::sqrt(sqr_offdiag_numr / sqr_offdiag_denm));
         }
-        roots[i] = TasmanianTridiagonalSolver::getSymmetricEigenvalues(i+1, diag, offdiag);
-        if (roots[i].size() % 2 == 1 && is_symmetric) {
-            // Zero out the center for stability.
-            roots[i][(roots[i].size() - 1) / 2] = 0.0;
+        // Compute the Gauss nodes and weights.
+        if (gauss_quadrature_version == 1) {
+            // Use LAPACK to obtain the Gauss nodes and the reference nodes and weights to obtain the Gauss weights.
+            nodes_cache[i] = TasmanianTridiagonalSolver::getSymmetricEigenvalues(i+1, diag, off_diag);
+            weights_cache[i] = std::vector<double>(nodes_cache[i].size(), 0.0);
+            for (size_t j=0; j<nodes_cache[i].size(); j++) {
+                // Integrate the function l_j(x) according to the measure induced by the function [weight_fn(x) + shift].
+                for (size_t k=0; k<ref_nodes.size(); k++) {
+                    weights_cache[i][j] += lagrange_eval(j, nodes_cache[i], ref_nodes[k]) * ref_weights[k];
+                }
+            }
+        } else if (gauss_quadrature_version == 2) {
+            // Use TasmanianTridiagonalSolver::decompose().
+            std::vector<double> dummy_diag = diag;
+            std::vector<double> dummy_off_diag = off_diag;
+            TasmanianTridiagonalSolver::decompose(dummy_diag, dummy_off_diag, mu0, nodes_cache[i], weights_cache[i]);
+        } else {
+            throw std::invalid_argument("ERROR: gauss_quadrature_version must be a valid number!");
         }
-        // Update the values of the polynomials at ref_points.
+        // Zero out the center for stability.
+        if (nodes_cache[i].size() % 2 == 1) {
+            nodes_cache[i][(nodes_cache[i].size() - 1) / 2] = 0.0;
+        }
+        // Update the values of the polynomials at ref_nodes.
         std::swap(poly_m1_vals, poly_vals);
-        std::transform(ref_points.begin(), ref_points.end(), poly_vals.begin(),
-                       [&roots, i](double x){return poly_eval(roots[i], x);});
+        std::transform(ref_nodes.begin(), ref_nodes.end(), poly_vals.begin(),
+                       [&nodes_cache, i](double x){return poly_eval(nodes_cache[i], x);});
     }
     return roots;
 }
@@ -134,60 +164,54 @@ inline double lagrange_eval(size_t idx, const std::vector<double> &roots, double
 /*!
  * \internal
  * \ingroup TasmanianAddonsExoticQuad
- * \brief Generate the full cache of Exotic (weighted and possibly shifted) quadrature weights and points for an (input) max level
- * \b n, using parameters \b shift, \b weight_fn_vals, \b shifted_weights, and \b ref_points.
+ * \brief Generate the full cache of Exotic (weighted and possibly shifted) quadrature weights and nodes for an (input) max level
+ * \b n, using parameters \b shift, \b weight_fn_vals, \b shifted_weights, and \b ref_nodes.
  *
  * It is assumed that shifted_weights[i] is nonnegative and is already computed as shifted_weights[i] = ref_weights[i] *
  * (weight_fn_vals[i] + shift) for every i.
  * \endinternal
  */
-inline TasGrid::CustomTabulated getShiftedExoticQuadrature(const int n, const double shift,
-                                                           const std::vector<double> &shifted_weights, const std::vector<double> &ref_points,
+inline TasGrid::CustomTabulated getShiftedExoticQuadrature(const int n, const double shift, const std::vector<double> &weight_fn_vals,
+                                                           const std::vector<double> &shifted_weights, const std::vector<double> &ref_nodes,
                                                            const char* description, const bool is_symmetric = false) {
 
-    // Create the set of points (roots) for the first term.
-    assert(shifted_weights.size() == ref_points.size());
-    std::vector<std::vector<double>> points_cache;
+    // Create the set of nodes (roots) for the first term.
+    assert(shifted_weights.size() == ref_nodes.size());
+    assert(weight_fn_vals.size() == ref_nodes.size());
+    std::vector<std::vector<double>> nodes_cache(n), weights_cache(n);
     if (is_symmetric) {
-        points_cache = getRoots<true>(n, shifted_weights, ref_points);
+        getGaussNodesAndWeights<true>(n, ref_nodes, shifted_weights, nodes_cache, weights_cache);
     } else {
-        points_cache = getRoots<false>(n, shifted_weights, ref_points);
+        getGaussNodesAndWeights<false>(n, ref_nodes, shifted_weights, nodes_cache, weights_cache);
     }
 
     // Create the set of weights for the first term.
     std::vector<std::vector<double>> weights_cache(n);
     for (int i=0; i<n; i++) {
-        weights_cache[i] = std::vector<double>(points_cache[i].size(), 0.0);
-        for (size_t j=0; j<points_cache[i].size(); j++) {
-            // Integrate the function l_j(x) according to the measure induced by the function [weight_fn(x) + shift].
-            for (size_t k=0; k<ref_points.size(); k++) {
-                weights_cache[i][j] += lagrange_eval(j, points_cache[i], ref_points[k]) * shifted_weights[k];
-            }
-        }
-    }
+           }
 
-    // Create and append the set of correction points and weights for the second term only if the shift is nonzero.
+    // Create and append the set of correction nodes and weights for the second term only if the shift is nonzero.
     if (shift != 0.0) {
         for (int i=0; i<n; i++) {
-            const int init_size = points_cache[i].size();
-            std::vector<double> correction_points, correction_weights;
-            TasGrid::OneDimensionalNodes::getGaussLegendre(init_size, correction_weights, correction_points);
+            const int init_size = nodes_cache[i].size();
+            std::vector<double> correction_nodes, correction_weights;
+            TasGrid::OneDimensionalNodes::getGaussLegendre(init_size, correction_weights, correction_nodes);
             for (auto &w : correction_weights) w *= -shift;
-            if (correction_points.size() % 2 == 1) {
+            if (correction_nodes.size() % 2 == 1) {
                 // Zero out for stability.
-                correction_points[(correction_points.size() - 1) / 2] = 0.0;
+                correction_nodes[(correction_nodes.size() - 1) / 2] = 0.0;
             }
             // Account for duplicates up to a certain tolerance.
-            for (size_t j=0; j<correction_points.size(); j++) {
+            for (size_t j=0; j<correction_nodes.size(); j++) {
                 int nonunique_idx = -1;
                 for (int k=0; k<init_size; k++) {
-                    if (std::abs(correction_points[j] - points_cache[i][k]) <= Maths::num_tol) {
+                    if (std::abs(correction_nodes[j] - nodes_cache[i][k]) <= Maths::num_tol) {
                         nonunique_idx = k;
                         break;
                     }
                 }
                 if (nonunique_idx == -1) {
-                    points_cache[i].push_back(correction_points[j]);
+                    nodes_cache[i].push_back(correction_nodes[j]);
                     weights_cache[i].push_back(correction_weights[j]);
                 } else {
                     weights_cache[i][nonunique_idx] += correction_weights[j];
@@ -199,10 +223,10 @@ inline TasGrid::CustomTabulated getShiftedExoticQuadrature(const int n, const do
     // Output to a CustomTabulated instance.
     std::vector<int> num_nodes(n), precision(n);
     for (int i=0; i<n; i++) {
-        num_nodes[i] = points_cache[i].size();
+        num_nodes[i] = nodes_cache[i].size();
         precision[i] = 2 * (i + 1) - 1;
     }
-    return TasGrid::CustomTabulated(n, std::move(num_nodes), std::move(precision), std::move(points_cache),
+    return TasGrid::CustomTabulated(n, std::move(num_nodes), std::move(precision), std::move(nodes_cache),
                                     std::move(weights_cache), description);
 }
 
@@ -249,11 +273,16 @@ inline TasGrid::CustomTabulated getExoticQuadrature(const int n, const double sh
     if (grid.getNumOutputs() != 1) {
         throw std::invalid_argument("ERROR: grid needs to have scalar outputs!");
     }
-    std::vector<double> ref_points = grid.getLoadedPoints();
+    std::vector<double> ref_nodes = grid.getLoadedPoints();
     std::vector<double> shifted_weights = grid.getQuadratureWeights();
     std::vector<double> weight_fn_vals = std::vector<double>(grid.getLoadedValues(), grid.getLoadedValues() + grid.getNumLoaded());
-    shiftReferenceWeights(weight_fn_vals, shift, shifted_weights);
-    return getShiftedExoticQuadrature(n, shift, shifted_weights, ref_points, description, is_symmetric);
+    if (not std::all_of(weight_fn_vals.begin(), weight_fn_vals.end(), [shift](double x){return (x+shift)>=0.0;})) {
+        throw std::invalid_argument("ERROR: shift needs to be chosen so that weight_fn(x)+shift is nonnegative!");
+    }
+    for (size_t k=0; k<ref_nodes.size(); k++) {
+        shifted_weights[k] *= (weight_fn_vals[k] + shift);
+    }
+    return getShiftedExoticQuadrature(n, shift, weight_fn_vals, shifted_weights, ref_nodes, description, is_symmetric);
 }
 
 /*
@@ -268,11 +297,16 @@ inline TasGrid::CustomTabulated getExoticQuadrature(const int n, const double sh
  */
 inline TasGrid::CustomTabulated getExoticQuadrature(const int n, const double shift, std::function<double(double)> weight_fn,
                                                     const int nref, const char* description, const bool is_symmetric = false) {
-    std::vector<double> shifted_weights, ref_points, weight_fn_vals(nref);
-    TasGrid::OneDimensionalNodes::getGaussLegendre(nref, shifted_weights, ref_points);
-    std::transform(ref_points.begin(), ref_points.end(), weight_fn_vals.begin(), weight_fn);
-    shiftReferenceWeights(weight_fn_vals, shift, shifted_weights);
-    return getShiftedExoticQuadrature(n, shift, shifted_weights, ref_points, description, is_symmetric);
+    std::vector<double> shifted_weights, ref_nodes, weight_fn_vals(nref);
+    TasGrid::OneDimensionalNodes::getGaussLegendre(nref, shifted_weights, ref_nodes);
+    std::transform(ref_nodes.begin(), ref_nodes.end(), weight_fn_vals.begin(), weight_fn);
+    if (not std::all_of(weight_fn_vals.begin(), weight_fn_vals.end(), [shift](double x){return (x+shift)>=0.0;})) {
+        throw std::invalid_argument("ERROR: shift needs to be chosen so that weight_fn(x)+shift is nonnegative!");
+    }
+    for (int k=0; k<nref; k++) {
+        shifted_weights[k] *= (weight_fn_vals[k] + shift);
+    }
+    return getShiftedExoticQuadrature(n, shift, weight_fn_vals, shifted_weights, ref_nodes, description, is_symmetric);
 }
 
 } // namespace(TasGrid)

--- a/Addons/tsgExoticQuadrature.hpp
+++ b/Addons/tsgExoticQuadrature.hpp
@@ -129,8 +129,8 @@ inline void getGaussNodesAndWeights(const int n, const std::vector<double> &ref_
         } else if (gauss_quadrature_version == 2) {
             // Use TasmanianTridiagonalSolver::decompose().
             std::vector<double> dummy_diag = diag;
-            std::vector<double> dummy_off_diag = offdiag;
-            TasmanianTridiagonalSolver::decompose(dummy_diag, dummy_off_diag, mu0, points_cache[i], weights_cache[i]);
+            std::vector<double> dummy_offdiag = offdiag;
+            TasmanianTridiagonalSolver::decompose(dummy_diag, dummy_offdiag, mu0, points_cache[i], weights_cache[i]);
         } else {
             throw std::invalid_argument("ERROR: gauss_quadrature_version must be a valid number!");
         }

--- a/Addons/tsgExoticQuadrature.hpp
+++ b/Addons/tsgExoticQuadrature.hpp
@@ -61,6 +61,17 @@ template <bool is_symmetric>
 inline std::vector<std::vector<double>> getRoots(const int n, const std::vector<double> &ref_weights,
                                                  const std::vector<double> &ref_points) {
 
+/*!
+ * \internal
+ * \ingroup TasmanianAddonsExoticQuad
+ * \brief Generate the nodes and weights of a Gaussian quadrature (up to degree n) whose weight function is evaluated on \b
+ * ref_nodes and its corresponding values are stored in \b ref_weights. Specializes depending on if the underlying weight
+ * function is symmetric or not.
+ * \endinternal
+ */
+template <bool is_symmetric>
+inline void getGaussNodesAndWeights(const int n, const std::vector<double> &ref_nodes, const std::vector<double> &ref_weights,
+                                    std::vector<std::vector<double>> &nodes_cache, std::vector<std::vector<double>> &weights_cache) {
     // Compute the roots incrementally.
     assert(ref_points.size() == ref_weights.size());
     assert(ref_points.size() > 0);

--- a/Addons/tsgExoticQuadrature.hpp
+++ b/Addons/tsgExoticQuadrature.hpp
@@ -38,7 +38,7 @@
 
 namespace TasGrid {
 
-// Specifies which algorithm is used in computing the Gauss quadrature nodes and weights in getGaussNodesAndWeights() (developer use only).
+// Specifies which algorithm is used in computing the Gauss quadrature points and weights in getGaussNodesAndWeights() (developer use only).
 static constexpr int gauss_quadrature_version = 2;
 
 /*!

--- a/Addons/tsgExoticQuadrature.hpp
+++ b/Addons/tsgExoticQuadrature.hpp
@@ -74,8 +74,8 @@ inline double lagrange_eval(size_t idx, const std::vector<double> &roots, double
  * \internal
  * \ingroup TasmanianAddonsExoticQuad
  * \brief Generate the points and weights of a Gaussian quadrature (up to degree n) whose weight function is evaluated on \b
- * ref_points and its corresponding values are stored in \b ref_weights. Specializes depending on if the underlying weight
- * function is symmetric or not.
+ * ref_points and whose corresponding values are stored in \b ref_weights. Specializes depending on if the underlying weight
+ * function is symmetric or not (see \b is_symmetric).
  * \endinternal
  */
 template <bool is_symmetric>
@@ -158,14 +158,15 @@ inline TasGrid::CustomTabulated getShiftedExoticQuadrature(const int n, const do
     #ifndef Tasmanian_ENABLE_BLAS
     if (gauss_quadrature_version == 1) {
         #ifndef NDEBUG
-        std::cout << "WARNING: BLAS acceleration is not enabled. Switching to an exotic quadrature algorithm that does not"
+        std::cout << "WARNING: BLAS acceleration is not enabled!\nSwitching to an exotic quadrature algorithm that does not"
                   << "rely on BLAS subroutines..." << std::endl;
         #endif
         gauss_quadrature_version = 2;
-        #ifndef
-        std::cout << "Now using exotic quadrature with the following flags:\n" 
-                  << "TasGrid::gauss_quadrature_version = " << TasGrid::gauss_quadrature_version << "\n"
-                  << "TasGrid::decompose_version = " << TasGrid::decompose_version << std::endl;
+        #ifndef NDEBUG
+        std::cout << "Success! Now using exotic quadrature with the following (algorithm) flags:\n" 
+                  << "  TasGrid::gauss_quadrature_version = " << TasGrid::gauss_quadrature_version << "\n"
+                  << "  TasGrid::TasmanianTridiagonalSolver::decompose_version = "
+                  << TasGrid::TasmanianTridiagonalSolver::decompose_version << std::endl;
         #endif
     }
     #endif


### PR DESCRIPTION
This PR also includes some minor fixes in the testing code.