### PR TITLE
fix python executable usage

### DIFF
--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -36,7 +36,6 @@ jobs:
           -D CMAKE_CXX_FLAGS="-O3 -Wall -Wextra -Wshadow -pedantic"
           -D CMAKE_CXX_COMPILER=${{ matrix.compiler }}
           -D CMAKE_Fortran_COMPILER=${{ matrix.fortran_compiler }}
-          -D PYTHON_EXECUTABLE=/usr/bin/python3
           -D Tasmanian_ENABLE_RECOMMENDED=ON
           -D Tasmanian_ENABLE_FORTRAN=ON
           -D Tasmanian_TESTS_OMP_NUM_THREADS=4 .. &&

--- a/.jenkins
+++ b/.jenkins
@@ -121,7 +121,6 @@ cmake \
   -D CMAKE_BUILD_TYPE=Release \
   -D CMAKE_CXX_FLAGS="-Wall -Wextra -Wshadow" \
   -D CMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
-  -D PYTHON_EXECUTABLE=/usr/bin/python3 \
   -D Tasmanian_ENABLE_OPENMP=ON \
   -D Tasmanian_ENABLE_BLAS=ON \
   -D Tasmanian_ENABLE_CUDA=OFF \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(Tasmanian_license "BSD 3-Clause with UT-Battelle disclaimer") # used in some
 #    -D Tasmanian_EXTRA_LINK_DIRS:PATH="appends more link paths"
 #
 # Selecting specific packages for find_package()
-#     -D PYTHON_EXECUTABLE:PATH
+#     -D Python_ROOT_DIR:PATH
 #     -D CMAKE_CUDA_COMPILER:PATH
 #     -D Tasmanian_MAGMA_ROOT:PATH (or just MAGMA_ROOT)
 #     -D MPI_CXX_COMPILER

--- a/InterfacePython/CMakeLists.txt
+++ b/InterfacePython/CMakeLists.txt
@@ -34,7 +34,7 @@ unset(_tsg_opt)
 ########################################################################
 # Stage 1: Build folder paths
 ########################################################################
-set(Tasmanian_string_python_hashbang "${PYTHON_EXECUTABLE}")
+set(Tasmanian_string_python_hashbang "${Python_EXECUTABLE}")
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 # windows puts the temp .dll files in Release or Debug subfolder, as opposed to directly in ${CMAKE_CURRENT_BINARY_DIR}

--- a/InterfacePython/testTSG.py
+++ b/InterfacePython/testTSG.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # The hash-bang is used only but the GNU Make build system
-# The CMake build system uses the PYTHON_EXECUTABLE and ignores the hash-bang.
+# The CMake build system ignores the hash-bang and uses the executable from find_package().
 
 import unittest
 import TasmanianSG

--- a/Tasgrid/tasgridLogs.in.hpp
+++ b/Tasgrid/tasgridLogs.in.hpp
@@ -56,7 +56,7 @@ CMAKE_CUDA_FLAGS_DEBUG             @CMAKE_CUDA_FLAGS_DEBUG@
 CMAKE_CUDA_FLAGS_RELEASE           @CMAKE_CUDA_FLAGS_RELEASE@
 Tasmanian_cudamathlibs             @Tasmanian_cudamathlibs@
 Tasmanian_cudaruntime              @Tasmanian_cudaruntime@
-PYTHON_EXECUTABLE                  @PYTHON_EXECUTABLE@
+Python_EXECUTABLE                  @Python_EXECUTABLE@
 BUILD_SHARED_LIBS                  @BUILD_SHARED_LIBS@
 BLAS_LIBRARIES                     @BLAS_LIBRARIES@
 LAPACK_LIBRARIES                   @LAPACK_LIBRARIES@


### PR DESCRIPTION
Fix usage of the deprecated `PYTHON_EXECUTABLE`