### PR TITLE
Add nodal differentiation tests

### DIFF
--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -379,6 +379,26 @@ void TasmanianSparseGrid::getInterpolationWeights(const double x[], double weigh
     base->getInterpolationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
 }
 
+std::vector<double> TasmanianSparseGrid::getDifferentiationWeights(std::vector<double> const &x) const{
+    std::vector<double> w;
+    getDifferentiationWeights(x, w);
+    return w;
+}
+void TasmanianSparseGrid::getDifferentiationWeights(const std::vector<double> &x, std::vector<double> &weights) const{
+    if (x.size() != (size_t) base->getNumDimensions())
+        throw std::runtime_error("ERROR: getDifferentiationWeights() incorrect size of x, must be same as getNumDimensions()");
+    weights.resize((size_t) getNumPoints());
+    getDifferentiationWeights(x.data(), weights.data());
+}
+void TasmanianSparseGrid::getDifferentiationWeights(const double x[], double weights[]) const{
+    Data2D<double> x_tmp;
+    if (!isGlobal()) {
+        get<GridGlobal>()->getDifferentiationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
+    } else {
+        throw std::runtime_error("ERROR: getDifferentiationWeights() cannot be called for grids of this type");
+    }
+}
+
 void TasmanianSparseGrid::loadNeededValues(const double *vals){
     if (empty()) throw std::runtime_error("Cannot load model values into an empty grid!");
     base->loadNeededValues(vals);

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -387,12 +387,12 @@ std::vector<double> TasmanianSparseGrid::getDifferentiationWeights(std::vector<d
 void TasmanianSparseGrid::getDifferentiationWeights(const std::vector<double> &x, std::vector<double> &weights) const{
     if (x.size() != (size_t) base->getNumDimensions())
         throw std::runtime_error("ERROR: getDifferentiationWeights() incorrect size of x, must be same as getNumDimensions()");
-    weights.resize((size_t) getNumPoints());
+    weights.resize((size_t) getNumPoints() * (size_t) getNumDimensions());
     getDifferentiationWeights(x.data(), weights.data());
 }
 void TasmanianSparseGrid::getDifferentiationWeights(const double x[], double weights[]) const{
     Data2D<double> x_tmp;
-    if (!isGlobal()) {
+    if (isGlobal()) {
         get<GridGlobal>()->getDifferentiationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
     } else {
         throw std::runtime_error("ERROR: getDifferentiationWeights() cannot be called for grids of this type");

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -175,7 +175,7 @@ namespace TasGrid{
  * - getLoadedValues()
  * - getQuadratureWeights()
  * - getInterpolationWeights()
- * - getDerivativeWeights()
+ * - getDifferentiationWeights()
  *
  * \par Load Model Values or Hierarchical Coefficients
  * In order to construct an interpolant, Tasmanian needed to compute the

--- a/SparseGrids/gridtestTestFunctions.cpp
+++ b/SparseGrids/gridtestTestFunctions.cpp
@@ -48,7 +48,7 @@ void OneOneP0::getDerivative(const double*, double y[]) const{ y[0] = 0.0; }
 OneOneP3::OneOneP3(){} OneOneP3::~OneOneP3(){} int OneOneP3::getNumInputs() const{ return 1; } int OneOneP3::getNumOutputs() const{ return 1; }
 const char* OneOneP3::getDescription() const{ return "f(x) = x^3 + 2 x^2 + x + 3"; }
 void OneOneP3::eval(const double x[], double y[]) const{ y[0] = x[0]*x[0]*x[0] + 2.0*x[0]*x[0] + x[0] + 3.0; } void OneOneP3::getIntegral(double y[]) const{ y[0] = 22.0/3.0; }
-void OneOneP3::getDerivative(const double x[], double y[]) const{ y[0] = 2.0*x[0]*x[0] + 4.0*x[0] + 1.0; }
+void OneOneP3::getDerivative(const double x[], double y[]) const{ y[0] = 3.0*x[0]*x[0] + 4.0*x[0] + 1.0; }
 
 OneOneP4::OneOneP4(){} OneOneP4::~OneOneP4(){} int OneOneP4::getNumInputs() const{ return 1; } int OneOneP4::getNumOutputs() const{ return 1; }
 const char* OneOneP4::getDescription() const{ return "f(x) = 0.5 x^4 + x^3 + 2 x^2 + x + 3"; }

--- a/SparseGrids/tsgGridGlobal.cpp
+++ b/SparseGrids/tsgGridGlobal.cpp
@@ -273,7 +273,7 @@ void GridGlobal::getInterpolationWeights(const double x[], double weights[]) con
     }
 }
 
-void GridGlobal::getDerivativeWeights(const double x[], double weights[]) const{
+void GridGlobal::getDifferentiationWeights(const double x[], double weights[]) const{
     // The weight of the i-th point in the k-th dimension is given by weights[i * num_dimensions + k].
     std::fill_n(weights, (points.empty() ? needed.getNumIndexes(): points.getNumIndexes()) * num_dimensions, 0.0);
 
@@ -707,7 +707,7 @@ void GridGlobal::integrate(double q[], double *conformal_correction) const{
 void GridGlobal::differentiate(const double x[], double jacobian[]) const {
     // Based on the logic in the GridGlobal::evaluate() function.
     std::vector<double> w(points.getNumIndexes() * num_dimensions);
-    getDerivativeWeights(x, w.data());
+    getDifferentiationWeights(x, w.data());
     std::fill_n(jacobian, num_outputs * num_dimensions, 0.0);
     for(int i=0; i<points.getNumIndexes(); i++) {
         const double *v = values.getValues(i);

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -77,7 +77,7 @@ public:
 
     void getQuadratureWeights(double weights[]) const override;
     void getInterpolationWeights(const double x[], double weights[]) const override;
-    void getDerivativeWeights(const double x[], double weights[]) const;
+    void getDifferentiationWeights(const double x[], double weights[]) const;
 
     void loadNeededValues(const double *vals) override;
 


### PR DESCRIPTION
Adds tests for nodal differentiation, which uses the weights generated by the new function `TasGrid::TasmanianSparseGrid::getDifferentiationWeights()` and outer products these with the function values to generate the Jacobian matrix. 

Note that I renamed `TasGrid::GridGlobal::getDerivativeWeights()` to `TasGrid::GridGlobal::getDifferentiationWeights()` in order to be more consistent with the other "getWeight()" functions, i.e., `TasGrid::GridGlobal::getInterpolationWeights()` and `TasGrid::GridGlobal::getQuadratureWeights()`.