### PR TITLE
added differentiation benchmark

### DIFF
--- a/SparseGrids/Benchmarks/benchCommon.hpp
+++ b/SparseGrids/Benchmarks/benchCommon.hpp
@@ -11,6 +11,7 @@ enum BenchFuction{
     bench_loadneeded,
     bench_evaluate,
     bench_evaluate_mixed,
+    bench_differentiate,
     bench_iweights
 };
 
@@ -18,6 +19,7 @@ BenchFuction getTest(std::string const &s){
     std::map<std::string, BenchFuction> str_to_test = {
         {"evaluate", bench_evaluate},
         {"evaluate-mixed", bench_evaluate_mixed},
+        {"differentiate", bench_differentiate},
         {"loadneeded", bench_loadneeded},
         {"makegrid", bench_make},
         {"iweights", bench_iweights}
@@ -200,7 +202,9 @@ void loadGenericModel(TasmanianSparseGrid &grid){
 
 struct DryRun{};
 struct NoDryRun{};
-template<typename use_dry_run = NoDryRun>
+struct NormalizedTime{};
+struct RawTime{};
+template<typename use_dry_run = NoDryRun, typename normalize = NormalizedTime>
 int testMethod(int iteratons, std::function<void(int)> test){
     if (std::is_same<use_dry_run, DryRun>::value)
         test(iteratons-1);
@@ -210,7 +214,11 @@ int testMethod(int iteratons, std::function<void(int)> test){
     auto time_end = std::chrono::system_clock::now();
 
     long long elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(time_end - time_start).count();
-    return int( 0.5 + double(elapsed) / double(iteratons) );
+    if (std::is_same<normalize, NormalizedTime>::value){
+        return static_cast<int>( 0.5 + double(elapsed) / double(iteratons) );
+    }else{
+        return static_cast<int>(elapsed);
+    }
 }
 
 #endif

--- a/SparseGrids/Benchmarks/benchDifferentiate.hpp
+++ b/SparseGrids/Benchmarks/benchDifferentiate.hpp
@@ -1,0 +1,45 @@
+#ifndef _TASMANIAN_BENCHMARK_DIFFERENTIATE_HPP
+#define _TASMANIAN_BENCHMARK_DIFFERENTIATE_HPP
+
+#include "benchCommon.hpp"
+
+bool benchmark_differentiate(std::deque<std::string> &args){
+    if (args.size() < 9) return false;
+
+    // report the test parameters to reference later
+    cout << "differentiate";
+    for(auto &s : args) cout << " " << s;
+
+    auto grid_family = getGridFamily(args);
+    if (grid_family == GridFamily::none) return false;
+
+    int num_dimensions, num_outputs, num_depth, order, iteratons, num_jumps;
+    TypeDepth dtype;
+    TypeOneDRule rule;
+
+    auto riter = readEntries(args.begin(), num_dimensions, num_outputs, num_depth, dtype, rule, order, iteratons, num_jumps);
+
+    auto extra = extractWeightsLimits(grid_family, num_dimensions, dtype, riter, args.end());
+
+    auto make_grid = getLambdaMakeGrid(grid_family, num_dimensions, num_outputs, num_depth, dtype, rule, order, extra);
+
+    num_jumps = std::max(num_jumps, 1); // make at least one test
+
+    std::vector<std::vector<double>> inputs = getRandomVectors<double>(iteratons, num_dimensions, 1);
+
+    for(int jump = 0; jump < num_jumps; jump++){
+        auto grid = make_grid();
+        if (jump == 0) cout << " (points: " << grid.getNumPoints() << ")" << endl;
+        loadGenericModel(grid);
+        if (jump == 0) cout << "    note: reporting total time (ms), does not normalize (divide) by iterations\n";
+
+        // make one dry-run, using RawTime since each call to differentiate is very fast
+        std::vector<double> result;
+        cout << setw(7) << testMethod<DryRun, RawTime>(iteratons, [&](int i)->void{ grid.differentiate(inputs[i], result); }) << endl;;
+        num_outputs *= 2;
+    }
+
+    return true;
+}
+
+#endif

--- a/SparseGrids/Benchmarks/bench_main.cpp
+++ b/SparseGrids/Benchmarks/bench_main.cpp
@@ -1,6 +1,7 @@
 #include "benchMakeGrid.hpp"
 #include "benchLoadNeeded.hpp"
 #include "benchEvaluate.hpp"
+#include "benchDifferentiate.hpp"
 #include "benchInterpolationWeights.hpp"
 
 void printHelp(BenchFuction test);
@@ -24,14 +25,26 @@ int main(int argc, const char** argv){
     }
 
     bool pass = true; // check if the rest of the inputs are OK
-    if (test == bench_make)
-        pass = benchmark_makegrid(args);
-    if (test == bench_loadneeded)
-        pass = benchmark_loadneeded(args);
-    if (test == bench_evaluate || test == bench_evaluate_mixed)
-        pass = benchmark_evaluate(args, (test == bench_evaluate_mixed));
-    if (test == bench_iweights)
-        pass = benchmark_iweights(args);
+    switch(test){
+        case bench_make:
+            pass = benchmark_makegrid(args);
+            break;
+        case bench_loadneeded:
+            pass = benchmark_loadneeded(args);
+            break;
+        case bench_evaluate:
+        case bench_evaluate_mixed:
+            pass = benchmark_evaluate(args, (test == bench_evaluate_mixed));
+            break;
+        case bench_differentiate:
+            pass = benchmark_differentiate(args);
+            break;
+        case bench_iweights:
+            pass = benchmark_iweights(args);
+            break;
+        default:
+            throw std::runtime_error("bench_main.cpp: invalid test type in switch statement!");
+    }
 
     if (!pass) // if problem with inputs
         printHelp(test);
@@ -42,7 +55,7 @@ int main(int argc, const char** argv){
 void printHelp(BenchFuction test){
     if (test == bench_none){
         cout << "\nusage: ./benchmark <function> <parameters>\n\n";
-        cout << "functions: makegrid, loadneeded, evaluate(-mixed), iweights\n";
+        cout << "functions: makegrid, loadneeded, evaluate(-mixed), differentiate, iweights\n";
         cout << "\n see: ./benchmark <function> help\n";
     }else if (test == bench_make){
         cout << "\nusage: ./benchmark makegrid <grid> <dims> <depth> <type> <rule> <iters> <jumps> <aniso>\n\n";
@@ -84,6 +97,19 @@ void printHelp(BenchFuction test){
         cout << "jumps : how many times to double <outs>\n";
         cout << "acc   : acceleration type, e.g., gpu-cuda, cpu-blas, none, etc.\n";
         cout << "gpu   : cuda device ID; ignored for cpu acceleration\n";
+        cout << "extra : (optional) sparse/dense flavor and/or list of anisotropic weights and level limits\n";
+        cout << "      : anisotropic weights come first (if used by the grid), then level limits\n";
+    }else if (test == bench_differentiate){
+        cout << "\nusage: ./benchmark differentiate <grid> <dims> <outs> <depth> <type> <rule> <order> <iters> <jumps>\n\n";
+        cout << "grid  : global, sequence, localp, wavelet, fourier\n";
+        cout << "dims  : number of dimensions\n";
+        cout << "outs  : number of outputs\n";
+        cout << "depth : grid density\n";
+        cout << "type  : level, iptotal, etc.; ignored if not used by the grid\n";
+        cout << "rule  : rleja, clenshaw-curtis, etc.; ignored for wavelet and fourier grids\n";
+        cout << "order : -1, 0, 1, 2; ignored if not used by the grid\n";
+        cout << "iters : number of times to repeat the function call\n";
+        cout << "jumps : how many times to double <outs>\n";
         cout << "extra : (optional) sparse/dense flavor and/or list of anisotropic weights and level limits\n";
         cout << "      : anisotropic weights come first (if used by the grid), then level limits\n";
     }else if (test == bench_iweights){

--- a/SparseGrids/CMakeLists.txt
+++ b/SparseGrids/CMakeLists.txt
@@ -71,11 +71,12 @@ add_executable(Tasmanian_gridtest gridtest_main.cpp
                                   gridtestUnitTests.hpp
                                   gridtestUnitTests.cpp
                                   gridtestTestInterfaceC.cpp)
-                                  
+
 add_executable(Tasmanian_benchmarksgrid  Benchmarks/benchCommon.hpp
                                          gridtestCLICommon.hpp
                                          Benchmarks/benchMakeGrid.hpp
                                          Benchmarks/benchLoadNeeded.hpp
+                                         Benchmarks/benchDifferentiate.hpp
                                          Benchmarks/benchEvaluate.hpp
                                          Benchmarks/bench_main.cpp)
 


### PR DESCRIPTION
* add a benchmark for the differentiation option, available for all grid types
* example usage: `./SparseGrids/benchmarksgrid differentiate wavelet 6 1 2 level wavelet 1 10 10`
* see also `./SparseGrids/benchmarksgrid differentiate help`