### PR TITLE
Simplify the differentiation code

### DIFF
--- a/SparseGrids/TasmanianSparseGrid.cpp
+++ b/SparseGrids/TasmanianSparseGrid.cpp
@@ -394,19 +394,7 @@ void TasmanianSparseGrid::getDifferentiationWeights(const double x[], double wei
     // See differentiate() for how the domain transforms are taken into consideration.
     Data2D<double> x_tmp;
     // Jacobian of f(.) at g(x).
-    if (isGlobal()) {
-        get<GridGlobal>()->getDifferentiationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
-    } else if (isSequence()) {
-        get<GridSequence>()->getDifferentiationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
-    } else if (isLocalPolynomial()) {
-        get<GridLocalPolynomial>()->getDifferentiationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
-    } else if (isFourier()) {
-        get<GridFourier>()->getDifferentiationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
-    } else if (isWavelet()) {
-        get<GridWavelet>()->getDifferentiationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
-    } else {
-        throw std::runtime_error("ERROR: getDifferentiationWeights() cannot be called for grids of this type");
-    }
+    base->getDifferentiationWeights(formCanonicalPoints(x, x_tmp, 1), weights);
     // Jacobian of f(g(.)) at x.
     if (not domain_transform_a.empty()) {
         int num_dimensions = getNumDimensions();
@@ -498,19 +486,7 @@ void TasmanianSparseGrid::differentiate(const double x[], double jacobian[]) con
     // Jacobian of f(g(x)), i.e., [Jacobian of f(.) at g(x)] * [Jacobian of g(.) at x].
     Data2D<double> x_tmp;
     // Jacobian of f(.) at g(x).
-    if (isGlobal()) {
-        get<GridGlobal>()->differentiate(formCanonicalPoints(x, x_tmp, 1), jacobian);
-    } else if (isSequence()) {
-        get<GridSequence>()->differentiate(formCanonicalPoints(x, x_tmp, 1), jacobian);
-    } else if (isLocalPolynomial()) {
-        get<GridLocalPolynomial>()->differentiate(formCanonicalPoints(x, x_tmp, 1), jacobian);
-    } else if (isFourier()) {
-        get<GridFourier>()->differentiate(formCanonicalPoints(x, x_tmp, 1), jacobian);
-    } else if (isWavelet()) {
-        get<GridWavelet>()->differentiate(formCanonicalPoints(x, x_tmp, 1), jacobian);
-    } else {
-        throw std::runtime_error("ERROR: in differentiate(), jacobians/gradients are not available for this type of grid");
-    }
+    base->differentiate(formCanonicalPoints(x, x_tmp, 1), jacobian);
     // Jacobian of f(g(.)) at x.
     if (not domain_transform_a.empty()) {
         int num_dimensions = getNumDimensions();

--- a/SparseGrids/tsgGridCore.hpp
+++ b/SparseGrids/tsgGridCore.hpp
@@ -86,12 +86,14 @@ public:
 
     virtual void getQuadratureWeights(double weights[]) const = 0;
     virtual void getInterpolationWeights(const double x[], double weights[]) const = 0;
+    virtual void getDifferentiationWeights(const double x[], double weights[]) const = 0;
 
     virtual void loadNeededValues(const double *vals) = 0;
     const double* getLoadedValues() const{ return (points.empty()) ? nullptr : values.getValues(0); }
 
     virtual void evaluate(const double x[], double y[]) const = 0;
     virtual void integrate(double q[], double *conformal_correction) const = 0;
+    virtual void differentiate(const double x[], double jacobian[]) const = 0;
 
     virtual void evaluateBatch(const double x[], int num_x, double y[]) const = 0;
 

--- a/SparseGrids/tsgGridFourier.hpp
+++ b/SparseGrids/tsgGridFourier.hpp
@@ -67,11 +67,11 @@ public:
 
     void getInterpolationWeights(const double x[], double weights[]) const override;
     void getQuadratureWeights(double weights[]) const override;
-    void getDifferentiationWeights(const double x[], double weights[]) const;
+    void getDifferentiationWeights(const double x[], double weights[]) const override;
 
     void evaluate(const double x[], double y[]) const override;
     void integrate(double q[], double *conformal_correction) const override;
-    void differentiate(const double x[], double jacobian[]) const;
+    void differentiate(const double x[], double jacobian[]) const override;
 
     void evaluateBatch(const double x[], int num_x, double y[]) const override;
 

--- a/SparseGrids/tsgGridGlobal.hpp
+++ b/SparseGrids/tsgGridGlobal.hpp
@@ -77,13 +77,13 @@ public:
 
     void getQuadratureWeights(double weights[]) const override;
     void getInterpolationWeights(const double x[], double weights[]) const override;
-    void getDifferentiationWeights(const double x[], double weights[]) const;
+    void getDifferentiationWeights(const double x[], double weights[]) const override;
 
     void loadNeededValues(const double *vals) override;
 
     void evaluate(const double x[], double y[]) const override;
     void integrate(double q[], double *conformal_correction) const override;
-    void differentiate(const double x[], double jacobian[]) const;
+    void differentiate(const double x[], double jacobian[]) const override;
 
     void evaluateBatch(const double x[], int num_x, double y[]) const override;
 

--- a/SparseGrids/tsgGridLocalPolynomial.hpp
+++ b/SparseGrids/tsgGridLocalPolynomial.hpp
@@ -74,13 +74,13 @@ public:
 
     void getQuadratureWeights(double weights[]) const override;
     void getInterpolationWeights(const double x[], double weights[]) const override;
-    void getDifferentiationWeights(const double x[], double weights[]) const;
+    void getDifferentiationWeights(const double x[], double weights[]) const override;
 
     void loadNeededValues(const double *vals) override;
 
     void evaluate(const double x[], double y[]) const override;
     void integrate(double q[], double *conformal_correction) const override;
-    void differentiate(const double x[], double jacobian[]) const;
+    void differentiate(const double x[], double jacobian[]) const override;
 
     void evaluateBatchOpenMP(const double x[], int num_x, double y[]) const;
     void evaluateBatch(const double x[], int num_x, double y[]) const override;

--- a/SparseGrids/tsgGridSequence.hpp
+++ b/SparseGrids/tsgGridSequence.hpp
@@ -62,13 +62,13 @@ public:
 
     void getQuadratureWeights(double weights[]) const override;
     void getInterpolationWeights(const double x[], double weights[]) const override;
-    void getDifferentiationWeights(const double x[], double weights[]) const;
+    void getDifferentiationWeights(const double x[], double weights[]) const override;
 
     void loadNeededValues(const double *vals) override;
 
     void evaluate(const double x[], double y[]) const override;
     void integrate(double q[], double *conformal_correction) const override;
-    void differentiate(const double x[], double jacobian[]) const;
+    void differentiate(const double x[], double jacobian[]) const override;
 
     void evaluateBatch(const double x[], int num_x, double y[]) const override;
 

--- a/SparseGrids/tsgGridWavelet.hpp
+++ b/SparseGrids/tsgGridWavelet.hpp
@@ -60,13 +60,13 @@ public:
 
     void getQuadratureWeights(double weights[]) const override;
     void getInterpolationWeights(const double x[], double weights[]) const override;
-    void getDifferentiationWeights(const double x[], double weights[]) const;
+    void getDifferentiationWeights(const double x[], double weights[]) const override;
 
     void loadNeededValues(const double *vals) override;
 
     void evaluate(const double x[], double y[]) const override;
     void integrate(double q[], double *conformal_correction) const override;
-    void differentiate(const double x[], double jacobian[]) const;
+    void differentiate(const double x[], double jacobian[]) const override;
 
     void evaluateBatch(const double x[], int num_x, double y[]) const override;
 


### PR DESCRIPTION
- Add virtual functions to the base canonical grid class
- Remove excessive if statements from `gridExternalTests.cpp` and `TasmanianSparseGrid.cpp`