### PR TITLE
Add differentiation to Fourier grids + small bug fixes

### DIFF
--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -391,7 +391,9 @@ void TasmanianSparseGrid::getDifferentiationWeights(const std::vector<double> &x
     getDifferentiationWeights(x.data(), weights.data());
 }
 void TasmanianSparseGrid::getDifferentiationWeights(const double x[], double weights[]) const{
+    // See differentiate() for how the domain transforms are taken into consideration.
     Data2D<double> x_tmp;
+    // Jacobian of f(.) at g(x).
     if (isGlobal()) {
         get<GridGlobal>()->getDifferentiationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
     } else if (isSequence()) {
@@ -402,6 +404,16 @@ void TasmanianSparseGrid::getDifferentiationWeights(const double x[], double wei
         get<GridFourier>()->getDifferentiationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
     } else {
         throw std::runtime_error("ERROR: getDifferentiationWeights() cannot be called for grids of this type");
+    }
+    // Jacobian of f(g(.)) at x.
+    if (domain_transform_a.size() != 0 or conformal_asin_power.size() != 0) {
+        int num_dimensions = getNumDimensions();
+        int num_points = getNumPoints();
+        std::vector<double> jacobian_g_diag(num_dimensions);
+        diffCanonicalTransform<double>(x, jacobian_g_diag.data());
+        for(int i=0; i<num_points; i++)
+            for(int j=0; j<num_dimensions; j++)
+                weights[i * num_dimensions + j] = weights[i * num_dimensions + j] * jacobian_g_diag[j];
     }
 }
 
@@ -481,16 +493,30 @@ void TasmanianSparseGrid::integrate(double q[]) const{
 }
 
 void TasmanianSparseGrid::differentiate(const double x[], double jacobian[]) const {
+    // For a grid with a transformed-to-canonical operator g(x) and model f(x) over the canonical domain, this returns the
+    // Jacobian of f(g(x)), i.e., [Jacobian of f(.) at g(x)] * [Jacobian of g(.) at x].
+    Data2D<double> x_tmp;
+    // Jacobian of f(.) at g(x).
     if (isGlobal()) {
-        get<GridGlobal>()->differentiate(x, jacobian);
+        get<GridGlobal>()->differentiate(formCanonicalPoints(x, x_tmp, 1), jacobian);
     } else if (isSequence()) {
-        get<GridSequence>()->differentiate(x, jacobian);
+        get<GridSequence>()->differentiate(formCanonicalPoints(x, x_tmp, 1), jacobian);
     } else if (isLocalPolynomial()) {
-        get<GridLocalPolynomial>()->differentiate(x, jacobian);
+        get<GridLocalPolynomial>()->differentiate(formCanonicalPoints(x, x_tmp, 1), jacobian);
     } else if (isFourier()) {
-        get<GridFourier>()->differentiate(x, jacobian);
+        get<GridFourier>()->differentiate(formCanonicalPoints(x, x_tmp, 1), jacobian);
     } else {
         throw std::runtime_error("ERROR: in differentiate(), jacobians/gradients are not available for this type of grid");
+    }
+    // Jacobian of f(g(.)) at x.
+    if (domain_transform_a.size() != 0 or conformal_asin_power.size() != 0) {
+        int num_dimensions = getNumDimensions();
+        int num_outputs = getNumOutputs();
+        std::vector<double> jacobian_g_diag(num_dimensions);
+        diffCanonicalTransform<double>(x, jacobian_g_diag.data());
+        for(int j=0; j<num_dimensions; j++)
+            for(int k=0; k<num_outputs; k++)
+                jacobian[k * num_dimensions + j] = jacobian[k * num_dimensions + j] * jacobian_g_diag[j];
     }
 }
 
@@ -821,6 +847,31 @@ template<typename FloatType> const FloatType* TasmanianSparseGrid::formCanonical
 }
 template const float* TasmanianSparseGrid::formCanonicalPoints(const float *x, Data2D<float> &x_temp, int num_x) const;
 template const double* TasmanianSparseGrid::formCanonicalPoints<double>(const double *x, Data2D<double> &x_temp, int num_x) const;
