### PR TITLE
Small bug fix to Particle Swarm API

### DIFF
--- a/DREAM/Optimization/tasdreamOptimizationTests.cpp
+++ b/DREAM/Optimization/tasdreamOptimizationTests.cpp
@@ -173,8 +173,7 @@ bool testParticleSwarm(bool verbose) {
                         x[0] * x[1] +
                         (-4.0 + 4.0 * x[1]*x[1]) * x[1]*x[1];};
     TasOptimization::ObjectiveFunction shc = TasOptimization::makeObjectiveFunction(num_dimensions, shc_single);
-    state.setNumDimensions(num_dimensions);
-    state.setNumParticles(num_particles);
+    state = ParticleSwarmState(num_dimensions, num_particles);
     state.initializeParticlesInsideBox(lower, upper);
     pass = pass and testParticleSwarmSingle(shc, state, TasDREAM::hypercube(lower, upper), iterations, -1.031628453489877);
 

--- a/DREAM/Optimization/tsgParticleSwarm.hpp
+++ b/DREAM/Optimization/tsgParticleSwarm.hpp
@@ -102,10 +102,6 @@ public:
         return {positions_initialized, velocities_initialized, best_positions_initialized, cache_initialized};
     }
 
-    //! \brief Set the number of dimensions.
-    void setNumDimensions(const int nd) {num_dimensions = nd;};
-    //! \brief Set the number of particles.
-    void setNumParticles(const int np) {num_particles = np;};
     //! \brief Set the particle positions.
     void setParticlePositions(const std::vector<double> &pp) {
         checkVarSize("ParticleSwarmState::setParticlePositions", "particle position", pp.size(), num_dimensions * num_particles);


### PR DESCRIPTION
Certain state vectors should be resized and reset when either `num_dimensions` or `num_particles` change.