### PR TITLE
Change a CustomTabulated constructor

### DIFF
--- a/Addons/testCustomTabulated.hpp
+++ b/Addons/testCustomTabulated.hpp
@@ -56,7 +56,7 @@ inline bool testGetSubrules() {
             precision[i] = i;
             OneDimensionalNodes::getGaussLegendre(num_nodes[i], weights[i], nodes[i]);
         }
-        TasGrid::CustomTabulated ct = TasGrid::CustomTabulated(n, std::move(num_nodes), std::move(precision), std::move(nodes),
+        TasGrid::CustomTabulated ct = TasGrid::CustomTabulated(std::move(num_nodes), std::move(precision), std::move(nodes),
                                                                std::move(weights), "Gauss-Legendre rules");
         // Create the subset and test different start_index and stride combinations.
         for (auto start_index : start_index_vec) {

--- a/Addons/tsgExoticQuadrature.hpp
+++ b/Addons/tsgExoticQuadrature.hpp
@@ -278,8 +278,8 @@ inline TasGrid::CustomTabulated getShiftedExoticQuadrature(const int n, const do
         num_nodes[i] = static_cast<int>(points_cache[i].size());
         precision[i] = 2 * (i + 1) - 1;
     }
-    return TasGrid::CustomTabulated(n, std::move(num_nodes), std::move(precision), std::move(points_cache),
-                                    std::move(weights_cache), description);
+    return TasGrid::CustomTabulated(std::move(num_nodes), std::move(precision), std::move(points_cache), std::move(weights_cache),
+                                    description);
 }
 
 /*!

--- a/SparseGrids/TasmanianSparseGridWrapC.cpp
+++ b/SparseGrids/TasmanianSparseGridWrapC.cpp
@@ -529,7 +529,7 @@ void* tsgMakeCustomTabulatedFromData(const int cnum_levels, const int* cnum_node
         vec_cweights[l] = std::vector<double>(&cweights[ptr_idx], &cweights[ptr_idx] + cnum_nodes[l]);
         ptr_idx += cnum_nodes[l];
     }
-    return new TasGrid::CustomTabulated(cnum_levels, std::vector<int>(cnum_nodes, cnum_nodes + cnum_levels),
+    return new TasGrid::CustomTabulated(std::vector<int>(cnum_nodes, cnum_nodes + cnum_levels),
                                         std::vector<int>(cprecision, cprecision + cnum_levels), std::move(vec_cnodes),
                                         std::move(vec_cweights), cdescription);
 }

--- a/SparseGrids/tsgCoreOneDimensional.cpp
+++ b/SparseGrids/tsgCoreOneDimensional.cpp
@@ -152,8 +152,8 @@ CustomTabulated getSubrules(CustomTabulated &ct, int start_index, int stride, st
         sub_nodes.emplace_back(std::vector<double>());
         ct.getWeightsNodes(level, sub_weights.back(), sub_nodes.back());
     }
-    return CustomTabulated(sub_num_nodes.size(), std::move(sub_num_nodes), std::move(sub_precision), std::move(sub_nodes),
-                           std::move(sub_weights), std::move(description));
+    return CustomTabulated(std::move(sub_num_nodes), std::move(sub_precision), std::move(sub_nodes), std::move(sub_weights),
+                           std::move(description));
 }
 
 int OneDimensionalMeta::getNumPoints(int level, TypeOneDRule rule){

--- a/SparseGrids/tsgCoreOneDimensional.hpp
+++ b/SparseGrids/tsgCoreOneDimensional.hpp
@@ -73,10 +73,10 @@ public:
             read<mode_ascii>(is); else read<mode_binary>(is);
     }
     //! \brief Assume ownership of existing data instead of reading from a file.
-    CustomTabulated(int cnum_levels, std::vector<int> &&cnum_nodes, std::vector<int> &&cprecision,
+    CustomTabulated(std::vector<int> &&cnum_nodes, std::vector<int> &&cprecision,
                     std::vector<std::vector<double>> &&cnodes, std::vector<std::vector<double>> &&cweights,
                     std::string &&cdescription) :
-        num_levels(cnum_levels), num_nodes(std::move(cnum_nodes)), precision(std::move(cprecision)),
+        num_levels(cnum_nodes.size()), num_nodes(std::move(cnum_nodes)), precision(std::move(cprecision)),
         nodes(std::move(cnodes)), weights(std::move(cweights)), description(std::move(cdescription))
     {}
 


### PR DESCRIPTION
Remove the first argument of one of the ``CustomTabulated`` constructors, and modify all code that depends on this constructor appropriately.