### PR TITLE
Add GradientDescent tests + small fixes

### DIFF
--- a/DREAM/Optimization/TasmanianOptimizationWrapC.cpp
+++ b/DREAM/Optimization/TasmanianOptimizationWrapC.cpp
@@ -210,6 +210,9 @@ extern "C" {
     void tsgGradientDescentState_GetX(void* state, double x_out[]) {
         reinterpret_cast<GradientDescentState*>(state)->getX(x_out);
     }
+    void tsgGradientDescentState_SetAdaptiveStepsize(void* state, const double new_stepsize) {
+        reinterpret_cast<GradientDescentState*>(state)->setAdaptiveStepsize(new_stepsize);
+    }
     void tsgGradientDescentState_SetX(void* state, double x_new[]) {
         reinterpret_cast<GradientDescentState*>(state)->setX(x_new);
     }

--- a/InterfacePython/CMakeLists.txt
+++ b/InterfacePython/CMakeLists.txt
@@ -144,6 +144,7 @@ add_test(NAME PythonLearning     COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT
 add_test(NAME PythonMisc         COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/testTSG.py" TestTasmanian.testZMisc)
 add_test(NAME PythonAddons       COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/testTSG.py" TestTasmanian.testAddons)
 add_test(NAME PythonDream        COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/testTSG.py" TestTasmanian.testDream)
+add_test(NAME PythonOptimization COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/testTSG.py" TestTasmanian.testOptimization)
 set_tests_properties(PythonIO PROPERTIES RUN_SERIAL ON) # IO and Refine read/write to potentially the same files
 set_tests_properties(PythonRefine PROPERTIES RUN_SERIAL ON)
 Tasmanian_set_test_properties(TESTS PythonIO PythonAcceleration PythonExceptions PythonMakeUpdate PythonRefine PythonLearning PythonMisc PythonAddons PythonDream)

--- a/InterfacePython/TasmanianGradientDescent.py
+++ b/InterfacePython/TasmanianGradientDescent.py
@@ -61,6 +61,9 @@ pLibDTSG.tsgGradientDescentState_GetAdaptiveStepsize.restype = c_double
 pLibDTSG.tsgGradientDescentState_GetAdaptiveStepsize.argtypes = [c_void_p]
 pLibDTSG.tsgGradientDescentState_GetX.argtypes = [c_void_p, POINTER(c_double)]
 
+pLibDTSG.tsgGradientDescentState_SetAdaptiveStepsize.argtypes = [c_void_p, c_double]
+pLibDTSG.tsgGradientDescentState_SetX.argtypes = [c_void_p, POINTER(c_double)]
+
 pLibDTSG.tsgGradientDescent_AdaptProj.argtypes = [type_optim_obj_fn_single, type_optim_grad_fn_single, type_optim_proj_fn_single,
                                                   c_double, c_double, c_int, c_double, c_void_p, POINTER(c_int)]
 pLibDTSG.tsgGradientDescent_AdaptProj.restype = optimization_status
@@ -112,6 +115,14 @@ class GradientDescentState:
         aResult = np.zeros((iNumDims,), np.float64)
         pLibDTSG.tsgGradientDescentState_GetX(self.pStatePntr, as_ctypes(aResult))
         return aResult
+
+    def setAdaptiveStepsize(self, fNewStepsize):
+        '''
+        Set new adaptive stepsize
+
+        fNewStepsize : a double representing the new adaptive stepsize.
+        '''
+        pLibDTSG.tsgGradientDescentState_SetAdaptiveStepsize(self.pStatePntr, fNewStepsize)
 
     def setX(self, aXNew):
         '''

--- a/InterfacePython/testTSG.py
+++ b/InterfacePython/testTSG.py
@@ -21,6 +21,7 @@ import testUnstructuredData
 import testMisc
 import testAddons
 import testDream
+import testOptimization
 
 grid = TasmanianSG.TasmanianSparseGrid()
 
@@ -75,6 +76,11 @@ class TestTasmanian(unittest.TestCase):
         print("\nTesting DREAM wrappers")
         tester = testDream.TestTasClass()
         tester.performDreamTests()
+
+    def testOptimization(self):
+        print("\nTesting Optimization Functions")
+        tester = testOptimization.TestTasClass()
+        tester.performOptTests()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR implements three changes:

- Adds Python unit tests for the `GradientDescent` functions
- Adds the optimization tests to the list of Python CTests 
- Adds a missing Python wrapper for the `setAdaptiveStepsize()` method in the `GradientDescentState` class