### PR TITLE
Avoid excess allocations in buildUpdateMap

### DIFF
--- a/SparseGrids/tsgGridLocalPolynomial.cpp
+++ b/SparseGrids/tsgGridLocalPolynomial.cpp
@@ -1266,14 +1266,14 @@ Data2D<int> GridLocalPolynomial::buildUpdateMap(double tolerance, TypeRefinement
         int max_1D_parents = rule->getMaxNumParents();
 
         HierarchyManipulations::SplitDirections split(points);
-
-        #pragma omp parallel for
+        std::vector<int> global_to_pnts(num_points);
+        #pragma omp parallel for firstprivate(global_to_pnts)
         for(int j=0; j<split.getNumJobs(); j++){ // split.getNumJobs() gives the number of 1D interpolants to construct
             int d = split.getJobDirection(j);
             int nump = split.getJobNumPoints(j);
             const int *pnts = split.getJobPoints(j);
 
-            std::vector<int> global_to_pnts(num_points);
+            
             std::vector<int> levels(nump);
 
             int max_level = 0;


### PR DESCRIPTION
First of all, thanks for an excellent library. I use TASMANIAN on almost a daily basis for a combination of uncertainty quantification and surrogate dataset generation. 

When building larger surrogate datasets, I noticed runtimes grew rapidly compared to the number of points added during surplus refinement. For some of my faster running models, TASMANIAN was accounting for 99%+ of the runtime, and most of that was spent in `buildUpdateMap`. 

I profiled the code and noticed that the vast majority of the calculations were spent allocating `std::vector<int>`, which I tracked down to the allocation of `global_to_pnts` inside the parallel loop.  This PR significantly reduces the number of allocations by moving `global_to_pnts` outside of the parallel loop and allocating them for each thread using a `firstprivate` clause. On my laptop, this has improved performance for grids with millions of points by at least an order of magnitude.