+
+template<typename FloatType> void TasmanianSparseGrid::diffCanonicalTransform(const FloatType*, FloatType *jacobian_diag) const {
+    int num_dimensions = base->getNumDimensions();
+    for(int i=0; i<num_dimensions; i++)
+        jacobian_diag[i] = 1.0;
+    if (conformal_asin_power.size() != 0) {
+        throw std::runtime_error("ERROR: in diffCanonicalTransform() derivatives/Jacobians are not available for conformal mappings");
+    }
+    if (domain_transform_a.size() != 0) {
+        // Based on the logic in mapTransformedToCanonical(). These are all affine transforms.
+        TypeOneDRule rule = base->getRule();
+        if (rule == rule_gausslaguerre or rule == rule_gausslaguerreodd)
+            for(int j=0; j<num_dimensions; j++)
+                jacobian_diag[j] *= (FloatType) domain_transform_b[j];
+        else if (rule == rule_gausshermite or rule == rule_gausshermiteodd)
+            for(int j=0; j<num_dimensions; j++)
+                jacobian_diag[j] *= (FloatType) std::sqrt(domain_transform_b[j]);
+        else if (rule == rule_fourier)
+            for(int j=0; j< num_dimensions; j++)
+                jacobian_diag[j] /= (FloatType) (domain_transform_b[j]-domain_transform_a[j]);
+        else
+            for(int j=0; j<num_dimensions; j++)
+                jacobian_diag[j] *= (FloatType) (2.0 / (domain_transform_b[j] - domain_transform_a[j]));
+    }
+}
 
 void TasmanianSparseGrid::formTransformedPoints(int num_points, double x[]) const{
     mapConformalCanonicalToTransformed(base->getNumDimensions(), num_points, x); // internally switch based on the conformal transform

--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -398,6 +398,8 @@ void TasmanianSparseGrid::getDifferentiationWeights(const double x[], double wei
         get<GridSequence>()->getDifferentiationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
     } else if (isLocalPolynomial()) {
         get<GridLocalPolynomial>()->getDifferentiationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
+    } else if (isFourier()) {
+        get<GridFourier>()->getDifferentiationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
     } else {
         throw std::runtime_error("ERROR: getDifferentiationWeights() cannot be called for grids of this type");
     }
@@ -485,6 +487,8 @@ void TasmanianSparseGrid::differentiate(const double x[], double jacobian[]) con
         get<GridSequence>()->differentiate(x, jacobian);
     } else if (isLocalPolynomial()) {
         get<GridLocalPolynomial>()->differentiate(x, jacobian);
+    } else if (isFourier()) {
+        get<GridFourier>()->differentiate(x, jacobian);
     } else {
         throw std::runtime_error("ERROR: in differentiate(), jacobians/gradients are not available for this type of grid");
     }

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -2140,6 +2140,15 @@ protected:
     const T* formCanonicalPointsGPU(const T *gpu_x, int num_x, GpuVector<T> &gpu_x_temp) const;
     /*!
      * \internal
+     * \brief Calculates the Jacobian matrix (derivative) of the transform defined by formCanonicalPoints(). Since this matrix is
+     * diagonal, we only return the diagonal vector.
+     *
+     * This is primarily used in the TasmanianSparseGrid::differentiate() method, which applies the chain rule to the (possibly)
+     * transformed grid.
+     */
+    template<typename FloatType> void diffCanonicalTransform(const FloatType *x, FloatType *jacobian_diag) const;
+    /*!
+     * \internal
      * \brief Applies both linear and non-linear transformation to the canonical points.
      *
      * The raw-array \b x holds \b num_points and will be overwritten with the result

--- a/SparseGrids/TasmanianSparseGrid.hpp
+++ b/SparseGrids/TasmanianSparseGrid.hpp
@@ -2146,7 +2146,7 @@ protected:
      * This is primarily used in the TasmanianSparseGrid::differentiate() method, which applies the chain rule to the (possibly)
      * transformed grid.
      */
