### PR TITLE
Change ParticleSwarm function signature

### DIFF
--- a/DREAM/Optimization/TasmanianOptimizationWrapC.cpp
+++ b/DREAM/Optimization/TasmanianOptimizationWrapC.cpp
@@ -154,8 +154,8 @@ extern "C" {
     }
 
     // Particle Swarm Algorithm.
-    void tsgParticleSwarm(const tsg_optim_obj_fn f_ptr, const int num_iterations, const tsg_optim_dom_fn inside_ptr, void *state,
-                          const double inertia_weight, const double cognitive_coeff, const double social_coeff,
+    void tsgParticleSwarm(const tsg_optim_obj_fn f_ptr, const tsg_optim_dom_fn inside_ptr, const double inertia_weight,
+                          const double cognitive_coeff, const double social_coeff, const int num_iterations,  void *state,
                           const char* random_type, const int random_seed, tsg_dream_random random_callback, int *err) {
         *err = 1;
         // Create the U[0,1] random number generator.
@@ -188,8 +188,8 @@ extern "C" {
             return inside;
         };
         try {
-            ParticleSwarm(f_cpp, num_iterations, inside_cpp, *(reinterpret_cast<ParticleSwarmState*>(state)), inertia_weight,
-                          cognitive_coeff, social_coeff, randgen);
+            ParticleSwarm(f_cpp, inside_cpp, inertia_weight, cognitive_coeff, social_coeff, num_iterations,
+                          *(reinterpret_cast<ParticleSwarmState*>(state)), randgen);
             *err = 0; // Success
         } catch (std::runtime_error &) {}
     }

--- a/DREAM/Optimization/tasdreamOptimizationTests.cpp
+++ b/DREAM/Optimization/tasdreamOptimizationTests.cpp
@@ -116,7 +116,7 @@ bool testParticleSwarmSingle(ObjectiveFunction f, ParticleSwarmState state, TasD
     std::minstd_rand park_miller(42);
     std::uniform_real_distribution<double> unif(0.0, 1.0);
     auto get_rand = [&]()->double{ return unif(park_miller); };
-    ParticleSwarm(f, iterations, inside, state, 0.5, 2, 2, get_rand);
+    ParticleSwarm(f, inside, 0.5, 2, 2, iterations, state, get_rand);
 
     // Check optimality and state changes of the run.
     std::vector<double> best_swarm_point = state.getBestPosition();
@@ -127,7 +127,7 @@ bool testParticleSwarmSingle(ObjectiveFunction f, ParticleSwarmState state, TasD
     pass = pass and init_vector[3];
 
     // Make sure subsequent runs do not make any strange modifications.
-    ParticleSwarm(f, 1, inside, state, 0.5, 2, 2, get_rand);
+    ParticleSwarm(f, inside, 0.5, 2, 2, 1, state, get_rand);
     f(best_swarm_point, best_swarm_value_vec);
     pass = pass and std::fabs(best_swarm_value_vec[0] - optimal_val) <= TasGrid::Maths::num_tol;
     init_vector = state.getStateVector();

--- a/DREAM/Optimization/tsgParticleSwarm.cpp
+++ b/DREAM/Optimization/tsgParticleSwarm.cpp
@@ -80,9 +80,9 @@ void ParticleSwarmState::initializeParticlesInsideBox(const std::vector<double> 
     ParticleSwarmState::initializeParticlesInsideBox(box_lower.data(), box_upper.data(), get_random01);
 }
 
-void ParticleSwarm(const ObjectiveFunction f, const int max_iterations, const TasDREAM::DreamDomain inside, ParticleSwarmState &state,
-                   const double inertia_weight, const double cognitive_coeff, const double social_coeff,
-                   const std::function<double(void)> get_random01) {
+void ParticleSwarm(const ObjectiveFunction f, const TasDREAM::DreamDomain inside, const double inertia_weight,
+                   const double cognitive_coeff, const double social_coeff, const int num_iterations,
+                   ParticleSwarmState &state, const std::function<double(void)> get_random01) {
 
     // Only run the algorithm on properly initialized states.
     if (!state.positions_initialized) {
@@ -158,7 +158,7 @@ void ParticleSwarm(const ObjectiveFunction f, const int max_iterations, const Ta
     state.best_positions_initialized = true;
 
     // Main algorithm starts here.
-    for(int iter=0; iter<max_iterations; iter++) {
+    for(int iter=0; iter<num_iterations; iter++) {
         for (size_t i=0; i<num_particles * num_dimensions; i++) {
             particle_velocities[i] = inertia_weight * particle_velocities[i] +
                                      cognitive_coeff * get_random01() * (best_particle_positions[i] - particle_positions[i]) +

--- a/DREAM/Optimization/tsgParticleSwarm.hpp
+++ b/DREAM/Optimization/tsgParticleSwarm.hpp
@@ -238,19 +238,19 @@ public:
      * uniform [0,1] random number generator used by the algorithm is \b get_random01.
      *
      * \param f Objective function to be minimized
-     * \param num_iterations number of iterations to perform
      * \param inside indicates whether a given point is inside or outside of the domain of interest
-     * \param state holds the state of the particles, e.g., positions and velocities, see TasOptimization::ParticleSwarmState
      * \param inertia_weight inertial weight for the particle swarm algorithm
      * \param cognitive_coeff cognitive coefficient for the particle swarm algorithm
      * \param social_coeff social coefficient for the particle swarm algorithm
+     * \param num_iterations number of iterations to perform
+     * \param state holds the state of the particles, e.g., positions and velocities, see TasOptimization::ParticleSwarmState
      * \param get_random01 random number generator, defaults to rand()
      *
      * \throws std::runtime_error if either the positions or the velocities of the \b state have not been initialized
      */
-    friend void ParticleSwarm(const ObjectiveFunction f, const int num_iterations, const TasDREAM::DreamDomain inside,
-                              ParticleSwarmState &state, const double inertia_weight, const double cognitive_coeff,
-                              const double social_coeff, const std::function<double(void)> get_random01);
+    friend void ParticleSwarm(const ObjectiveFunction f, const TasDREAM::DreamDomain inside, const double inertia_weight,
+                              const double cognitive_coeff, const double social_coeff, const int num_iterations,
+                              ParticleSwarmState &state, const std::function<double(void)> get_random01);
 
 protected:
     #ifndef __TASMANIAN_DOXYGEN_SKIP_INTERNAL
@@ -278,9 +278,9 @@ private:
 };
 
 // Forward declarations.
-void ParticleSwarm(const ObjectiveFunction f, const int num_iterations, const TasDREAM::DreamDomain inside, ParticleSwarmState &state,
-                   const double inertia_weight, const double cognitive_coeff, const double social_coeff,
-                   const std::function<double(void)> get_random01 = TasDREAM::tsgCoreUniform01);
+void ParticleSwarm(const ObjectiveFunction f, const TasDREAM::DreamDomain inside, const double inertia_weight,
+                   const double cognitive_coeff, const double social_coeff, const int num_iterations,
+                   ParticleSwarmState &state, const std::function<double(void)> get_random01 = TasDREAM::tsgCoreUniform01);
 
 }
 #endif

--- a/InterfacePython/TasmanianParticleSwarm.py
+++ b/InterfacePython/TasmanianParticleSwarm.py
@@ -75,8 +75,8 @@ pLibDTSG.tsgParticleSwarmState_SetBestParticlePositions.argtypes = [c_void_p, PO
 pLibDTSG.tsgParticleSwarmState_ClearBestParticles.argtypes = [c_void_p]
 pLibDTSG.tsgParticleSwarmState_ClearCache.argtypes = [c_void_p]
 pLibDTSG.tsgParticleSwarmState_InitializeParticlesInsideBox.argtypes = [c_void_p, POINTER(c_double), POINTER(c_double), c_char_p, c_int, type_dream_random]
-pLibDTSG.tsgParticleSwarm.argtypes = [type_optim_obj_fn, c_int, type_optim_dom_fn, c_void_p, c_double, c_double, c_double, c_char_p, c_int,
-                                      type_dream_random, POINTER(c_int)]
+pLibDTSG.tsgParticleSwarm.argtypes = [type_optim_obj_fn, type_optim_dom_fn, c_double, c_double, c_double, c_int, c_void_p,
+                                      c_char_p, c_int, type_dream_random, POINTER(c_int)]
 
 class ParticleSwarmState:
     '''
@@ -263,8 +263,8 @@ class ParticleSwarmState:
                                                                     c_char_p(random01.sType), c_int(random01.iSeed),
                                                                     type_dream_random(random01.pCallable))
 
-def ParticleSwarm(pObjectiveFunction, iNumIterations, pInside, oParticleSwarmState, fInertiaWeight, fCognitiveCoeff,
-                  fSocialCoeff, random01 = DREAM.RandomGenerator(sType = "default")):
+def ParticleSwarm(pObjectiveFunction, pInside, fInertiaWeight, fCognitiveCoeff, fSocialCoeff, iNumIterations, oParticleSwarmState,
+                  random01 = DREAM.RandomGenerator(sType = "default")):
     '''
     Wrapper around TasOptimization::ParticleSwarm().
 
@@ -275,14 +275,14 @@ def ParticleSwarm(pObjectiveFunction, iNumIterations, pInside, oParticleSwarmSta
     pObjectiveFunction  : a Python lambda representing the objective function; it should take in one 2D NumPy array (x_batch)
                           and produce a 1D NumPy array, sized (iNumBatch,), whose i-th entry should be the result of evaluating
                           the objective function to x_batch[i,:]; it is expected that x_batch.shape[1] = .getNumDimensions().
-    iNumIterations      : a positive integer representing the number iterations the algorithm is run.
     pInside             : a Python lambda representing the function domain; it should take in a 1D NumPy array (x) and produce a
                           Boolean (isInside); when called, it should return True if x is in the domain and False otherwise;
                           it is expected that x.shape[0] = .getNumDimensions().
-    oParticleSwarmState : an instance of the Python ParticleSwarmState class; it will contain the results of applying the algorithm.
     fInertiaWeight      : a double that controls the speed of the particles; should be in (0,1).
     fCognitiveCoeff     : a double that controls how much a particle favors its own trajectory; usually in [1,3].
     fSocialCoeff        : a double that controls how much a particle favors the swarm's trajectories; usually in [1,3].
+    iNumIterations      : a positive integer representing the number iterations the algorithm is run.
+    oParticleSwarmState : an instance of the Python ParticleSwarmState class; it will contain the results of applying the algorithm.
     random01            : (optional) a DREAM.RandomGenerator instance that produces floats in [0,1]
     '''
     def cpp_obj_fn(num_dim, num_batch, x_batch_ptr, fval_ptr, err_arr):
@@ -308,9 +308,9 @@ def ParticleSwarm(pObjectiveFunction, iNumIterations, pInside, oParticleSwarmSta
         return iResult
 
     pErrorCode = (c_int * 1)()
-    pLibDTSG.tsgParticleSwarm(type_optim_obj_fn(cpp_obj_fn), c_int(iNumIterations), type_optim_dom_fn(cpp_dom_fn),
-                              oParticleSwarmState.pStatePntr, c_double(fInertiaWeight), c_double(fCognitiveCoeff),
-                              c_double(fSocialCoeff), c_char_p(random01.sType), c_int(random01.iSeed),
+    pLibDTSG.tsgParticleSwarm(type_optim_obj_fn(cpp_obj_fn), type_optim_dom_fn(cpp_dom_fn), c_double(fInertiaWeight),
+                              c_double(fCognitiveCoeff), c_double(fSocialCoeff), c_int(iNumIterations),
+                              oParticleSwarmState.pStatePntr, c_char_p(random01.sType), c_int(random01.iSeed),
                               type_dream_random(random01.pCallable), pErrorCode)
 
     if pErrorCode[0] != 0:

--- a/InterfacePython/testExceptions.py
+++ b/InterfacePython/testExceptions.py
@@ -299,12 +299,12 @@ class TestTasClass(unittest.TestCase):
                 ["pss.initializeParticlesInsideBox(np.array([-1.0, -2.0]), np.array([1.0, 3.0]));" +
                  "f = lambda x_batch : np.append(np.apply_along_axis(np.sum, 1, x_batch), np.array([0.5]), axis=0);" +
                  "inside = lambda x : True;" +
-                 "Opt.ParticleSwarm(f, 1, inside, pss, 0.5, 2, 2)", "ParticleSwarm"],
+                 "Opt.ParticleSwarm(f, inside, 0.5, 2, 2, 1, pss)", "ParticleSwarm"],
                 ["pss.initializeParticlesInsideBox(np.array([-1.0, -2.0]), np.array([1.0, 3.0]));" +
                  "f = lambda x_batch : np.apply_along_axis(np.sum, 1, x_batch);" +
                  "inside = lambda x : 0.01;" +
-                 "Opt.ParticleSwarm(f, 1, inside, pss, 0.5, 2, 2)", "ParticleSwarm"],
-                ]    
+                 "Opt.ParticleSwarm(f, inside, 0.5, 2, 2, 1, pss)", "ParticleSwarm"],
+                ]
 
     def testListedExceptions(self, llTests):
         grid = Tasmanian.SparseGrid()

--- a/InterfacePython/testOptimization.py
+++ b/InterfacePython/testOptimization.py
@@ -97,13 +97,12 @@ class TestTasClass(unittest.TestCase):
         f = lambda x_batch : np.apply_along_axis(shc, 1, x_batch)
         inside = lambda x : bool((-3 <= x[0]) and (x[0] <= 3) and (-2 <= x[1]) and (x[1] <= 2))
         # Main call + tests.
-        Opt.ParticleSwarm(f, 1, inside, state, 0.5, 2, 2,
-                          random01=DREAM.RandomGenerator(sType="default", iSeed=777))
+        Opt.ParticleSwarm(f, inside, 0.5, 2, 2, 1, state, random01=DREAM.RandomGenerator(sType="default", iSeed=777))
         self.assertTrue(state.isCacheInitialized())
         state.clearCache()
         self.assertFalse(state.isCacheInitialized())
         iNumIterations = 200
-        Opt.ParticleSwarm(f, iNumIterations, inside, state, 0.5, 2, 2)
+        Opt.ParticleSwarm(f, inside, 0.5, 2, 2, iNumIterations, state)
         self.assertTrue(np.allclose(np.array([-0.08984201368301331, +0.7126564032704135]), state.getBestPosition()) or
                         np.allclose(np.array([+0.08984201368301331, -0.7126564032704135]), state.getBestPosition()) )
 


### PR DESCRIPTION
I would like to change the `ParticleSwarm` function signature to be more structured, like the `GradientDescent` function signature. Specifically, I would like to change its inputs to follow this ordering:
```
([optimization functions], [algorithm parameters], [iteration limits], [tolerance limits], [optimization state], [other]) 
```