### PR TITLE
Add a MATLAB interface to exotic quadrature (from the command line).

### DIFF
--- a/InterfaceMATLAB/CMakeLists.txt
+++ b/InterfaceMATLAB/CMakeLists.txt
@@ -24,6 +24,7 @@ set(Tasmanian_matlab_source_files tsgCancelRefine.m
                                   tsgListGridsByName.m
                                   tsgLoadHCoefficients.m
                                   tsgLoadValues.m
+                                  tsgMakeExoticQuadrature.m
                                   tsgMakeFilenames.m
                                   tsgMakeFourier.m
                                   tsgMakeGlobal.m
@@ -33,6 +34,7 @@ set(Tasmanian_matlab_source_files tsgCancelRefine.m
                                   tsgMakeWavelet.m
                                   tsgMergeRefine.m
                                   tsgPlotPoints2D.m
+                                  tsgReadCustomTabulated.m
                                   tsgReadMatrix.m
                                   tsgRefineAnisotropic.m
                                   tsgRefineSurplus.m

--- a/InterfaceMATLAB/tsgMakeExoticQuadrature.m
+++ b/InterfaceMATLAB/tsgMakeExoticQuadrature.m
@@ -1,0 +1,66 @@
+function lCustomRule = tsgMakeExoticQuadrature(iDepth, fShift, sWeightFile, sDescription, bSymmetric)
+%
+% creates a custom-tabulated contain global exotic quadrature nodes and weights
+%
+% INPUT:
+%
+% fShift: (float)
+%         the shift of the weight function
+%
+% sWeightFile: (string)
+%              filename for a file constaining a surrogate/interpolant of the weight function; the format should be a 
+%              TasmanianSparseGrid in ASCII
+%
+% sDescription: (string)
+%               description of the generated custom rule, e.g. "Exotic Quadrature 1" and "Sinc rule"
+%
+% bSymmetric: (bool)
+%             if true, this declares that the weight function is symmetric
+%
+% OUTPUT:
+%
+% lCustomRule: (global grids of custom-tabulated rule)
+%
+%                structure defining the fields
+%                   lCustomRule.sDescription
+%                   lCustomRule.iMaxLevel
+%                   lCustomRule.vLevels
+%                   lCustomRule.vPrecision
+%                   lCustomRule.vNodes
+%                   lCustomRule.vWeights
+%
+%                  see help tsgWriteCustomRuleFile.m for definition of each field of the structure
+
+if (isempty(sDescription))
+    error('sDescription cannot be empty');
+end
+
+% generate filenames
+[~, sTasGrid] = tsgGetPaths();
+[~, ~, ~, ~, ~, sFileC, ~] = tsgMakeFilenames(sDescription);
+
+sCommand = [sTasGrid,' -makeexoquad'];
+sCommand = [sCommand, ' -depth ',       num2str(iDepth)];
+sCommand = [sCommand, ' -shift ',       num2str(fShift)];
+sCommand = [sCommand, ' -weightfile ', '"', sWeightFile, '"'];
+sCommand = [sCommand, ' -description ', '"', sDescription, '"'];
+if (bSymmetric)
+  sCommand = [sCommand, ' -symmetric '];
+end
+sCommand = [sCommand, ' -outputfile ', '"', sFileC, '"'];
+
+[~, cmdout] = system(sCommand);
+
+if (max(size(strfind('ERROR', cmdout))) ~= 0)
+    disp(cmdout);
+    error('The tasgrid execurable returned an error, see above');
+end
+
+% create lCustomRule object
+lCustomRule = tsgReadCustomTabulated(sFileC);
+
+lClean.sFileC = 1;
+lDummyGrid.sName = sDescription;
+tsgCleanTempFiles(lDummyGrid, lClean);
+
+end

--- a/InterfaceMATLAB/tsgMakeExoticQuadrature.m
+++ b/InterfaceMATLAB/tsgMakeExoticQuadrature.m
@@ -4,15 +4,18 @@ function lCustomRule = tsgMakeExoticQuadrature(iDepth, fShift, sWeightFile, sDes
 %
 % INPUT:
 %
+% iDepth: (integer non-negative)
+%         controls the density of the grid
+%
 % fShift: (float)
 %         the shift of the weight function
 %
 % sWeightFile: (string)
 %              filename for a file constaining a surrogate/interpolant of the weight function; the format should be a 
-%              TasmanianSparseGrid in ASCII
+%              TasmanianSparseGrid in ASCII format
 %
 % sDescription: (string)
-%               description of the generated custom rule, e.g. "Exotic Quadrature 1" and "Sinc rule"
+%               description of the generated custom rule, e.g. "Exotic Quadrature 1" or "Sinc rule"
 %
 % bSymmetric: (bool)
 %             if true, this declares that the weight function is symmetric

--- a/InterfaceMATLAB/tsgReadCustomTabulated.m
+++ b/InterfaceMATLAB/tsgReadCustomTabulated.m
@@ -1,0 +1,58 @@
+function lCustomRule = tsgReadCustomTabulated(sFilename)
+%
+% reads a custom-tabulated rule from an ASCII file
+%
+% description: Test CT
+% levels: 2
+% 1 1
+% 2 3
+% 2.0 0.0
+% 1.5 -0.5
+% 0.5 0.5
+%
+% results in the list with properties
+%
+% sDescription = 'Test CT'
+% iMaxLevel = 2
+% vLevels = [1; 2]
+% vPrecision = [1; 3]
+% vNodes = [0.0, -0.5, 0.5]
+% vWeights = [2.0, 1.5, 0.5]
+%
+
+sFilename = regexprep(sFilename, '\\ ', ' ');
+fid = fopen(sFilename);
+
+sLine = fgetl(fid);
+if (strfind('description: ', sLine) ~= 1)
+  error('Wrong file format of custom tabulated file on line 1!');
+end
+lCustomRule.sDescription = strrep(sLine, 'description: ', '');
+
+sLine = fgetl(fid);
+if (strfind('levels: ', sLine) ~= 1)
+  error('Wrong file format of custom tabulated file on line 2!');
+end
+lCustomRule.iMaxLevel = str2num(strrep(sLine, 'levels: ', ''));
+
+lCustomRule.vLevels = NaN(lCustomRule.iMaxLevel, 1);
+lCustomRule.vPrecision = NaN(lCustomRule.iMaxLevel, 1);
+for i=1:lCustomRule.iMaxLevel
+  sLine = fgetl(fid);
+  aData = strsplit(sLine, ' ');
+  lCustomRule.vLevels(i) = str2num(aData{1});
+  lCustomRule.vPrecision(i) = str2num(aData{2});
+end
+
+lCustomRule.vNodes = NaN(sum(lCustomRule.vLevels), 1);
+lCustomRule.vWeights = NaN(sum(lCustomRule.vLevels), 1);
+for i=1:sum(lCustomRule.vLevels)
+  sLine = fgetl(fid);
+  aData = strsplit(sLine, ' ');
+  lCustomRule.vNodes(i) = str2double(aData{2});
+  lCustomRule.vWeights(i) = str2double(aData{1});
+end
+
+fclose(fid);
+
+end


### PR DESCRIPTION
Here is a sample MATLAB script that tests the functionality:
```
iDepth = 5;
fShift = 1.0;
sWeightFile = './sinc0.txt';
sDescription = 'Sinc Exoquad';
bSymmetric = true;
lCustomRule = tsgMakeExoticQuadrature(iDepth, fShift, sWeightFile, sDescription, bSymmetric);
disp(lCustomRule);
```
The file "sinc0.txt" can be found [here](https://github.com/ORNL/TASMANIAN/files/7313579/sinc0.txt).