-    template<typename FloatType> void diffCanonicalTransform(const FloatType *x, FloatType *jacobian_diag) const;
+    template<typename FloatType> std::vector<double> diffCanonicalTransform() const;
     /*!
      * \internal
      * \brief Applies both linear and non-linear transformation to the canonical points.

--- a/SparseGrids/gridtestExternalTests.cpp
+++ b/SparseGrids/gridtestExternalTests.cpp
@@ -288,7 +288,7 @@ TestResults ExternalTester::getError(const BaseFunction *f, TasGrid::TasmanianSp
         };
         R.error = err;
     }else if (type == type_internal_interpolation or type == type_internal_differentiation){
-        if (type == type_internal_differentiation and !(grid.isGlobal() or grid.isSequence() or grid.isLocalPolynomial())) {
+        if (type == type_internal_differentiation and !(grid.isGlobal() or grid.isSequence() or grid.isLocalPolynomial() or grid.isFourier())) {
             // Avoid testing grids where derivatives have not been implemented.
             R.error = 0.0;
         } else {
@@ -326,7 +326,6 @@ TestResults ExternalTester::getError(const BaseFunction *f, TasGrid::TasmanianSp
 
             if (type == type_internal_differentiation or type == type_nodal_differentiation)
                 rel_err = std::max(rel_err, unitDerivativeTests(f, grid));
-
             R.error = rel_err;
         }
     }
@@ -1216,13 +1215,13 @@ bool ExternalTester::testAllWavelet() const{
 
 bool ExternalTester::testAllFourier() const{
     bool pass = true;
-    const int depths1[3] = { 6, 6, 6 };
-    const int depths2[3] = { 5, 5, 5 };
-    const double tols1[3] = { 1.E-11, 1.E-06, 1.E-06 };
-    const double tols2[3] = { 1.E-11, 5.E-03, 5.E-03 };
+    const int depths1[5] = { 6, 6, 6, 8, 8 };
+    const int depths2[5] = { 5, 5, 5, 7, 7 };
+    const double tols1[5] = { 1.E-11, 1.E-06, 1.E-06, 1.E-05, 1.E-05 };
+    const double tols2[5] = { 1.E-11, 5.E-03, 5.E-03, 5.E-02, 5.E-02 };
     int wfirst = 11, wsecond = 34, wthird = 15;
-    if (testGlobalRule(&f21expsincos, TasGrid::rule_fourier, 0, 0, 0, quad_int, depths1, tols1) &&
-        testGlobalRule(&f21expsincos, TasGrid::rule_fourier, 0, 0, 0, quad_int, depths2, tols2)){
+    if (testGlobalRule(&f21expsincos, TasGrid::rule_fourier, 0, 0, 0, all_test_types, depths1, tols1) &&
+        testGlobalRule(&f21expsincos, TasGrid::rule_fourier, 0, 0, 0, all_test_types, depths2, tols2)){
         cout << setw(wfirst) << "Rules" << setw(wsecond) << "fourier" << setw(wthird) << "Pass" << endl;
     }else{
         cout << setw(wfirst) << "Rules" << setw(wsecond) << "fourier" << setw(wthird) << "FAIL" << endl; pass = false;
@@ -2318,8 +2317,32 @@ bool ExternalTester::testAllAcceleration() const{
 }
 
 void ExternalTester::debugTest(){
-    cout << "Debug Test (callable from the CMake build folder)" << endl;
-    cout << "Put testing code here and call with ./SparseGrids/gridtester debug" << endl;
+    // cout << "Debug Test (callable from the CMake build folder)" << endl;
+    // cout << "Put testing code here and call with ./SparseGrids/gridtester debug" << endl;
+
+    int depth = 8;
+    // auto f = &f21sinsin;
+    auto f = &f21expsincos;
+    auto grid = makeFourierGrid(f->getNumInputs(), f->getNumOutputs(), depth, TasGrid::type_level);
+
+    // // BASIC TEST.
+    // loadValues(f, grid);
+
+    // std::vector<double> x0 = {0.30, 0.60};
+    // std::vector<double> grad_tasm(f->getNumInputs()), grad_true(f->getNumInputs());
+    // grid.differentiate(x0.data(), grad_tasm.data());
+    // f->getDerivative(x0.data(), grad_true.data());
+
+    // std::cout << f->getDescription(); std::cout << ", x = "; for (auto xi : x0) std::cout << xi << " ";
+    // std::cout << std::endl;
+    // std::cout << "tasm = "; for (auto g : grad_tasm) std::cout << g << " ";
+    // std::cout << std::endl;
+    // std::cout << "true = "; for (auto g : grad_true) std::cout << g << " ";
+
+    // SIMULATED TEST.
+    auto R = getError(f, grid, type_internal_differentiation);
+    std::cout << "err = " << R.error << std::endl;
+
 }
 
 void ExternalTester::debugTestII(){

--- a/SparseGrids/gridtestExternalTests.cpp
+++ b/SparseGrids/gridtestExternalTests.cpp
@@ -313,6 +313,11 @@ TestResults ExternalTester::getError(const BaseFunction *f, TasGrid::TasmanianSp
                 }
             }
 
+
+            std::cout << "TEST: " << testName(type) << std::endl;
+            std::cout << f->getDescription() << std::endl;
+
+
             double rel_err = 0.0; // relative error
             for(int k=0; k<num_entries; k++){
                 double nrm = 0.0; // norm, needed to compute relative error
@@ -324,8 +329,13 @@ TestResults ExternalTester::getError(const BaseFunction *f, TasGrid::TasmanianSp
                 rel_err = std::max(rel_err, std::fabs(nrm) <= Maths::num_tol ? err : err / nrm);
             }
 
-            if (type == type_internal_differentiation or type == type_nodal_differentiation)
+            std::cout << "rel_err (pre): " << rel_err << std::endl;
+
+            if (type == type_internal_differentiation)
                 rel_err = std::max(rel_err, unitDerivativeTests(f, grid));
+
+            std::cout << "rel_err (post): " << rel_err << std::endl;
+
             R.error = rel_err;
         }
     }
@@ -358,6 +368,13 @@ bool ExternalTester::testGlobalRule(const BaseFunction *f, TasGrid::TypeOneDRule
                 grid.makeGlobalGrid(f->getNumInputs(), num_fn_outputs, depths[i], type, rule, anisotropic, alpha, beta, custom_filename);
             }
         }
+
+
+        std::cout << std::endl;
+        std::cout << "tests[i]: " << testName(tests[i]) << std::endl;
+        std::cout << "depths[i]: " << depths[i] << std::endl;
+
+
         R = getError(f, grid, tests[i], x);
         if (R.error > tols[i]){
             bPass = false;
@@ -1215,8 +1232,8 @@ bool ExternalTester::testAllWavelet() const{
 
 bool ExternalTester::testAllFourier() const{
     bool pass = true;
-    const int depths1[5] = { 6, 6, 6, 8, 8 };
-    const int depths2[5] = { 5, 5, 5, 7, 7 };
+    const int depths1[5] = { 6, 6, 6, 6, 6 };
+    const int depths2[5] = { 5, 5, 5, 5, 5 };
     const double tols1[5] = { 1.E-11, 1.E-06, 1.E-06, 1.E-05, 1.E-05 };
     const double tols2[5] = { 1.E-11, 5.E-03, 5.E-03, 5.E-02, 5.E-02 };
     int wfirst = 11, wsecond = 34, wthird = 15;
@@ -2320,7 +2337,7 @@ void ExternalTester::debugTest(){
     // cout << "Debug Test (callable from the CMake build folder)" << endl;
     // cout << "Put testing code here and call with ./SparseGrids/gridtester debug" << endl;
 
-    int depth = 8;
+    int depth = 5;
     // auto f = &f21sinsin;
     auto f = &f21expsincos;
     auto grid = makeFourierGrid(f->getNumInputs(), f->getNumOutputs(), depth, TasGrid::type_level);
@@ -2339,9 +2356,14 @@ void ExternalTester::debugTest(){
     // std::cout << std::endl;
     // std::cout << "true = "; for (auto g : grad_true) std::cout << g << " ";
 
-    // SIMULATED TEST.
-    auto R = getError(f, grid, type_internal_differentiation);
-    std::cout << "err = " << R.error << std::endl;
+    // // SIMULATED TEST.
+    // auto R = getError(f, grid, type_internal_differentiation);
+    // std::cout << "err = " << R.error << std::endl;
+
+    // FOURIER TEST.
+    int depths[2] = { 6, 6 };
+    double tols[2] = { 1E-05, 1E-05 };
+    testGlobalRule(&f21expsincos, TasGrid::rule_fourier, 0, 0, 0, diff_only, depths, tols);
 
 }
 

--- a/SparseGrids/gridtestExternalTests.cpp
+++ b/SparseGrids/gridtestExternalTests.cpp
@@ -312,6 +312,7 @@ TestResults ExternalTester::getError(const BaseFunction *f, TasGrid::TasmanianSp
                     f->getDerivative(&(test_x[i * num_dimensions]), &(result_true[i * num_entries]));
                 }
             }
+
             double rel_err = 0.0; // relative error
             for(int k=0; k<num_entries; k++){
                 double nrm = 0.0; // norm, needed to compute relative error
@@ -1217,7 +1218,7 @@ bool ExternalTester::testAllFourier() const{
     bool pass = true;
     const int depths1[5] = { 6, 6, 6, 6, 6 };
     const int depths2[5] = { 5, 5, 5, 5, 5 };
-    const double tols1[5] = { 1.E-11, 1.E-06, 1.E-06, 5.E-05, 1.E-05 };
+    const double tols1[5] = { 1.E-11, 1.E-06, 1.E-06, 5.E-04, 1.E-05 };
     const double tols2[5] = { 1.E-11, 1.E-02, 1.E-02, 5.E-01, 1.E-01 };
     int wfirst = 11, wsecond = 34, wthird = 15;
     if (testGlobalRule(&f21expsincos, TasGrid::rule_fourier, 0, 0, 0, all_test_types, depths1, tols1) &&
@@ -2317,47 +2318,8 @@ bool ExternalTester::testAllAcceleration() const{
 }
 
 void ExternalTester::debugTest(){
-    // cout << "Debug Test (callable from the CMake build folder)" << endl;
-    // cout << "Put testing code here and call with ./SparseGrids/gridtester debug" << endl;
-
-    int depth = 7;
-    auto f = &f21expsincos;
-    std::vector<double> x0 = genRandom(f->getNumInputs());
-    for (auto &x0i : x0) x0i = 0.5 * (x0i + 1.0);
-    auto grid = makeFourierGrid(f->getNumInputs(), f->getNumOutputs(), depth, TasGrid::type_level);
-
-    // // BASIC TEST.
-    // loadValues(f, grid);
-
-    // std::vector<double> grad_tasm(f->getNumInputs()), grad_true(f->getNumInputs());
-    // grid.differentiate(x0.data(), grad_tasm.data());
-    // f->getDerivative(x0.data(), grad_true.data());
-
-    // std::cout << f->getDescription(); std::cout << ", x = "; for (auto xi : x0) std::cout << xi << " ";
-    // std::cout << std::endl;
-    // std::cout << "tasm = "; for (auto g : grad_tasm) std::cout << g << " ";
-    // std::cout << std::endl;
-    // std::cout << "true = "; for (auto g : grad_true) std::cout << g << " ";
-
-    // // SIMULATED TEST.
-
-    std::cout << "NODAL INTERPOLATION\n";
-    auto R0 = getError(f, grid, type_nodal_interpolation, x0);
-    std::cout << "err = " << R0.error << "\n\n";
-
-    std::cout << "NODAL DIFFERENTIATION\n";
-    auto R1 = getError(f, grid, type_nodal_differentiation, x0);
-    std::cout << "err = " << R1.error << "\n\n";
-
-    std::cout << "INTERNAL DIFFERENTIATION\n";
-    auto R2 = getError(f, grid, type_internal_differentiation, x0);
-    std::cout << "err = " << R2.error << "\n\n";
-
-    // // FOURIER TEST.
-    // int depths[2] = { 6, 6 };
-    // double tols[2] = { 1E-05, 1E-05 };
-    // testGlobalRule(&f21expsincos, TasGrid::rule_fourier, 0, 0, 0, diff_only, depths, tols);
-
+    cout << "Debug Test (callable from the CMake build folder)" << endl;
+    cout << "Put testing code here and call with ./SparseGrids/gridtester debug" << endl;
 }
 
 void ExternalTester::debugTestII(){

--- a/SparseGrids/gridtestTestFunctions.cpp
+++ b/SparseGrids/gridtestTestFunctions.cpp
@@ -122,7 +122,7 @@ const char* TwoOneExpSinCos::getDescription() const{ return "f(x,y) = exp(sin(2*
 void TwoOneExpSinCos::eval(const double x[], double y[]) const{ y[0] = std::exp(std::sin(2*pi*x[0])+std::cos(2*pi*x[1])); } void TwoOneExpSinCos::getIntegral(double y[]) const{ y[0] = 1.6029228068079633 * 4.0; }
 void TwoOneExpSinCos::getDerivative(const double x[], double y[]) const{
     y[0] = 2*pi * std::cos(2*pi*x[0]) * std::exp(std::sin(2*pi*x[0])+std::cos(2*pi*x[1]));
-    y[1] = -2*pi * std::sin(2*pi*x[0]) * std::exp(std::sin(2*pi*x[0])+std::cos(2*pi*x[1]));
+    y[1] = -2*pi * std::sin(2*pi*x[1]) * std::exp(std::sin(2*pi*x[0])+std::cos(2*pi*x[1]));
 }
 
 TwoOneSinCosAxis::TwoOneSinCosAxis() {} TwoOneSinCosAxis::~TwoOneSinCosAxis() {} int TwoOneSinCosAxis::getNumInputs() const{ return 2; } int TwoOneSinCosAxis::getNumOutputs() const{ return 1; }

--- a/SparseGrids/gridtestTestFunctions.cpp
+++ b/SparseGrids/gridtestTestFunctions.cpp
@@ -288,7 +288,7 @@ TwoOneConformalOne::TwoOneConformalOne(){} TwoOneConformalOne::~TwoOneConformalO
 const char* TwoOneConformalOne::getDescription() const{ return "f(x) = 1 / ((1 + 5x^2)*(1 + 5y^2))"; }
 void TwoOneConformalOne::eval(const double x[], double y[]) const{ y[0] = 1.0 / ((1.0 + 5.0*x[0]*x[0]) * (1.0 + 5.0*x[1]*x[1])); } void TwoOneConformalOne::getIntegral(double y[]) const{ y[0] = 1.028825601981092*1.028825601981092; }
 void TwoOneConformalOne::getDerivative(const double x[], double y[]) const{
-    double a0 = (1.0 + 5.0 * x[0] * x[0]) * (1.0 + 5.0 * x[1] * x[1]);
+    double a0 = (1.0 + 5.0*x[0]*x[0]) * (1.0 + 5.0*x[1]*x[1]);
     y[0] = -10.0 * x[0] * (1.0 + 5.0 * x[1] * x[1]) / (a0 * a0);
     y[1] = -10.0 * x[1] * (1.0 + 5.0 * x[0] * x[0]) / (a0 * a0);
 }

--- a/SparseGrids/gridtestTestFunctions.cpp
+++ b/SparseGrids/gridtestTestFunctions.cpp
@@ -148,7 +148,7 @@ const char* TwoOneExpm40::getDescription() const{ return "f(x,y) = 1.0 / (1.0 + 
 void TwoOneExpm40::eval(const double x[], double y[]) const{ y[0] = 1.0 / (1.0 + exp(-40.0 * (std::sqrt(x[0]*x[0] + x[1]*x[1]) - 0.4))); } void TwoOneExpm40::getIntegral(double y[]) const{ y[0] = 0.0; }
 void TwoOneExpm40::getDerivative(const double x[], double y[]) const{
     double nrm = std::sqrt(x[0]*x[0] + x[1]*x[1]);
-    double a0 = -40.0 * (nrm - 0.4);
+    double a0 = -40.0 * nrm - 0.4;
     double a1 = 40 * exp(a0) / ((exp(a0) + 1) * (exp(a0) + 1) * nrm);
     y[0] = x[0] * a1;
     y[1] = x[1] * a1;
@@ -183,7 +183,7 @@ void EightOneCosSum::getDerivative(const double x[], double y[]) const{
 
 
 ThreeOneUnitBall::ThreeOneUnitBall(){} ThreeOneUnitBall::~ThreeOneUnitBall(){} int ThreeOneUnitBall::getNumInputs() const{ return 3; } int ThreeOneUnitBall::getNumOutputs() const{ return 1; }
-const char* ThreeOneUnitBall::getDescription() const{ return "f(y_i) = 1 if |x| < 1, 0 otherwise"; }
+const char* ThreeOneUnitBall::getDescription() const{ return "f(x_i) = 1 if ||x||_{2} < 1, 0 otherwise"; }
 void ThreeOneUnitBall::eval(const double x[], double y[]) const{ if ((x[0]*x[0]+x[1]*x[1]+x[2]*x[2]) <= 1.0){ y[0] = 1.0; }else{ y[0] = 0.0; } } void ThreeOneUnitBall::getIntegral(double y[]) const{ y[0] = (4.0/3.0) * pi; }
 void ThreeOneUnitBall::getDerivative(const double*, double y[]) const { y[0] = 0.0; y[1] = 0.0; y[2] = 0.0; }
 
@@ -258,9 +258,8 @@ const char* TwoOneDivisionAnisotropic::getDescription() const{ return "f(x,y) = 
 void TwoOneDivisionAnisotropic::eval(const double x[], double y[]) const{ y[0] = 1.0 / ((x[0] - 1.1) * (x[0] + 1.1) * (x[1] - 2) * (x[1] + 2)); } void TwoOneDivisionAnisotropic::getIntegral(double y[]) const{ y[0] = 1.520340801458519; }
 void TwoOneDivisionAnisotropic::getDerivative(const double x[], double y[]) const{
     double a0 = ((x[0] - 1.1) * (x[0] + 1.1) * (x[1] - 2.0) * (x[1] + 2.0));
-    double a1 = 1 / (a0 * a0);
-    y[0] = 2.0 * (x[0] - 1.1) * (x[1] - 2.0) * (x[1] + 2.0) * a1;
-    y[1] = 2.0 * (x[1] - 2.0) * (x[0] - 1.1) * (x[0] + 1.1) * a1;
+    y[0] = -2.0 * x[0] * (x[1] - 2.0) * (x[1] + 2.0) / (a0 * a0);
+    y[1] = -2.0 * x[1] * (x[0] - 1.1) * (x[0] + 1.1) / (a0 * a0);
 }
 
 TwoOne1DCurved::TwoOne1DCurved(){} TwoOne1DCurved::~TwoOne1DCurved(){} int TwoOne1DCurved::getNumInputs() const{ return 2; } int TwoOne1DCurved::getNumOutputs() const{ return 1; }
@@ -271,23 +270,27 @@ void TwoOne1DCurved::getDerivative(const double x[], double y[]) const{ y[0] = -
 TwoOneExpShiftedDomain::TwoOneExpShiftedDomain(){} TwoOneExpShiftedDomain::~TwoOneExpShiftedDomain(){} int TwoOneExpShiftedDomain::getNumInputs() const{ return 2; } int TwoOneExpShiftedDomain::getNumOutputs() const{ return 1; }
 const char* TwoOneExpShiftedDomain::getDescription() const{ return "f(x,y) = exp(x[0] / 3.0 + x[1] / 5.0)"; }
 void TwoOneExpShiftedDomain::eval(const double x[], double y[]) const{ y[0] = std::exp(x[0]/3.0  + x[1]/5.0); } void TwoOneExpShiftedDomain::getIntegral(double y[]) const{ y[0] = 15.0*(std::exp(26.0/15.0) - std::exp(11.0/15.0) - std::exp(7.0/5.0) + std::exp(2.0/5.0)); }
-void TwoOneExpShiftedDomain::getDerivative(const double x[], double y[]) const{ y[0] = 1/3.0 * std::exp(x[0]/3.0  + x[1]/5.0); y[1] = 1/5.0 * std::exp(x[0]/3.0  + x[1]/5.0); }
+void TwoOneExpShiftedDomain::getDerivative(const double x[], double y[]) const{
+    double a0 = std::exp(x[0]/3.0  + x[1]/5.0);
+    y[0] = 1/3.0 * a0;
+    y[1] = 1/5.0 * a0;
+}
 
 OneOneConformalOne::OneOneConformalOne(){} OneOneConformalOne::~OneOneConformalOne(){} int OneOneConformalOne::getNumInputs() const{ return 1; } int OneOneConformalOne::getNumOutputs() const{ return 1; }
 const char* OneOneConformalOne::getDescription() const{ return "f(x) = 1 / (1 + 5x^2)"; }
 void OneOneConformalOne::eval(const double x[], double y[]) const{ y[0] = 1.0 / (1.0 + 5.0 * x[0]*x[0]); } void OneOneConformalOne::getIntegral(double y[]) const{ y[0] = 1.028825601981092; }
 void OneOneConformalOne::getDerivative(const double x[], double y[]) const{
     double a0 = 1.0 + 5.0 * x[0]*x[0];
-    y[0] = 10.0 * x[0] / (a0 * a0);
+    y[0] = -10.0 * x[0] / (a0 * a0);
 }
 
 TwoOneConformalOne::TwoOneConformalOne(){} TwoOneConformalOne::~TwoOneConformalOne(){} int TwoOneConformalOne::getNumInputs() const{ return 2; } int TwoOneConformalOne::getNumOutputs() const{ return 1; }
 const char* TwoOneConformalOne::getDescription() const{ return "f(x) = 1 / ((1 + 5x^2)*(1 + 5y^2))"; }
 void TwoOneConformalOne::eval(const double x[], double y[]) const{ y[0] = 1.0 / ((1.0 + 5.0*x[0]*x[0]) * (1.0 + 5.0*x[1]*x[1])); } void TwoOneConformalOne::getIntegral(double y[]) const{ y[0] = 1.028825601981092*1.028825601981092; }
 void TwoOneConformalOne::getDerivative(const double x[], double y[]) const{
-    double a0 = (1.0 + 5.0*x[0]*x[0]) * (1.0 + 5.0*x[1]*x[1]);
-    y[0] = 10.0 * x[0] / (a0 * a0);
-    y[1] = 10.0 * x[1] / (a0 * a0);
+    double a0 = (1.0 + 5.0 * x[0] * x[0]) * (1.0 + 5.0 * x[1] * x[1]);
+    y[0] = -10.0 * x[0] * (1.0 + 5.0 * x[1] * x[1]) / (a0 * a0);
+    y[1] = -10.0 * x[1] * (1.0 + 5.0 * x[0] * x[0]) / (a0 * a0);
 }
 
 Two3KExpSinCos::Two3KExpSinCos(){} Two3KExpSinCos::~Two3KExpSinCos(){} int Two3KExpSinCos::getNumInputs() const{ return 2; } int Two3KExpSinCos::getNumOutputs() const{ return 3072; }

--- a/SparseGrids/tsgGridFourier.cpp
+++ b/SparseGrids/tsgGridFourier.cpp
@@ -387,7 +387,6 @@ void GridFourier::getInterpolationWeights(const double x[], double weights[]) co
             weights[work.getSlot(p)] += (tensorw * fftprod);
         }
     }
-
 }
 
 void GridFourier::getQuadratureWeights(double weights[]) const{

--- a/SparseGrids/tsgGridFourier.hpp
+++ b/SparseGrids/tsgGridFourier.hpp
@@ -66,10 +66,13 @@ public:
     void getPoints(double *x) const override; // returns the loaded points unless no points are loaded, then returns the needed points
 
     void getInterpolationWeights(const double x[], double weights[]) const override;
-
     void getQuadratureWeights(double weights[]) const override;
+    void getDifferentiationWeights(const double x[], double weights[]) const;
 
     void evaluate(const double x[], double y[]) const override;
+    void integrate(double q[], double *conformal_correction) const override;
+    void differentiate(const double x[], double jacobian[]) const;
+
     void evaluateBatch(const double x[], int num_x, double y[]) const override;
 
     void evaluateBatchGPU(const double gpu_x[], int cpu_num_x, double gpu_y[]) const override;
@@ -79,8 +82,6 @@ public:
     void evaluateHierarchicalFunctionsGPU(const float gpu_x[], int num_x, float gpu_y[]) const override;
     template<typename T>
     void evaluateHierarchicalFunctionsInternalGPU(const T gpu_x[], int num_x, GpuVector<T> &wreal, GpuVector<T> &wimag) const;
-
-    void integrate(double q[], double *conformal_correction) const override;
 
     void evaluateHierarchicalFunctions(const double x[], int num_x, double y[]) const override;
     void evaluateHierarchicalFunctionsInternal(const double x[], int num_x, Data2D<double> &wreal, Data2D<double> &wimag) const;


### PR DESCRIPTION
Bug fixes include:

- Corrections to derivatives defined in `gridtestTestFunctions.cpp`
- Including the effect of affine (non-conformal) domain transforms in `TasmanianSparseGrid::differentiate()`